### PR TITLE
[BUG] CI breaks when trying to set env var, updating how env vars are set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pre-commit
-        key: pre-commit|${PY}|${{ hashFiles('.pre-commit-config.yaml') }}
+        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - uses: pre-commit/action@v1.0.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

```
Run echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
Error: Unable to process command '::set-env name=PY::c19639f9a84382269728f4ed835489e2160195648d7a2fcffd6a3bf36146c743' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```