### PR TITLE
Fix remove link breaking when deleted

### DIFF
--- a/datahub/webapp/ui/RichTextEditor/RichTextEditor.tsx
+++ b/datahub/webapp/ui/RichTextEditor/RichTextEditor.tsx
@@ -62,6 +62,12 @@ export class RichTextEditor extends React.Component<
     private toolBarRef = React.createRef<RichTextEditorToolBar>();
     private selfRef = React.createRef<HTMLDivElement>();
 
+    public componentDidCatch() {
+        // Suppressing error due to LinkDecorator failing on delete
+        // related github issue https://github.com/facebook/draft-js/issues/1320#issuecomment-476509968
+        this.forceUpdate();
+    }
+
     public getContent() {
         return this.state.editorState.getCurrentContent();
     }

--- a/datahub/webapp/ui/RichTextEditorToolBar/RichTextEditorToolBar.tsx
+++ b/datahub/webapp/ui/RichTextEditorToolBar/RichTextEditorToolBar.tsx
@@ -179,10 +179,10 @@ export class RichTextEditorToolBar extends React.PureComponent<
         const { showLinkInput } = this.state;
 
         let contentDOM = null;
-        if (showLinkInput) {
-            const selectionRect = getSelectionRect() || this.lastSelectionRect;
+        const selectionRect = getSelectionRect() || this.lastSelectionRect;
 
-            if (selectionRect != null) {
+        if (selectionRect != null) {
+            if (showLinkInput) {
                 this.lastSelectionRect = selectionRect;
 
                 const linkInput = showLinkInput ? (
@@ -197,11 +197,10 @@ export class RichTextEditorToolBar extends React.PureComponent<
                         />
                     </Popover>
                 ) : null;
-
                 contentDOM = linkInput;
+            } else {
+                contentDOM = this.renderButtons();
             }
-        } else {
-            contentDOM = this.renderButtons();
         }
 
         return (


### PR DESCRIPTION
2 issues

- When deleting an url completely, an error is thrown. This issue is suppressed by componentDidCatch
- When deleting an url, the toolbar breaks because there is no `editorState.getCurrentInlineStyle()`. This is resolved by requiring a non empty selection rect for the toolbar to appear