### PR TITLE
fix: Update nofile ulimit for docker to be 65536 to enable es

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,9 @@ services:
             memlock:
                 soft: -1
                 hard: -1
+            nofile:
+                soft: 65536
+                hard: 65536
         volumes:
             - esdata1:/usr/share/elasticsearch/data
         ports:


### PR DESCRIPTION
Closes #493 
Tested on mac and ubuntu. 