### PR TITLE
Add ClickHouse Support Through SQLAlchemy

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -43,6 +43,9 @@ pydruid==0.5.7
 google-cloud-bigquery==1.28.0
 # Snowflake
 snowflake-sqlalchemy==1.2.4
+# ClickHouse
+clickhouse-driver==0.2.0
+clickhouse-sqlalchemy==0.1.6
 
 # Query templating
 Jinja2==2.11.3  # From Flask


### PR DESCRIPTION
- Adds the native clickhouse driver

- Adds the sqlalchemy driver clickhouse

- Supports connection options within the string

- Specify your connection string as follows:

**HTTP** (default)
```
clickhouse://[user]:[pass]@[host]:[port]/[db][?key=value..]
or
clickhouse+http://[user]:[pass]@[host]:[port]/[db][?key=value..]
```

**Native**
```
clickhouse+native://[user]:[pass]@[host]:[port]/[db][?key=value..]
```