### PR TITLE
Make Presto syntax error include context sensitive errors

### DIFF
--- a/datahub/server/lib/query_executor/executors/presto.py
+++ b/datahub/server/lib/query_executor/executors/presto.py
@@ -43,13 +43,14 @@ class PrestoQueryExecutor(QueryExecutorBaseClass):
                 error_dict = get_presto_error_dict(e)
                 if error_dict:
                     error_extracted = error_dict.get("message", None)
-                    if error_dict.get("errorName") == "SYNTAX_ERROR":
+                    # In Presto, only context free syntax error are labelled as
+                    # SYNTAX_ERROR, and context sensitive errors are user errors
+                    # However in both cases errorLocation is provided
+                    if "errorLocation" in error_dict:
                         return get_parsed_syntax_error(
                             error_extracted,
-                            error_dict.get("errorLocation", {}).get("lineNumber", 1)
-                            - 1,
-                            error_dict.get("errorLocation", {}).get("columnNumber", 1)
-                            - 1,
+                            error_dict["errorLocation"].get("lineNumber", 1) - 1,
+                            error_dict["errorLocation"].get("columnNumber", 1) - 1,
                         )
 
         except Exception:


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/8283407/93283571-c6c64f00-f79e-11ea-9ed0-f1ec472eaa7c.png)

After
![image](https://user-images.githubusercontent.com/8283407/93283409-7cdd6900-f79e-11ea-8579-5c544f6f9e94.png)
