### PR TITLE
Use content for markdown formatting

### DIFF
--- a/datahub/webapp/ui/Content/Content.scss
+++ b/datahub/webapp/ui/Content/Content.scss
@@ -69,6 +69,10 @@
         padding: 24px;
     }
 
+    pre {
+        font-size: inherit;
+    }
+
     ol {
         list-style-position: outside;
         margin-left: 32px;

--- a/datahub/webapp/ui/Markdown/Markdown.tsx
+++ b/datahub/webapp/ui/Markdown/Markdown.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import MarkdownJSX, { MarkdownToJSX } from 'markdown-to-jsx';
 import { Link } from 'ui/Link/Link';
+import { Content } from 'ui/Content/Content';
 
 const MarkdownLink: React.FC<{ title: string; href: string }> = ({
     title,
@@ -21,5 +22,7 @@ const markdownOptions: MarkdownToJSX.Options = {
 };
 
 export const Markdown: React.FC<{ children: string }> = ({ children }) => (
-    <MarkdownJSX options={markdownOptions}>{children}</MarkdownJSX>
+    <Content>
+        <MarkdownJSX options={markdownOptions}>{children}</MarkdownJSX>
+    </Content>
 );


### PR DESCRIPTION
So that the styling can be more specified in the context of content.
No visible change in looks