### PR TITLE
Modify cellType title

### DIFF
--- a/querybook/config/datadoc.yaml
+++ b/querybook/config/datadoc.yaml
@@ -1,6 +1,7 @@
 cell_types:
     text:
         key: 'text'
+        name: 'Text'
         icon: 'font'
         meta:
             collapsed: false
@@ -8,6 +9,7 @@ cell_types:
             collapsed: false
     query:
         key: 'query'
+        name: 'Query'
         icon: 'code'
         meta:
             title: '' # can be any string
@@ -21,6 +23,7 @@ cell_types:
             query_collapsed: false
     chart:
         key: 'chart'
+        name: 'Chart'
         icon: 'chart-line'
         meta:
             title: ''

--- a/querybook/webapp/components/DataDoc/DataDocCellControl.tsx
+++ b/querybook/webapp/components/DataDoc/DataDocCellControl.tsx
@@ -10,7 +10,16 @@ import { SoftButton } from 'ui/Button/Button';
 import { Dropdown } from 'ui/Dropdown/Dropdown';
 import { ListMenu, IListMenuItem } from 'ui/Menu/ListMenu';
 
-const cellTypes = require('config/datadoc.yaml').cell_types;
+const cellTypes: Record<
+    string,
+    {
+        key: string;
+        icon: string;
+        name?: string;
+        meta: Record<string, unknown>;
+        meta_default: Record<string, unknown>;
+    }
+> = require('config/datadoc.yaml').cell_types;
 
 interface IProps {
     index?: number;

--- a/querybook/webapp/components/DataDoc/DataDocCellControl.tsx
+++ b/querybook/webapp/components/DataDoc/DataDocCellControl.tsx
@@ -262,14 +262,14 @@ const InsertCellButtons: React.FC<{
         [insertCellAt, index]
     );
 
-    const buttonsDOM = Object.keys(cellTypes).map((cellKey) => (
+    const buttonsDOM = Object.entries(cellTypes).map(([cellKey, cellType]) => (
         <AsyncButton
             className="block-crud-button"
             key={cellKey}
             onClick={() => handleInsertcell(cellKey)}
             icon="plus"
             title={ !cellTypes[cellKey].name
-                ? titleize(cellKey)
+                ?? titleize(cellKey)
                 : cellTypes[cellKey].name
             }
             type="soft"

--- a/querybook/webapp/components/DataDoc/DataDocCellControl.tsx
+++ b/querybook/webapp/components/DataDoc/DataDocCellControl.tsx
@@ -268,7 +268,8 @@ const InsertCellButtons: React.FC<{
             key={cellKey}
             onClick={() => handleInsertcell(cellKey)}
             icon="plus"
-            title={titleize(cellKey)}
+            title={ !cellTypes[cellKey].name ? 
+                titleize(cellKey) : cellTypes[cellKey].name }
             type="soft"
         />
     ));

--- a/querybook/webapp/components/DataDoc/DataDocCellControl.tsx
+++ b/querybook/webapp/components/DataDoc/DataDocCellControl.tsx
@@ -268,8 +268,10 @@ const InsertCellButtons: React.FC<{
             key={cellKey}
             onClick={() => handleInsertcell(cellKey)}
             icon="plus"
-            title={ !cellTypes[cellKey].name ? 
-                titleize(cellKey) : cellTypes[cellKey].name }
+            title={ !cellTypes[cellKey].name
+                ? titleize(cellKey)
+                : cellTypes[cellKey].name
+            }
             type="soft"
         />
     ));

--- a/querybook/webapp/components/DataDoc/DataDocCellControl.tsx
+++ b/querybook/webapp/components/DataDoc/DataDocCellControl.tsx
@@ -268,10 +268,7 @@ const InsertCellButtons: React.FC<{
             key={cellKey}
             onClick={() => handleInsertcell(cellKey)}
             icon="plus"
-            title={ !cellTypes[cellKey].name
-                ?? titleize(cellKey)
-                : cellTypes[cellKey].name
-            }
+            title={cellType.name ?? titleize(cellKey)}
             type="soft"
         />
     ));


### PR DESCRIPTION
Read cellType title from 'name' field of 'datadoc.yaml' for better UI customizations, such as using alternative terms or translating into other languages.