### PR TITLE
Fix for lineage processing and auto completion

### DIFF
--- a/datahub/server/lib/query_analysis/lineage.py
+++ b/datahub/server/lib/query_analysis/lineage.py
@@ -210,8 +210,13 @@ def compute_lineage(table_list, from_list):
 
 
 def tokenize_by_statement(query: str):
-    return sqlparse.parse(
+    statements = sqlparse.parse(
         sqlparse.format(
             query.strip(), strip_comments=True, keyword_case="upper", reindent=True
         )
     )
+
+    # Filter out empty statements
+    return [
+        statement for statement in statements if statement.token_first() is not None
+    ]

--- a/datahub/webapp/__tests__/lib/utils/index.test.ts
+++ b/datahub/webapp/__tests__/lib/utils/index.test.ts
@@ -18,7 +18,7 @@ test('titleize', () => {
 
 test('sleep', () => {
     const mockFunction = jest.fn(() => {
-        // console.log('mock function runs');
+        /* empty function */
     });
 
     const testFunction = async () => {

--- a/datahub/webapp/lib/sql-helper/sql-autocompleter.ts
+++ b/datahub/webapp/lib/sql-helper/sql-autocompleter.ts
@@ -543,6 +543,7 @@ export class SqlAutoCompleter {
             const processedList = result
                 .sort((a, b) => b.score - a.score)
                 .slice(0, RESULT_MAX_LENGTH);
+
             resolve({
                 list: processedList,
                 from: this.Pos(cursor.line, start),

--- a/datahub/webapp/lib/sql-helper/sql-lexer.ts
+++ b/datahub/webapp/lib/sql-helper/sql-lexer.ts
@@ -57,10 +57,12 @@ const contextSensitiveKeyWord = {
     // insert,
     table: 'table',
     update: 'table',
+    join: 'table',
     set: 'column',
 
     desc: 'table',
     describe: 'table',
+
     // delete: 'table',
 
     limit: 'none',
@@ -89,6 +91,7 @@ function getTokenTypeMatcher(language: string) {
         VARIABLE: [/^(\w+|`.*`)(?:\.(\w+|`.*`)?)+/],
         WORD: [/^\w+/],
         TEMPLATED_TAG: [/^{{.*?}}/],
+        TEMPLATED_BLOCK: [/^{%.*?%}/, /^{#.*?#}/, /^#.*?/],
     };
 }
 


### PR DESCRIPTION
- Skip empty statement for lineage processing
- `join` keyword in auto completion should change the context to 'table`