### PR TITLE
Improved sharing experience

### DIFF
--- a/datahub/webapp/components/DataDoc/DataDoc.scss
+++ b/datahub/webapp/components/DataDoc/DataDoc.scss
@@ -1,5 +1,17 @@
 @import './../../scss_variables.scss';
 
+@keyframes highlight-fade {
+    0% {
+        background-color: transparent;
+    }
+    25% {
+        background-color: var(--color-accent-bg);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
 // Temporal
 .temporal-edit-title-modal-wrapper {
     .close {
@@ -95,6 +107,11 @@
 
         .data-doc-container {
             .data-doc-cell-container-pair {
+                &.highlight-cell {
+                    animation-name: highlight-fade;
+                    animation-duration: 5s;
+                }
+
                 position: relative;
                 &:hover {
                     .data-doc-cell-divider-container {
@@ -143,22 +160,19 @@
                             opacity: 1;
                         }
 
-                        .block-collapse-buttons-wrapper {
+                        .block-left-buttons-wrapper {
                             position: absolute;
                             left: 4px;
                         }
 
-                        .block-edit-buttons-wrapper {
+                        .block-right-buttons-wrapper {
                             position: absolute;
                             right: 4px;
                         }
                         .block-crud-button {
-                            &.disabled {
-                                background-color: var(--select-bg-color);
-                                cursor: not-allowed;
-                                &:hover {
-                                    background-color: var(--select-bg-color);
-                                }
+                            margin: 0;
+                            & + .block-crud-button {
+                                margin-left: 4px;
                             }
                         }
 

--- a/datahub/webapp/components/DataDoc/DataDocCellControl.tsx
+++ b/datahub/webapp/components/DataDoc/DataDocCellControl.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { titleize, sleep } from 'lib/utils';
 import { AsyncButton } from 'ui/AsyncButton/AsyncButton';
 import { Button } from 'ui/Button/Button';
+import { CopyButton } from 'ui/CopyButton/CopyButton';
 
 const cellTypes = require('config/datadoc.yaml').cell_types;
 
@@ -26,6 +27,7 @@ interface IProps {
     setShowCollapsed?: (collapsed: boolean) => any;
     isCollapsedDefault?: boolean;
     toggleDefaultCollapsed?: () => Promise<any>;
+    shareUrl?: string;
 }
 
 export const DataDocCellControl: React.FunctionComponent<IProps> = ({
@@ -43,111 +45,132 @@ export const DataDocCellControl: React.FunctionComponent<IProps> = ({
     setShowCollapsed,
     isCollapsedDefault,
     toggleDefaultCollapsed,
+    shareUrl,
 }) => {
-    if (!isEditable) {
-        return null;
-    }
-
     const [animateDefaultChange, setAnimateDefaultChange] = React.useState(
         false
     );
 
-    const swapCellButtonDOM = ((isHeader && index > 0) ||
-        (!isHeader && index <= numberOfCells - 1)) && (
-        <AsyncButton
+    const shareButton = isHeader && shareUrl && (
+        <CopyButton
             className="block-crud-button"
             borderless
-            onClick={moveCellAt.bind(
-                this,
-                index,
-                isHeader ? index - 1 : index + 1
-            )}
-            icon={isHeader ? 'chevrons-up' : 'chevrons-down'}
+            icon="link"
             type="soft"
+            key="share"
+            tooltip="Share"
+            tooltipDirection="down"
+            copyText={shareUrl}
         />
     );
 
-    const deleteCellButtonDOM = deleteCellAt &&
-        isHeader &&
-        numberOfCells > 0 && (
+    const rightButtons: JSX.Element[] = [];
+    const centerButtons: JSX.Element[] = [];
+    const leftButtons: JSX.Element[] = [shareButton];
+
+    if (isEditable) {
+        const swapCellButtonDOM = ((isHeader && index > 0) ||
+            (!isHeader && index <= numberOfCells - 1)) && (
             <AsyncButton
                 className="block-crud-button"
                 borderless
-                onClick={deleteCellAt.bind(this, index)}
-                icon="x"
+                onClick={moveCellAt.bind(
+                    this,
+                    index,
+                    isHeader ? index - 1 : index + 1
+                )}
+                icon={isHeader ? 'chevrons-up' : 'chevrons-down'}
                 type="soft"
+                key="swap"
             />
         );
+        rightButtons.push(swapCellButtonDOM);
 
-    const handleToggleDefaultCollapsed = React.useCallback(() => {
-        setAnimateDefaultChange(true);
-        Promise.all([sleep(500), toggleDefaultCollapsed()]).then(() =>
-            setAnimateDefaultChange(false)
-        );
-    }, [toggleDefaultCollapsed]);
+        const deleteCellButtonDOM = deleteCellAt &&
+            isHeader &&
+            numberOfCells > 0 && (
+                <AsyncButton
+                    className="block-crud-button"
+                    borderless
+                    onClick={deleteCellAt.bind(this, index)}
+                    icon="x"
+                    type="soft"
+                    key="delete"
+                />
+            );
+        rightButtons.push(deleteCellButtonDOM);
 
-    let collapseCellButtonDOM: React.ReactChild;
-    if (isHeader && showCollapsed !== undefined) {
-        // undefined means the cell cannot be collapsed
-        const setDefaultCollapsedButton = !isCollapsedDefault && (
-            <Button
-                className={
-                    animateDefaultChange
-                        ? 'block-crud-button disabled'
-                        : 'block-crud-button'
-                }
-                borderless
-                onClick={
-                    animateDefaultChange ? null : handleToggleDefaultCollapsed
-                }
-                icon={animateDefaultChange ? 'lock' : 'unlock'}
-                type="soft"
-                attachedLeft
-                aria-label={
-                    showCollapsed
-                        ? 'default to collapsed'
-                        : 'default to uncollapsed'
-                }
-                data-balloon-pos="down"
-            />
-        );
-        const collapseButtonDOM = (
-            <AsyncButton
-                className="block-crud-button"
-                borderless
-                onClick={() => setShowCollapsed(!showCollapsed)}
-                icon={showCollapsed ? 'maximize-2' : 'minimize-2'}
-                type="soft"
-                attachedRight={isCollapsedDefault}
-                aria-label={showCollapsed ? 'Uncollapse' : 'Collapse'}
-                data-balloon-pos="down"
-            />
-        );
-        collapseCellButtonDOM = (
-            <div className="block-collapse-buttons-wrapper">
-                {collapseButtonDOM}
-                {setDefaultCollapsedButton}
-            </div>
+        const handleToggleDefaultCollapsed = React.useCallback(() => {
+            setAnimateDefaultChange(true);
+            Promise.all([sleep(500), toggleDefaultCollapsed()]).then(() =>
+                setAnimateDefaultChange(false)
+            );
+        }, [toggleDefaultCollapsed]);
+
+        if (isHeader && showCollapsed !== undefined) {
+            // undefined means the cell cannot be collapsed
+            const setDefaultCollapsedButton = !isCollapsedDefault && (
+                <Button
+                    className={
+                        animateDefaultChange
+                            ? 'block-crud-button disabled'
+                            : 'block-crud-button'
+                    }
+                    borderless
+                    onClick={
+                        animateDefaultChange
+                            ? null
+                            : handleToggleDefaultCollapsed
+                    }
+                    icon={animateDefaultChange ? 'lock' : 'unlock'}
+                    type="soft"
+                    attachedLeft
+                    aria-label={
+                        showCollapsed
+                            ? 'default to collapsed'
+                            : 'default to uncollapsed'
+                    }
+                    data-balloon-pos="down"
+                    key="default-collapse"
+                />
+            );
+            leftButtons.push(setDefaultCollapsedButton);
+            const collapseButtonDOM = (
+                <AsyncButton
+                    className="block-crud-button"
+                    borderless
+                    onClick={() => setShowCollapsed(!showCollapsed)}
+                    icon={showCollapsed ? 'maximize-2' : 'minimize-2'}
+                    type="soft"
+                    attachedRight={isCollapsedDefault}
+                    aria-label={showCollapsed ? 'Uncollapse' : 'Collapse'}
+                    data-balloon-pos="down"
+                    key="collapse"
+                />
+            );
+            leftButtons.push(collapseButtonDOM);
+        }
+
+        Object.keys(cellTypes).forEach((cellKey) =>
+            centerButtons.push(
+                <AsyncButton
+                    className="block-crud-button"
+                    borderless
+                    key={cellKey}
+                    onClick={insertCellAt.bind(
+                        null,
+                        index,
+                        cellKey,
+                        null,
+                        null
+                    )}
+                    icon="plus"
+                    title={titleize(cellKey)}
+                    type="soft"
+                />
+            )
         );
     }
-    const cellEditButtonsDOM = (
-        <div className="block-edit-buttons-wrapper flex-row">
-            {deleteCellButtonDOM}
-            {swapCellButtonDOM}
-        </div>
-    );
-
-    const insertCellButtons = Object.keys(cellTypes).map((cellKey) => (
-        <AsyncButton
-            className="block-crud-button"
-            borderless
-            key={cellKey}
-            onClick={insertCellAt.bind(null, index, cellKey, null, null)}
-            icon="plus"
-            title={titleize(cellKey)}
-            type="soft"
-        />
-    ));
 
     return (
         <div
@@ -157,9 +180,17 @@ export const DataDocCellControl: React.FunctionComponent<IProps> = ({
                 active,
             })}
         >
-            {collapseCellButtonDOM}
-            {cellEditButtonsDOM}
-            {insertCellButtons}
+            {leftButtons.length ? (
+                <div className="block-left-buttons-wrapper flex-row">
+                    {leftButtons}
+                </div>
+            ) : null}
+            {centerButtons}
+            {rightButtons.length ? (
+                <div className="block-right-buttons-wrapper flex-row">
+                    {rightButtons}
+                </div>
+            ) : null}
         </div>
     );
 };

--- a/datahub/webapp/components/ExecutionPicker/QueryExecutionPicker.tsx
+++ b/datahub/webapp/components/ExecutionPicker/QueryExecutionPicker.tsx
@@ -43,11 +43,15 @@ export const QueryExecutionPicker: React.FunctionComponent<IProps> = React.memo(
             if (
                 autoSelect &&
                 queryExecutionId == null &&
-                queryExecutions.length > 0
+                filteredQueryExecutions.length > 0
             ) {
-                onSelection(queryExecutions[0].id);
+                onSelection(filteredQueryExecutions[0].id);
             }
-        }, [autoSelect, queryExecutionId, (queryExecutions || []).length]);
+        }, [
+            autoSelect,
+            queryExecutionId,
+            (filteredQueryExecutions || []).length,
+        ]);
 
         const executionSelectorButton = React.useCallback(() => {
             const execution = queryExecutions.find(

--- a/datahub/webapp/components/QueryExecutionBar/QueryExecutionBar.tsx
+++ b/datahub/webapp/components/QueryExecutionBar/QueryExecutionBar.tsx
@@ -55,7 +55,8 @@ export const QueryExecutionBar: React.FunctionComponent<IProps> = ({
                 borderless
                 small
                 copyText={permalink}
-                title="Share"
+                icon="link"
+                title="Share Execution"
                 type="inlineText"
             />
         </>

--- a/datahub/webapp/components/QuerySnippetInsertionModal/QuerySnippetView.tsx
+++ b/datahub/webapp/components/QuerySnippetInsertionModal/QuerySnippetView.tsx
@@ -190,7 +190,7 @@ export class QuerySnippetView extends React.Component<
 
         const controlDOM = (
             <div className="right-align">
-                <CopyButton copyText={context} text="Copy To Clipboard" />
+                <CopyButton copyText={context} title="Copy To Clipboard" />
                 <Button
                     type="confirm"
                     title="Insert"

--- a/datahub/webapp/const/datadoc.ts
+++ b/datahub/webapp/const/datadoc.ts
@@ -36,6 +36,11 @@ export interface IDataTextCell extends IDataCellBase {
 
 export type IDataChartCellMeta = IDataCellMetaBase & IChartConfig;
 
+export type IDataCellMeta =
+    | IDataQueryCellMeta
+    | IDataCellMetaBase
+    | IDataChartCellMeta;
+
 export interface IDataChartCell extends IDataCellBase {
     cell_type: 'chart';
     context: string;

--- a/datahub/webapp/context/DataDoc.ts
+++ b/datahub/webapp/context/DataDoc.ts
@@ -1,0 +1,28 @@
+import React from 'react';
+import { IDataCellMeta } from 'const/datadoc';
+
+export interface IDataDocContextType {
+    cellIdToExecutionId: Record<number, number>;
+    onQueryCellSelectExecution: (cellId: number, executionId: number) => any;
+
+    insertCellAt?: (
+        index: number,
+        cellKey: string,
+        context: string,
+        meta: IDataCellMeta
+    ) => any;
+
+    defaultCollapse: boolean;
+    focusedCellIndex?: number;
+    highlightCellIndex: number;
+    cellFocus: {
+        onUpKeyPressed: (index: number) => any;
+        onDownKeyPressed: (index: number) => any;
+        onFocus: (index: number) => any;
+        onBlur: (index: number) => any;
+    };
+
+    isEditable: boolean;
+}
+
+export const DataDocContext = React.createContext<IDataDocContextType>(null);

--- a/datahub/webapp/lib/data-doc/data-doc-utils.ts
+++ b/datahub/webapp/lib/data-doc/data-doc-utils.ts
@@ -1,15 +1,36 @@
 import { IDataCell } from 'const/datadoc';
 import { scrollToElement } from 'lib/utils';
 
-export function scrollToCell(dataDocCell: IDataCell, duration: number = 200) {
+export async function scrollToCell(
+    dataDocCell: IDataCell,
+    duration: number = 200,
+    repeat: number = 1
+) {
     const anchorName = getAnchorNameForCell(dataDocCell.id);
 
-    scrollToElement(document.getElementById(anchorName), duration).then(() => {
-        location.hash = '';
-        location.hash = anchorName;
-    });
+    for (let i = 0; i < repeat; i++) {
+        await scrollToElement(document.getElementById(anchorName), duration);
+    }
+
+    location.hash = '';
+    location.hash = anchorName;
 }
 
 export function getAnchorNameForCell(cellKey: string | number) {
     return `dataCell${cellKey}`;
+}
+
+export function getShareUrl(
+    cellId: number,
+    executionId: number,
+    relative = false
+) {
+    // Note: this only works when the doc is open
+    const hostpart = relative ? '' : `${location.protocol}//${location.host}`;
+    const executionParam =
+        executionId != null ? `executionId=${executionId}` : null;
+    const cellParam = cellId != null ? `cellId=${cellId}` : null;
+    const params = [cellParam, executionParam].filter((p) => p).join('&');
+
+    return `${hostpart}${location.pathname}?` + params;
 }

--- a/datahub/webapp/ui/CopyButton/CopyButton.tsx
+++ b/datahub/webapp/ui/CopyButton/CopyButton.tsx
@@ -1,5 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
+
+import { TooltipDirection } from 'const/tooltip';
 import * as Utils from 'lib/utils';
 import { Button, IButtonProps } from 'ui/Button/Button';
 
@@ -11,6 +13,10 @@ interface ICopyButtonProps extends IButtonProps {
     icon?: string;
     title?: string;
     className?: string;
+
+    tooltip?: string;
+    copiedTooltip?: string;
+    tooltipDirection?: TooltipDirection;
 }
 
 interface IState {
@@ -20,9 +26,12 @@ interface IState {
 export const CopyButton: React.FunctionComponent<ICopyButtonProps> = ({
     copyText,
     className = '',
+    tooltip = DEFAULT_TOOL_TIP,
+    copiedTooltip = DEFAULT_COPIED_TOOL_TIP,
+    tooltipDirection = 'up',
     ...propsForButton
 }) => {
-    const [tooltip, setTooltip] = React.useState(DEFAULT_TOOL_TIP);
+    const [tooltipToShow, setTooltipToShow] = React.useState(tooltip);
 
     return (
         <Button
@@ -30,13 +39,13 @@ export const CopyButton: React.FunctionComponent<ICopyButtonProps> = ({
                 CopyButton: true,
                 [className]: className,
             })}
-            aria-label={tooltip}
-            data-balloon-pos={'up'}
+            aria-label={tooltipToShow}
+            data-balloon-pos={tooltipDirection}
             onClick={() => {
                 Utils.copy(copyText);
-                setTooltip(DEFAULT_COPIED_TOOL_TIP);
+                setTooltipToShow(copiedTooltip);
             }}
-            onMouseLeave={() => setTooltip(DEFAULT_TOOL_TIP)}
+            onMouseLeave={() => setTooltipToShow(tooltip)}
             icon="copy"
             {...propsForButton}
         />

--- a/tslint.json
+++ b/tslint.json
@@ -21,7 +21,8 @@
                 "worker-loader!.",
                 "history",
                 "const",
-                "hooks"
+                "hooks",
+                "context"
             ]
         ],
         "no-shadowed-variable": [


### PR DESCRIPTION
Generalized share button so you can share any cell in a datadoc
![image](https://user-images.githubusercontent.com/8283407/80051995-91ffe580-84e7-11ea-9ae1-7cfaed8b7245.png)

When datadoc is shared, make sure the correct cell is scrolled to (this issue is due to lazy loading) and highlight it for a brief time
![image](https://user-images.githubusercontent.com/8283407/80052024-a47a1f00-84e7-11ea-894f-86172dbcea3f.png)

When sharing query execution in a datadoc, provide the link directly to the execution page.
![image](https://user-images.githubusercontent.com/8283407/80052071-c2e01a80-84e7-11ea-899c-5b8e45c02616.png)

Focusing cells will automatically change the url
