### PR TITLE
fix: correct connection behavior with socketio

### DIFF
--- a/querybook/webapp/lib/data-doc/datadoc-socketio.ts
+++ b/querybook/webapp/lib/data-doc/datadoc-socketio.ts
@@ -79,7 +79,7 @@ export class DataDocSocket {
 
     private _activeDataDocId: number = null;
     private socket: SocketIOClient.Socket = null;
-    private socketPromise: Promise<any> = null;
+    private socketPromise: Promise<SocketIOClient.Socket> = null;
 
     private promiseMap: IDataDocSocketEvent = {};
     private eventMap: IDataDocSocketEvent = {};
@@ -101,11 +101,11 @@ export class DataDocSocket {
         if (docId !== this._activeDataDocId && this._activeDataDocId != null) {
             this.removeDataDoc(this._activeDataDocId, false);
         }
-
-        this._activeDataDocId = docId;
         this.eventMap = eventMap;
 
         await this.setupSocket();
+        this._activeDataDocId = docId;
+        this.socket.emit('subscribe', docId);
 
         this.getDataDocEditors(docId);
         this.getDataDocAccessRequests(docId);
@@ -204,7 +204,7 @@ export class DataDocSocket {
         }
     };
 
-    public onSocketConnect(socket: SocketIOClient.Socket) {
+    private onSocketConnect(socket: SocketIOClient.Socket) {
         if (this._activeDataDocId != null) {
             socket.emit('subscribe', this._activeDataDocId);
         }
@@ -220,7 +220,7 @@ export class DataDocSocket {
     }
 
     private checkIsSameOrigin(originator: string) {
-        return originator === this.socket.id;
+        return originator === this.socket?.id;
     }
 
     private resolvePromise(key: string, isSameOrigin: boolean, ...args: any[]) {

--- a/querybook/webapp/lib/socketio-manager.ts
+++ b/querybook/webapp/lib/socketio-manager.ts
@@ -26,7 +26,7 @@ const sendToastForError = throttle((error) => {
 export default {
     getSocket: async (
         nameSpace = '/',
-        onConnection: (socket: SocketIOClient.Socket) => any = null
+        onConnection: (socket: SocketIOClient.Socket) => void = null
     ) => {
         const socket = getSocketFromManager(nameSpace);
 
@@ -53,8 +53,11 @@ export default {
         return socket;
     },
     removeSocket: (socket: SocketIOClient.Socket) => {
-        if (socket && socket.connected) {
-            socket.close();
+        if (socket) {
+            if (socket.connected) {
+                socket.close();
+            }
+            socket.removeAllListeners();
         }
     },
 };

--- a/querybook/webapp/redux/queryExecutions/action.ts
+++ b/querybook/webapp/redux/queryExecutions/action.ts
@@ -552,7 +552,7 @@ class QueryExecutionSocket {
     // queryExecutionId => docId
     private activeQueryExecutions: Record<number, number> = {};
     private socket: SocketIOClient.Socket = null;
-    private socketPromise: Promise<any> = null;
+    private socketPromise: Promise<SocketIOClient.Socket> = null;
     private dispatch: ThunkDispatch = null;
 
     public addQueryExecution = async (
@@ -568,14 +568,15 @@ class QueryExecutionSocket {
                     updateDataDocPolling(docId, queryExecutionId, true)
                 );
             }
-            this.activeQueryExecutions[queryExecutionId] = docId;
 
             await this.setupSocket();
+            this.activeQueryExecutions[queryExecutionId] = docId;
+            this.socket.emit('subscribe', queryExecutionId);
         }
     };
 
     public onSocketConnect(socket: SocketIOClient.Socket) {
-        // Setup rooms
+        // Setup rooms for existing connections
         const activeQueryExecutionIds = Object.keys(this.activeQueryExecutions);
         if (activeQueryExecutionIds.length > 0) {
             activeQueryExecutionIds.map((queryExecutionId) => {
@@ -680,6 +681,7 @@ class QueryExecutionSocket {
                     this.processQueryExecution(queryExecution);
                 }
             );
+            return this.socket;
         }
     };
 }


### PR DESCRIPTION
since socketio 3 removed reconnection, connection is used for both initial connection and subsequent reconnection. In my last PR, I did not realize that onConnection is not called when you call setupSocket since the socket may already exist, this PR should solve that bug.