### PR TITLE
Update to error handling logic for datahub

### DIFF
--- a/datahub/server/tasks/run_query.py
+++ b/datahub/server/tasks/run_query.py
@@ -136,7 +136,7 @@ def get_query_execution_params(query_execution_id):
             raise InvalidQueryExecution(f"Query {query_execution_id} does not exist")
         if query_execution.status != QueryExecutionStatus.INITIALIZED:
             raise AlreadyExecutedException(
-                f"Query {query_execution_id} is already executed, this is likely caused by a worker crash."
+                f"Query {query_execution_id} is already executed. This is likely caused by a worker crash."
             )
 
         query = query_execution.query


### PR DESCRIPTION
Here are the changes to query execution error handling, note this should only impact error handling that happens outside executor for cases such as:
- the query ran for more than 2 days
- the execution crashed and was sent to another worker
- query error'ed out due to python runtime error outside executor 

The changes include:
- unified the error handler for different exceptions into 1
- only update to the error status and error message if the query status is not (done, error)
- always send out notification no matter what
- AlreadyExecuted error is not suppressed, however, it should only result in a query error if the query execution did not finish previously