### PR TITLE
Fixed gradient text with wrong class

### DIFF
--- a/docs_website/src/components/HomePage/HeaderSection/index.jsx
+++ b/docs_website/src/components/HomePage/HeaderSection/index.jsx
@@ -14,9 +14,9 @@ export default () => {
                             text="Discover"
                             className="text-discover"
                         />
-                        ,{' '}
+                        ,&nbsp;
                         <GradientText text="Analyze" className="text-analyze" />
-                        , and{' '}
+                        , and&nbsp;
                         <GradientText
                             text="Collaborate"
                             className="text-collaborate"


### PR DESCRIPTION
for some magical reason, when {' '} added, the css class for analyze became 'text-collaborate'. This is such a strange bug so I didn't delve into the actual root cause

![image](https://user-images.githubusercontent.com/8283407/101713113-f9fa4080-3a64-11eb-9522-05110302a136.png)
