### PR TITLE
Fixed username capitalization for notifier messages

### DIFF
--- a/datahub/server/datasources/datadoc.py
+++ b/datahub/server/datasources/datadoc.py
@@ -27,7 +27,7 @@ from logic.datadoc_permission import assert_can_read, assert_can_write, assert_i
 from logic.query_execution import get_query_execution_by_id
 from logic.schedule import run_and_log_scheduled_task
 from models.environment import Environment
-from lib.notify.utils import notify_user, capitalize_username
+from lib.notify.utils import notify_user
 
 LOG = get_logger(__file__)
 
@@ -444,7 +444,7 @@ def send_add_datadoc_editor_email(doc_id, uid, read, write, session=None):
         notifier_name=notification_setting,
         template_name="datadoc_invitation",
         template_params=dict(
-            inviting_username=capitalize_username(inviting_user.get_name()),
+            inviting_username=inviting_user.get_name(),
             read_or_write=read_or_write,
             doc_url=doc_url,
             data_doc_title=data_doc_title,
@@ -584,7 +584,7 @@ def send_datadoc_transfer_notification(doc_id, next_owner_id, session=None):
         notifier_name=notification_setting,
         template_name="datadoc_ownership_transfer",
         template_params=dict(
-            inviting_username=capitalize_username(inviting_user.get_name()),
+            inviting_username=inviting_user.get_name(),
             doc_url=doc_url,
             data_doc_title=data_doc_title,
         ),

--- a/datahub/server/lib/notify/utils.py
+++ b/datahub/server/lib/notify/utils.py
@@ -8,10 +8,6 @@ def notify_user(user, notifier_name, template_name, template_params):
     notifier.notify(user=user, message=markdown_message)
 
 
-def capitalize_username(username: str):
-    return " ".join([name.capitalize() for name in username.split(" ")])
-
-
 def render_message(template_name, context):
     jinja_env = jinja2.Environment(
         loader=jinja2.FileSystemLoader("./datahub/notification_templates/")

--- a/datahub/server/models/user.py
+++ b/datahub/server/models/user.py
@@ -52,7 +52,11 @@ class User(CRUDMixin, Base):
         return check_password_hash(self._password or "", plaintext)
 
     def get_name(self):
-        return self.fullname or self.username
+        return (
+            " ".join([name.capitalize() for name in self.fullname.split(" ")])
+            if self.fullname
+            else self.username
+        )
 
     def to_dict(self, with_roles=False):
         user_dict = {


### PR DESCRIPTION
Fix: usernames in DataDoc owner/editor change messages only had first part of username capitalized. This fix capitalizes each portion of the username. 
Example: First last -> First Last