### PR TITLE
Escape comments when rendering templated query

### DIFF
--- a/datahub/server/datasources/query_execution.py
+++ b/datahub/server/datasources/query_execution.py
@@ -8,7 +8,7 @@ from flask_login import current_user
 import requests
 
 from app.flask_app import socketio
-from app.datasource import register, api_assert
+from app.datasource import register, api_assert, RequestException
 from app.db import DBSession
 from app.auth.permission import (
     verify_environment_permission,
@@ -21,6 +21,7 @@ from lib.result_store import GenericReader
 from lib.query_analysis.templating import (
     render_templated_query,
     get_templated_variables_in_string,
+    QueryTemplatingError,
 )
 from const.query_execution import QueryExecutionStatus
 from const.datasources import RESOURCE_NOT_FOUND_STATUS_CODE
@@ -382,7 +383,10 @@ def export_statement_execution_result(statement_execution_id, export_name):
 
 @register("/query_execution/templated_query/", methods=["POST"])
 def get_templated_query(query: str, variables: Dict[str, str]):
-    return render_templated_query(query, variables)
+    try:
+        return render_templated_query(query, variables)
+    except QueryTemplatingError as e:
+        raise RequestException(e)
 
 
 @register("/query_execution/templated_query_params/", methods=["POST"])

--- a/datahub/tests/test_lib/test_query_analysis/test_templating.py
+++ b/datahub/tests/test_lib/test_query_analysis/test_templating.py
@@ -190,3 +190,40 @@ class RenderTemplatedQueryTestCase(TestCase):
             'select * from {{ table }} where dt="{{ date }}"',
             {"date": "{{ date2 }}", "date2": "{{ date }}"},
         )
+
+    def test_escape_comments(self):
+        query = """select * from
+-- {{ end_date }}
+/* {{ end_date }} */
+sample_table limit 5;
+-- '{{ end_date }}'
+/*
+    {{ end_date}}
+    {{ end_date}}
+*/
+/*
+{{ end_date}}*/
+-- {{ end_date }}"""
+        self.assertEqual(render_templated_query(query, {}), query)
+
+    def test_escape_comments_non_greedy(self):
+        query_non_greedy = """select * from
+/*
+   {{ end_date }}
+*/
+{{ test }}
+/*
+   {{ end_date2 }}
+*/
+"""
+        self.assertEqual(
+            render_templated_query(query_non_greedy, {"test": "render"}),
+            """select * from
+/*
+   {{ end_date }}
+*/
+render
+/*
+   {{ end_date2 }}
+*/""",
+        )


### PR DESCRIPTION
- Escape single/multi-line comments when rendering templated query
- Nicer templated query render error on frontend

![image](https://user-images.githubusercontent.com/8283407/84300134-e3a81200-ab1f-11ea-9e4e-e9d11e9543a1.png)
![image](https://user-images.githubusercontent.com/8283407/84300196-f6224b80-ab1f-11ea-9fa3-8d156fbe7fc3.png)
