### PR TITLE
fix for presto syntax extract(field FROM x)

### DIFF
--- a/datahub/webapp/lib/sql-helper/sql-lexer.ts
+++ b/datahub/webapp/lib/sql-helper/sql-lexer.ts
@@ -638,9 +638,9 @@ export function findTableReferenceAndAlias(statements: IToken[][]) {
                     tableSearchMode = false;
                 } else if (token.type === 'VARIABLE') {
                     if (tableSearchMode) {
-                        const isActualTable = !(
-                            placeholders && placeholders.has(token.string)
-                        ) && token.raw_type === 'VARIABLE';;
+                        const isActualTable =
+                            !(placeholders && placeholders.has(token.string)) &&
+                            token.raw_type === 'VARIABLE';
 
                         if (isActualTable) {
                             tables.push(token);


### PR DESCRIPTION
I'm not sure if this is the actual fix, but I wanted to open this as a bug(?) that we are seeing.

Problem:
The sql-lexer assumes that anything that is a VARIABLE type following a FROM statement is a table and breaks the suggestions.

Root cause:
Presto allows a FROM clause in front of things other than table names
```
The types supported by the extract function vary depending on the field to be extracted. Most fields support all date and time types.
extract(field FROM x) → bigint
Returns field from x.
```

Code where this fails:
```
         while (!stream.eol()) {
            // here the match fails, and because nothing gets consumed it goes off in an infinite loop if the match is handled
            // Maybe the right thing to do is, if there's no match, break out of the stream matching?
            const match = stream.match(/^([_\w\d]+|`.*`)\.?/, true);

           // this fails and kicks you out of the loop, but then the suggestions stop working
            if (match[1]) {
                let part = match[1];
                if (part.charAt(0) === '`') {
                    // remove first and last char
                    part = part.slice(1, -1);
                }
                parts.push(part);
            }
```


short snippet of what caused this:
```
   SELECT *
   FROM table_2
  JOIN table_1
        ON table_1.field_1 = table_2.field_2
       AND extract(YEAR FROM field_1_date) = table_2.field_year
```