### PR TITLE
Ensure scheduler works with old configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/lib/scheduled_datadoc/export.py
+++ b/querybook/server/lib/scheduled_datadoc/export.py
@@ -9,8 +9,8 @@ from logic.query_execution import get_last_query_execution_from_cell
 
 
 @with_session
-def export_datadoc(doc_id, uid, exports, session=None):
-    if not len(exports):
+def export_datadoc(doc_id: int, uid: int, exports: List, session=None):
+    if not exports or len(exports) == 0:
         return []
 
     export_by_cell = group_export_by_cell_id(exports)

--- a/querybook/server/lib/scheduled_datadoc/legacy.py
+++ b/querybook/server/lib/scheduled_datadoc/legacy.py
@@ -1,5 +1,7 @@
 from typing import Dict
 
+LEGACY_KEYS = ["exporter_cell_id", "exporter_name", "exporter_params"]
+
 
 def set_key_if_exists(to_dict: Dict, from_dict: Dict, key: str):
     if key in from_dict:
@@ -20,18 +22,21 @@ def convert_if_legacy_datadoc_schedule(schedule_config: Dict) -> Dict:
         Dict: Up to date config
     """
 
-    is_legacy_config = "exporter_cell_id" in schedule_config
+    is_legacy_config = any(key in schedule_config for key in LEGACY_KEYS)
     if not is_legacy_config:
         return schedule_config
 
-    export_config = {
-        "exporter_cell_id": schedule_config["exporter_cell_id"],
-        "exporter_name": schedule_config["exporter_name"],
-    }
-    set_key_if_exists(export_config, schedule_config, "exporter_params")
+    exports = []
+    if "exporter_cell_id" in schedule_config:
+        export_config = {
+            "exporter_cell_id": schedule_config["exporter_cell_id"],
+            "exporter_name": schedule_config["exporter_name"],
+        }
+        set_key_if_exists(export_config, schedule_config, "exporter_params")
+        exports.append(export_config)
 
     new_schedule_config = {
-        "exports": [export_config],
+        "exports": exports,
         "doc_id": schedule_config["doc_id"],
         "user_id": schedule_config["user_id"],
     }

--- a/querybook/tests/test_lib/test_scheduled_datadoc/test_legacy.py
+++ b/querybook/tests/test_lib/test_scheduled_datadoc/test_legacy.py
@@ -13,6 +13,7 @@ legacy_config = {
     "exporter_params": {},
 }
 
+
 current_config = {
     **unchanged_fields,
     "exports": [
@@ -27,6 +28,12 @@ def test_convert_current():
 
 def test_convert_legacy():
     assert convert_if_legacy_datadoc_schedule(legacy_config) == current_config
+
+
+def test_convert_semi_legacy():
+    assert convert_if_legacy_datadoc_schedule(
+        {**unchanged_fields, "exporter_name": "foobar", "exporter_params": {},}
+    ) == {**unchanged_fields, "exports": []}
 
 
 def test_convert_unchanged():

--- a/querybook/webapp/components/DataDocSchedule/DataDocScheduleForm.tsx
+++ b/querybook/webapp/components/DataDocSchedule/DataDocScheduleForm.tsx
@@ -284,7 +284,7 @@ const ScheduleExportsForm: React.FC<{
     const queryCellOptions = useSelector((state: IStoreState) =>
         queryCellSelector(state, { docId })
     );
-    const exportsValues = values.kwargs.exports;
+    const exportsValues = values.kwargs.exports ?? [];
 
     return (
         <FieldArray
@@ -358,7 +358,7 @@ const ScheduleExportsForm: React.FC<{
                     return (
                         <div
                             key={index}
-                            className="cell-export-field p4 mt16 flex-row"
+                            className="cell-export-field ph12 pv4 mt16 flex-row"
                         >
                             <div className="flex1">
                                 {cellPickerField}


### PR DESCRIPTION
Now, the legacy config converter will remove all "export_" keys from the old config. Also realized that "exports" field is nullable so added additional checks in both front/backend to prevent error