### PR TITLE
Bug fixes for TSV and copy paste

### DIFF
--- a/datahub/webapp/components/DataDoc/DataDoc.tsx
+++ b/datahub/webapp/components/DataDoc/DataDoc.tsx
@@ -369,9 +369,24 @@ class DataDocComponent extends React.Component<IProps, IState> {
 
     @bind
     public async pasteCellAt(pasteIndex: number) {
-        const copyCommand = deserializeCopyCommand(
-            await navigator.clipboard.readText()
-        );
+        let clipboardContent = null;
+        try {
+            if (navigator.clipboard.readText) {
+                clipboardContent = await navigator.clipboard.readText();
+            }
+        } catch (e) {
+            // ignore if user rejected, handle in finally
+        } finally {
+            if (clipboardContent == null) {
+                // If we failed to get content due to:
+                //    - firefox doesn't have navigator.clipboard.readText
+                //    - user refused to give clipboard permission
+                // then we show the prompt as a last resort
+                clipboardContent = prompt('Paste copied cell here');
+            }
+        }
+
+        const copyCommand = deserializeCopyCommand(clipboardContent);
         if (copyCommand) {
             try {
                 await dataDocActions.pasteDataCell(

--- a/datahub/webapp/components/DataDocStatementExecutionBar/ResultExportDropdown.tsx
+++ b/datahub/webapp/components/DataDocStatementExecutionBar/ResultExportDropdown.tsx
@@ -97,7 +97,11 @@ export const ResultExportDropdown: React.FunctionComponent<IProps> = ({
     const onExportPreviewClick = React.useCallback(async () => {
         const rawResult =
             statementResult?.data || (await loadStatementResult(statementId));
-        const parsedResult = rawResult.map((row) => row.join('\t')).join('\n');
+        const parsedResult = rawResult
+            .map((row) =>
+                row.map((cell) => cell.replace(/\s/g, ' ')).join('\t')
+            )
+            .join('\n');
         setExportedInfo({
             info: parsedResult,
             type: 'text',


### PR DESCRIPTION
- Sanitize export to tsv so that /n and /t values becomes ' ' in converted tsv
- Show prompt to paste cell info for when using copy/paste if 
     - the user is using firefox which doesn't have clipboard API  OR
     - the user rejected datahub's request to use clipboard
![image](https://user-images.githubusercontent.com/8283407/83690195-4ea49680-a5be-11ea-9ecf-dbe96a170d47.png)
