### PR TITLE
Bug Fix: Remove ability to add doc owner as doc editor

### DIFF
--- a/datahub/webapp/components/DataDocViewersList/DataDocViewersList.tsx
+++ b/datahub/webapp/components/DataDocViewersList/DataDocViewersList.tsx
@@ -56,7 +56,7 @@ export const DataDocViewersList: React.FunctionComponent<IDataDocViewersListProp
             <div className="user-select-wrapper">
                 <UserSelect
                     onSelect={(uid) => {
-                        if (uid in editorsByUid || uid == dataDoc.owner_uid) {
+                        if (uid in editorsByUid || uid === dataDoc.owner_uid) {
                             sendNotification('User already added.');
                         } else {
                             const newUserPermission = dataDoc.public


### PR DESCRIPTION
There's a bug in data doc sharing that allows the owner to be added as an editor, this causes an sql table integrity issue when ownership is transferred and the owner gets added to the editors table again.
This fix make's it so that the the owner cannot be added through the share button.