### PR TITLE
fix: disable react hot reloading for now

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         environment:
             PORT: ${PORT-10001}
             APIPORT: ${APIPORT-3000}
-            HOT_RELOAD: ${HOT_RELOAD-true}
+            HOT_RELOAD: ${HOT_RELOAD-false}
         restart: 'always'
         volumes:
             # This is for code change via watcher


### PR DESCRIPTION
Since it causes server logs not to show up. Disable it by default until we fix the issue