### PR TITLE
Bump Python & Flask version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.7
+FROM python:3.7.9
 ARG PRODUCTION=true
 
 ## Install DataHub package requirements + NodeJS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "datahub",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ python-ldap==3.3.1
 
 # Server
 Werkzeug==0.15.5
-flask==1.1.1
+flask==1.1.2
 Flask-Caching==1.7.2
 Flask-Compress==1.4.0
 Flask-Login==0.4.1


### PR DESCRIPTION
This PR bumps Python to 3.7.9, updating to python3.8 requires celery to be updated to ~5.0 due to https://github.com/celery/celery/issues/5761

Tested locally