### PR TITLE
Fix query engine and environment join bug

### DIFF
--- a/datahub/server/logic/query_execution.py
+++ b/datahub/server/logic/query_execution.py
@@ -149,6 +149,7 @@ def get_query_execution_by_ids(ids, session=None):
 def get_environment_by_execution_id(execution_id, session=None):
     return (
         session.query(Environment)
+        .join(QueryEngineEnvironment)
         .join(QueryEngine)
         .join(QueryExecution)
         .filter(QueryExecution.id == execution_id)


### PR DESCRIPTION
Error with new many to many environments - query engine change. This fixes the get_environment_by_execution_id by using the intermediary QueryEngineEnvironment table function.