### PR TITLE
Add snowflake support for DH

### DIFF
--- a/datahub/server/lib/query_executor/all_executors.py
+++ b/datahub/server/lib/query_executor/all_executors.py
@@ -7,6 +7,7 @@ from .executors.sqlalchemy import (
     MysqlQueryExecutor,
     DruidQueryExecutor,
     SqliteQueryExecutor,
+    SnowflakeQueryExecutor,
 )
 from .executors.bigquery import BigQueryQueryExecutor
 
@@ -21,6 +22,7 @@ ALL_EXECUTORS = [
     DruidQueryExecutor,
     SqliteQueryExecutor,
     BigQueryQueryExecutor,
+    SnowflakeQueryExecutor,
 ] + ALL_PLUGIN_EXECUTORS
 
 

--- a/datahub/server/lib/query_executor/executors/sqlalchemy.py
+++ b/datahub/server/lib/query_executor/executors/sqlalchemy.py
@@ -63,3 +63,13 @@ class SqliteQueryExecutor(SqlAlchemyQueryExecutor):
     @classmethod
     def EXECUTOR_LANGUAGE(cls):
         return "sqlite"
+
+
+class SnowflakeQueryExecutor(SqlAlchemyQueryExecutor):
+    @classmethod
+    def EXECUTOR_NAME(cls):
+        return "sqlalchemy"
+
+    @classmethod
+    def EXECUTOR_LANGUAGE(cls):
+        return "snowflake"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -41,6 +41,8 @@ hmsclient==0.1.1
 pydruid==0.5.7
 # BigQuery
 google-cloud-bigquery==1.24.0
+# Snowflake
+snowflake-sqlalchemy==1.2.4
 
 # Query templating
 Jinja2==2.10.3  # From Flask


### PR DESCRIPTION
closes #304 
This adds a primitive version for Snowflake query engine for Datahub, all calls go through sqlalchemy.

For more advanced support in the future, I suggest we use snowflake-python-connector directly to customize better integrations with DataHub.