### PR TITLE
Fix scheduler export

### DIFF
--- a/querybook/server/lib/query_executor/base_executor.py
+++ b/querybook/server/lib/query_executor/base_executor.py
@@ -2,7 +2,6 @@ from abc import ABCMeta, abstractclassmethod
 import datetime
 import time
 
-
 from app.db import DBSession
 from app.flask_app import socketio
 

--- a/querybook/server/lib/scheduled_datadoc/export.py
+++ b/querybook/server/lib/scheduled_datadoc/export.py
@@ -19,9 +19,10 @@ def export_datadoc(doc_id: int, uid: int, exports: List, session=None):
     export_urls = []
     for cell in query_cells:
         if cell.id not in export_by_cell:
-            pass
+            continue
+
         export_urls.extend(
-            _export_query_cell(cell, uid, export_by_cell[cell.id], session)
+            _export_query_cell(cell.id, uid, export_by_cell[cell.id], session=session)
         )
 
     return export_urls
@@ -34,15 +35,11 @@ def group_export_by_cell_id(exports: List):
     return export_by_cell
 
 
-def _export_query_cell(
-    cell,
-    uid,
-    cell_exports,
-    session,  # Don't use with_session because cell is should be in another
-):
+@with_session
+def _export_query_cell(cell_id, uid, cell_exports, session=None):
     statement_execution_id = None
 
-    query_execution = get_last_query_execution_from_cell(cell.id, session=session)
+    query_execution = get_last_query_execution_from_cell(cell_id, session=session)
     if not query_execution or query_execution.status != QueryExecutionStatus.DONE:
         return [query_execution.status]
     statement_execution_id = query_execution.statement_executions[-1].id

--- a/querybook/server/logic/query_execution.py
+++ b/querybook/server/logic/query_execution.py
@@ -45,7 +45,8 @@ def get_datadoc_id_from_query_execution_id(query_execution_id, session=None):
 def get_last_query_execution_from_cell(cell_id, session=None):
     return (
         session.query(QueryExecution)
-        .join(DataCellQueryExecution, DataCellQueryExecution.data_cell_id == cell_id,)
+        .join(DataCellQueryExecution)
+        .filter(DataCellQueryExecution.data_cell_id == cell_id)
         .order_by(QueryExecution.id.desc())
         .first()
     )

--- a/querybook/server/tasks/run_query.py
+++ b/querybook/server/tasks/run_query.py
@@ -1,4 +1,5 @@
 import traceback
+import datetime
 
 from app.db import with_session, DBSession
 from app.flask_app import celery
@@ -115,6 +116,7 @@ def run_query_task(self, query_execution_id):
                 qe_logic.update_query_execution(
                     query_execution_id,
                     status=QueryExecutionStatus.ERROR,
+                    completed_at=datetime.datetime.utcnow(),
                     session=session,
                 )
 

--- a/querybook/tests/test_lib/test_scheduled_datadoc/test_export.py
+++ b/querybook/tests/test_lib/test_scheduled_datadoc/test_export.py
@@ -22,6 +22,10 @@ def test_group_export_by_cell_id():
     }
 
 
+def mock_exporter_side_effect(statement_id, uid, **params):
+    return params.get("to", "foo.baz")
+
+
 @mock.patch("lib.scheduled_datadoc.export.get_last_query_execution_from_cell")
 @mock.patch("lib.scheduled_datadoc.export.get_exporter")
 def test_export_query_cell(mock_get_exporter, mock_get_execution):
@@ -30,15 +34,19 @@ def test_export_query_cell(mock_get_exporter, mock_get_execution):
     mock_get_execution.return_value = mock_execution
 
     mock_exporter = mock.MagicMock()
-    mock_exporter.export.return_value = "foobar.baz"
+    mock_exporter.export.side_effect = mock_exporter_side_effect
     mock_get_exporter.return_value = mock_exporter
 
     assert _export_query_cell(
-        cell=mock.MagicMock(),
+        cell_id=1,
         uid=1,
         cell_exports=[
             {"exporter_cell_id": 1, "exporter_name": "foo"},
-            {"exporter_cell_id": 1, "exporter_name": "bar"},
+            {
+                "exporter_cell_id": 1,
+                "exporter_name": "bar",
+                "exporter_params": {"to": "foobar.baz"},
+            },
         ],
         session=mock.MagicMock(),
-    ) == ["foobar.baz", "foobar.baz"]
+    ) == ["foo.baz", "foobar.baz"]


### PR DESCRIPTION
- Fixed get_last_query_execution_from_cell from cell to actually get that execution
- Fixed skipping cells that are not in the export list
- Updated unit test cases