### PR TITLE
Make webpack hot reload in docker compose

### DIFF
--- a/containers/docker-compose.dev.yml
+++ b/containers/docker-compose.dev.yml
@@ -22,7 +22,7 @@ services:
     web:
         extends:
             service: base
-        command: './querybook/scripts/docker_run_interactive ./querybook/scripts/runservice web ${PORT-10001}'
+        command: './querybook/scripts/docker_run_interactive ./querybook/scripts/runservice web --debug ${PORT-10001}'
     worker:
         extends:
             service: base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,13 @@ services:
         # network_mode: "host"
         command: './querybook/scripts/bundled_docker_run_web'
         ports:
-            - '10001:10001'
+            - '${PORT-10001}:${PORT-10001}'
         expose:
-            - '10001'
+            - '${PORT-10001}'
         environment:
-            PORT: 10001
+            PORT: ${PORT-10001}
+            APIPORT: ${APIPORT-3000}
+            HOT_RELOAD: ${HOT_RELOAD-true}
         restart: 'always'
         volumes:
             # This is for code change via watcher

--- a/querybook/scripts/bundled_docker_run_web
+++ b/querybook/scripts/bundled_docker_run_web
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
 
 ./querybook/scripts/init_db
-./querybook/scripts/runservice web ${PORT-10001}
+
+if [ "$HOT_RELOAD" = "true" ]; then
+    ./querybook/scripts/runservice web ${APIPORT-3000} & PIDSERVER=$!
+    yarn run webpack-dev-server \
+        --host 0.0.0.0 \
+        --port ${PORT-10001} \
+        --mode=development --open --hot \
+        --env.QUERYBOOK_UPSTREAM=http://0.0.0.0:${APIPORT-3000}  & PIDWEB=$!
+    wait $PIDSERVER
+    wait $PIDWEB
+else
+    ./querybook/scripts/runservice web --debug ${PORT-10001}
+fi

--- a/querybook/scripts/runservice
+++ b/querybook/scripts/runservice
@@ -12,13 +12,13 @@ fi
 COMMAND=""
 case "$SERVICE_NAME" in
 "web")
-    COMMAND="python3 querybook/server/runweb.py --debug"
+    COMMAND="python3 querybook/server/runweb.py"
     ;;
 "worker")
     COMMAND="watchmedo auto-restart -d querybook -p '*.py' -R -- celery worker -A tasks.all_tasks --loglevel=DEBUG"
     ;;
 "scheduler")
-    COMMAND="watchmedo auto-restart -d querybook -p '*.py' -R -- celery beat -A tasks.all_tasks -S scheduler.DatabaseScheduler --loglevel=DEBUG"
+    COMMAND="watchmedo auto-restart -d querybook -p '*.py' -R -- celery beat -A tasks.all_tasks -S scheduler.DatabaseScheduler --loglevel=INFO"
     ;;
 "worker_scheduler") # FIXME: this doesn't schedule task as desired
     COMMAND="celery -A tasks.all_tasks worker --beat --scheduler scheduler.DatabaseScheduler --loglevel=INFO"

--- a/querybook/server/app/flask_app.py
+++ b/querybook/server/app/flask_app.py
@@ -10,7 +10,7 @@ from flask_limiter.util import get_remote_address
 from flask_caching import Cache
 
 
-from const.path import BUILD_PATH, STATIC_PATH, WEBAPP_PATH
+from const.path import BUILD_PATH, STATIC_PATH, WEBAPP_DIR_PATH
 from env import QuerybookSettings
 from lib.utils.json import JSONEncoder
 
@@ -126,7 +126,7 @@ def make_blue_print(app, limiter):
     blueprint = Blueprint(
         "static_build_files",
         __name__,
-        static_folder=WEBAPP_PATH,
+        static_folder=WEBAPP_DIR_PATH,
         static_url_path=BUILD_PATH,
     )
     app.register_blueprint(blueprint)

--- a/querybook/server/app/server.py
+++ b/querybook/server/app/server.py
@@ -1,10 +1,10 @@
 import os
-from flask import send_from_directory, abort
+from flask import send_file, abort
 
 from app import auth
 from app.datasource import register, abort_request
 from app.flask_app import flask_app, limiter
-from const.path import WEBAPP_PATH
+from const.path import WEBAPP_INDEX_PATH
 
 
 import datasources
@@ -34,4 +34,4 @@ def get_health_check():
 @flask_app.route("/<path:ignore>/")
 @limiter.exempt
 def main(ignore=None):
-    return send_from_directory(WEBAPP_PATH, "index.html")
+    return send_file(WEBAPP_INDEX_PATH, mimetype="text/html")

--- a/querybook/server/const/path.py
+++ b/querybook/server/const/path.py
@@ -4,5 +4,6 @@ PROJECT_ROOT_PATH = os.path.join(os.path.dirname(__file__), "../../../")
 BUILD_PATH = "/build"
 STATIC_PATH = os.path.join(PROJECT_ROOT_PATH, "./querybook/static")
 CONFIG_PATH = os.path.join(PROJECT_ROOT_PATH, "./querybook/config")
-WEBAPP_PATH = os.path.join(PROJECT_ROOT_PATH, "./dist/webapp/")
+WEBAPP_DIR_PATH = os.path.join(PROJECT_ROOT_PATH, "./dist/webapp/")
+WEBAPP_INDEX_PATH = os.path.join(WEBAPP_DIR_PATH, "index.html")
 CHANGE_LOG_PATH = os.path.join(PROJECT_ROOT_PATH, "./docs/changelog/")

--- a/querybook/server/lib/richtext.py
+++ b/querybook/server/lib/richtext.py
@@ -31,5 +31,5 @@ def draftjs_content_state_to_plaintext(content_state) -> str:
 
 
 def html_to_plaintext(html) -> str:
-    soup = BeautifulSoup(html)
+    soup = BeautifulSoup(html, "html.parser")
     return soup.getText()


### PR DESCRIPTION
Closes #384 

Hot reloading is enabled by default, this is done by running 2 processes (webpack devserver on 10001 + python server on 3000) in web docker.
This functionality can be turned off by setting env variable HOT_RELOAD=false before running docker compose