### PR TITLE
Auto-detect links in text cells

### DIFF
--- a/datahub/webapp/ui/RichTextEditor/RichTextEditor.tsx
+++ b/datahub/webapp/ui/RichTextEditor/RichTextEditor.tsx
@@ -334,12 +334,12 @@ export class RichTextEditor extends React.Component<
         const currentBlock = currentContent.getBlockForKey(anchorKey);
         const end = selectionState.getEndOffset();
         const textBeforeSelection = currentBlock.getText().slice(0, end);
-        const urlMatch = textBeforeSelection.match(/[^\s]+$/gi) || [];
-        const url = urlMatch.length ? urlMatch[0] : '';
+        const urlMatch = textBeforeSelection.match(/[^\s]+$/);
+        const url = urlMatch ? urlMatch[0] : '';
         if (!url.startsWith('https://') && !url.startsWith('http://')) {
             return editorState;
         }
-        const start = textBeforeSelection.length - url.length;
+        const start = urlMatch.index;
 
         // If the text is already a link do not toggle.
         const entityAtStart = currentBlock.getEntityAt(start);


### PR DESCRIPTION
Auto-detect links in text cells

If the user types something like https://<some_str> with a \s character (like space, enter, or tab) then that string part should be converted to url

Behavior:

- Space.
   Hitting space at the end of a url will **toggle url to link** and **insert space**. Undoing will first remove the space, then remove the link toggle.
- Tab.
   Same behavior as space, but will insert a tab instead.
- Enter.
   Hitting enter at the end of a url will **toggle url to link**. Undoing will first remove the link toggle.
- Enter + Shift (Soft new line).
   Inserting a soft new line at the end of a url will **toggle url to link** and **insert new line**. Any behavior which is 'handled' will similarly **toggle url to link**, then **perform function**. These are invoked as two different changes so undoing will first undo **perform function**, then undo **toggle url to link**.