### PR TITLE
add access control for query search

### DIFF
--- a/datahub/server/datasources/query_execution.py
+++ b/datahub/server/datasources/query_execution.py
@@ -119,6 +119,13 @@ def search_query_execution(
 ):
     verify_environment_permission([environment_id])
     with DBSession() as session:
+        if "user" in filters:
+            api_assert(
+                current_user.id == filters["user"],
+                "You can only search your own queries",
+            )
+        else:
+            filters["user"] = current_user.id
         query_executions = logic.search_query_execution(
             environment_id=environment_id,
             filters=filters,


### PR DESCRIPTION
Lockdown search api by enforcing user can only search for their own queries.