### PR TITLE
Update default agg cell to null, fix scale auto detection

### DIFF
--- a/datahub/webapp/__tests__/lib/chart/chart-data-transformation.test.ts
+++ b/datahub/webapp/__tests__/lib/chart/chart-data-transformation.test.ts
@@ -137,7 +137,7 @@ test('data aggregates with specified series/vals 1', () => {
     expect(transformedData).toEqual([
         ['time', 'blue', 'pink', 'yellow'],
         ['2001-01-01', 14, 74, 21],
-        ['2001-01-02', 30, 102, 'No Value'],
+        ['2001-01-02', 30, 102, null],
         ['2001-01-03', 37, 72, 94],
     ]);
 });
@@ -152,7 +152,7 @@ test('data aggregates with specified series/vals 2', () => {
     expect(transformedData).toEqual([
         ['time', 'blue', 'pink', 'yellow'],
         ['2001-01-01', 7, 74, 1],
-        ['2001-01-02', 15, 102, 'No Value'],
+        ['2001-01-02', 15, 102, null],
         ['2001-01-03', 37, 72, 2],
     ]);
 });
@@ -166,7 +166,7 @@ test('data aggregates with specified series/vals 3', () => {
     expect(transformedData).toEqual([
         ['time', 'blue', 'pink', 'yellow'],
         ['2001-01-01', 1, 74, 21],
-        ['2001-01-02', -1, 99, 'No Value'],
+        ['2001-01-02', -1, 99, null],
         ['2001-01-03', 37, 72, 47],
     ]);
 });

--- a/datahub/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
+++ b/datahub/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
@@ -278,7 +278,16 @@ const DataDocChartComposerComponent: React.FunctionComponent<
     );
 
     const getAxesScaleType = React.useCallback(
-        (colIndex: number) => getDefaultScaleType(chartData?.[1]?.[colIndex]),
+        (colIndex: number) => {
+            for (let row = 1; row < chartData?.length; row++) {
+                const cell = chartData?.[row]?.[colIndex];
+                if (cell != null) {
+                    return getDefaultScaleType(chartData?.[row]?.[colIndex]);
+                }
+            }
+            // Unknown type, use linear as a default
+            return 'linear';
+        },
         [chartData]
     );
 

--- a/datahub/webapp/lib/chart/chart-data-transformation.ts
+++ b/datahub/webapp/lib/chart/chart-data-transformation.ts
@@ -2,7 +2,7 @@ import { cloneDeep, range } from 'lodash';
 import { ChartDataAggType } from 'const/dataDocChart';
 import { sortTable, getValueDataType } from './chart-utils';
 
-const emptyCellValue = 'No Value';
+const emptyCellValue = null;
 
 // from: https://stackoverflow.com/questions/4492678/swap-rows-with-columns-transposition-of-a-matrix-in-javascript
 function switchData(data: readonly any[][]) {


### PR DESCRIPTION
- The 'No Value' maps to category axis by the auto detection algo, use null instead to represent unknown chart value.
- Updated the chart axis detection algorithm to go through the entire column of values instead of checking just 1