### PR TITLE
Update linkifyLog to ensure it doesnt get escaped

### DIFF
--- a/datahub/webapp/__tests__/lib/utils/index.test.ts
+++ b/datahub/webapp/__tests__/lib/utils/index.test.ts
@@ -84,6 +84,20 @@ test('linkifyLog', () => {
     expect(utils.linkifyLog('https://www.datahub.com/')).toBe(
         '<a target="_blank" rel="noopener noreferrer" href="https://www.datahub.com/">https://www.datahub.com/</a>'
     );
+    // testing basic string with query params
+    expect(
+        utils.linkifyLog(
+            'Test https://www.google.com/search?source=hp&q=test&oq=test end test'
+        )
+    ).toBe(
+        'Test <a target="_blank" rel="noopener noreferrer" href="https://www.google.com/search?source=hp&q=test&oq=test">https://www.google.com/search?source=hp&q=test&oq=test</a> end test'
+    );
+    expect(
+        utils.linkifyLog('<a href="https://pinterest.com">Cool Website</a>')
+    ).toBe(
+        '&lt;a href=&quot;<a target="_blank" rel="noopener noreferrer" href="https://pinterest.com">https://pinterest.com</a>&quot;&gt;Cool Website&lt;/a&gt;'
+    );
+
     // when not url
     expect(utils.linkifyLog('datahub&')).toBe('datahub&amp;');
 });

--- a/datahub/webapp/lib/utils/index.ts
+++ b/datahub/webapp/lib/utils/index.ts
@@ -1,4 +1,4 @@
-import { escape } from 'lodash';
+import { escape, unescape } from 'lodash';
 import { PickType } from 'lib/typescript';
 
 // from: https://stackoverflow.com/questions/286141/remove-blank-attributes-from-an-object-in-javascript
@@ -278,12 +278,28 @@ export function getHumanReadableByteSize(
 
 export function linkifyLog(log: string) {
     // https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
-    const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}(\.[a-z]{2,6})?\b([-a-zA-Z0-9@:%_\+.~#?&\/=]*)/g;
+    const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}(\.[a-z]{2,6})?\b([-a-zA-Z0-9@:%_\+.~#?&\/=]*)/;
+    const processedParts: string[] = [];
 
-    return escape(log).replace(
-        urlRegex,
-        '<a target="_blank" rel="noopener noreferrer" href="$&">$&</a>'
-    );
+    while (true) {
+        const match = log.match(urlRegex);
+        if (match) {
+            const url = match[0];
+            const matchStart = match.index;
+            const matchEnd = match.index + url.length;
+
+            const partBeforeMatch = log.slice(0, matchStart);
+            log = log.slice(matchEnd);
+            processedParts.push(escape(partBeforeMatch));
+            processedParts.push(
+                `<a target="_blank" rel="noopener noreferrer" href="${url}">${url}</a>`
+            );
+        } else {
+            processedParts.push(escape(log));
+            break;
+        }
+    }
+    return processedParts.join('');
 }
 
 export function calculateTooltipSize(tooltip: string) {


### PR DESCRIPTION
Since the url regex only matches unescaped URL, it does not work when the URL contains ? & since they are turned into &amp; The new algorithm would get the URL part by part and merge them together at the end. 

Added unit test for these cases as well