### PR TITLE
Add enter short cut for confirm modal

### DIFF
--- a/datahub/config/shortcuts.yaml
+++ b/datahub/config/shortcuts.yaml
@@ -7,6 +7,8 @@ shortcuts:
             - toggle sidebar
           - - ['esc']
             - close modal
+          - - ['⏎']
+            - confirm modal
     - title: data doc and adhoc
       keys:
           - - ['⌘', 's']
@@ -39,7 +41,7 @@ shortcuts:
             - toggle comment
           - - ['⌘', 'p']
             - open table modal if cursor is on a table
-          - - ['shift', 'alt', 'f']
+          - - ['shift', '⌥', 'f']
             - format query
-          - - ['ctrl', 'd']
+          - - ['shift', '⌥', 'd']
             - delete current cell

--- a/datahub/webapp/components/ConfirmationManager/ConfirmationMessage.tsx
+++ b/datahub/webapp/components/ConfirmationManager/ConfirmationMessage.tsx
@@ -1,4 +1,7 @@
-import React from 'react';
+import React, { useCallback, useRef, useEffect } from 'react';
+
+import { useEvent } from 'hooks/useEvent';
+import { matchKeyPress } from 'lib/utils/keyboard';
 import { Button } from 'ui/Button/Button';
 import { Modal } from 'ui/Modal/Modal';
 import './ConfirmationMessage.scss';
@@ -26,17 +29,36 @@ export const ConfirmationMessage: React.FunctionComponent<IConfirmationMessagePr
     onHide,
     hideDismiss,
 }) => {
-    const onCloseButtonClick = (confirm) => (evt) => {
-        if (confirm && onConfirm) {
-            onConfirm();
-        }
-        if (!confirm && onDismiss) {
-            onDismiss();
-        }
-        if (onHide) {
-            onHide();
-        }
-    };
+    const selfRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        selfRef.current.focus();
+    }, []);
+
+    const onCloseButtonClick = useCallback(
+        (confirm) => () => {
+            if (confirm && onConfirm) {
+                onConfirm();
+            }
+            if (!confirm && onDismiss) {
+                onDismiss();
+            }
+            if (onHide) {
+                onHide();
+            }
+        },
+        [onConfirm, onDismiss, onHide]
+    );
+
+    const onEnterPress = useCallback(
+        (evt: KeyboardEvent) => {
+            if (matchKeyPress(evt, 'Enter')) {
+                onCloseButtonClick(true)();
+            }
+        },
+        [onCloseButtonClick]
+    );
+
+    useEvent('keydown', onEnterPress);
 
     const actionButtons = [
         <Button
@@ -69,7 +91,7 @@ export const ConfirmationMessage: React.FunctionComponent<IConfirmationMessagePr
             hideClose={true}
             className="message-size with-padding"
         >
-            <div className="ConfirmationMessage">
+            <div className="ConfirmationMessage" ref={selfRef} tabIndex={0}>
                 <div className="confirmation-top">
                     <div className="confirmation-header">{header}</div>
                     <div className="confirmation-message">{message}</div>

--- a/datahub/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
+++ b/datahub/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
@@ -99,7 +99,7 @@ class DataDocQueryCellComponent extends React.Component<IProps, IState> {
     private selfRef = React.createRef<HTMLDivElement>();
     private keyMap = {
         'Shift-Enter': this.clickOnRunButton,
-        'Ctrl-D': this.props.onDeleteKeyPressed,
+        'Shift-Alt-D': this.props.onDeleteKeyPressed,
     };
 
     constructor(props) {

--- a/datahub/webapp/components/DataDocTextCell/DataDocTextCell.tsx
+++ b/datahub/webapp/components/DataDocTextCell/DataDocTextCell.tsx
@@ -137,11 +137,9 @@ export const DataDocTextCell: React.FC<IProps> = ({
                     onDownKeyPressed();
                     handled = true;
                 }
-            } else if (matchKeyPress(event, 'Cmd-D')) {
-                if (!editorState.getCurrentContent().hasText()) {
-                    onDeleteKeyPressed?.();
-                    handled = true;
-                }
+            } else if (matchKeyPress(event, 'Shift-Alt-D')) {
+                onDeleteKeyPressed?.();
+                handled = true;
             } else if (matchKeyPress(event, 'Cmd-F')) {
                 searchContext.showSearchAndReplace();
                 handled = true;

--- a/datahub/webapp/stylesheets/_html.scss
+++ b/datahub/webapp/stylesheets/_html.scss
@@ -210,6 +210,7 @@ a {
     }
 }
 
+div,
 textarea,
 input,
 select,

--- a/datahub/webapp/ui/KeyboardKey/KeyboardKey.tsx
+++ b/datahub/webapp/ui/KeyboardKey/KeyboardKey.tsx
@@ -14,12 +14,17 @@ const StyledKeyboardKey = styled.span.attrs<{}>({
     text-transform: lowercase;
 `;
 
+const OSXToWindows = {
+    '⌘': 'ctrl',
+    '⌥': 'alt',
+};
+
 export const KeyboardKey: React.FC<{
     className?: string;
     value: string;
 }> = ({ value, className }) => {
     const mappedKey = useMemo(
-        () => (!isOSX && value === '⌘' ? 'ctrl' : value),
+        () => (!isOSX && value in OSXToWindows ? OSXToWindows[value] : value),
         [value]
     );
     return (


### PR DESCRIPTION
- Add enter key to confirm in confirmation modal
- Change to alt-shift-d to delete cell
- Show options for osx shortcut and alt for windows

![image](https://user-images.githubusercontent.com/8283407/84312499-08f24b80-ab33-11ea-8172-4deeffe8ef0c.png)
