### PR TITLE
Only show query engine from in the environment for samples

### DIFF
--- a/datahub/webapp/components/DataTableViewSamples/DataTableViewSamples.tsx
+++ b/datahub/webapp/components/DataTableViewSamples/DataTableViewSamples.tsx
@@ -134,11 +134,15 @@ export const DataTableViewSamples: React.FunctionComponent<IDataTableViewSamples
     );
 
     const dispatch: Dispatch = useDispatch();
-    const queryEngines = useSelector((state: IStoreState) =>
-        Object.values(state.queryEngine.queryEngineById).filter(
-            (engine) => engine.metastore_id === schema.metastore_id
-        )
-    );
+    const queryEngines = useSelector((state: IStoreState) => {
+        const queryEngineIds =
+            state.environment.environmentEngineIds[
+                state.environment.currentEnvironmentId
+            ] ?? [];
+        return queryEngineIds
+            .map((engineId) => state.queryEngine.queryEngineById[engineId])
+            .filter((engine) => engine?.metastore_id === schema.metastore_id);
+    });
 
     const loadDataTableSamples = React.useCallback(
         async () =>


### PR DESCRIPTION
Previous behavior:
- "Samples" engine selector shows all query engines associated with the metastore that are stored in the frontend redux store.
New behavior:
- Only query engines within the environment and associated with the metastore will be shown
