### PR TITLE
Pin greenlet version to 0.4.16

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ python-memcached==1.59
 redis==3.5.2
 
 gevent==20.6.2
-greenlet==0.4.16  # 0.4.17 update causes UWSGI to break 
+greenlet==0.4.16  # 0.4.17 update causes UWSGI to break
 
 alembic==1.0.3
 


### PR DESCRIPTION
The recent 0.4.17 update causes UWSGI to break