### PR TITLE
[UI] DataDoc Dropdown Icon Fix

### DIFF
--- a/datahub/webapp/components/DataDoc/DataDoc.scss
+++ b/datahub/webapp/components/DataDoc/DataDoc.scss
@@ -163,6 +163,11 @@
                         .block-left-buttons-wrapper {
                             position: absolute;
                             left: 4px;
+                            .Dropdown {
+                                .Dropdown-trigger {
+                                    display: flex;
+                                }
+                            }
                         }
 
                         .block-right-buttons-wrapper {


### PR DESCRIPTION
Before:
<img width="644" alt="Screen Shot 2020-09-09 at 2 08 33 PM" src="https://user-images.githubusercontent.com/29313935/92655612-8fd7d100-f2a6-11ea-9e27-3002591b223b.png">

After:
<img width="644" alt="Screen Shot 2020-09-09 at 2 08 26 PM" src="https://user-images.githubusercontent.com/29313935/92655615-9108fe00-f2a6-11ea-8796-530c60fe2d22.png">
