### PR TITLE
fix: Meaningful error when creating a datadoc in env without query engine

### DIFF
--- a/querybook/webapp/components/CreateDataDocButton/CreateDataDocButton.tsx
+++ b/querybook/webapp/components/CreateDataDocButton/CreateDataDocButton.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-
-import history from 'lib/router-history';
 import { TooltipDirection } from 'const/tooltip';
-import * as dataDocActions from 'redux/dataDoc/action';
-import { currentEnvironmentSelector } from 'redux/environment/selector';
-import { Dispatch, IStoreState } from 'redux/store/types';
+import { useCreateDataDoc } from 'hooks/dataDoc/useCreateDataDoc';
 import { IconButton } from 'ui/Button/IconButton';
-import { getQueryEngineId } from 'lib/utils';
-import { queryEngineSelector } from 'redux/queryEngine/selector';
 
 export interface ICreateDataDocButtonProps {
     // from own Props
@@ -20,26 +13,7 @@ export const CreateDataDocButton: React.FunctionComponent<ICreateDataDocButtonPr
     tooltipPos = 'left',
     tooltip = 'New DataDoc',
 }) => {
-    const environment = useSelector(currentEnvironmentSelector);
-    const queryEngines = useSelector(queryEngineSelector);
-    const defaultEngineId = useSelector((state: IStoreState) =>
-        getQueryEngineId(
-            state.user.computedSettings['default_query_engine'],
-            queryEngines.map(({ id }) => id)
-        )
-    );
-    const dispatch: Dispatch = useDispatch();
-
-    const handleCreateDataDoc = React.useCallback(() => {
-        const cell = {
-            type: 'query',
-            context: '',
-            meta: { engine: defaultEngineId },
-        };
-        dispatch(dataDocActions.createDataDoc([cell])).then((dataDoc) =>
-            history.push(`/${environment.name}/datadoc/${dataDoc.id}/`)
-        );
-    }, [environment]);
+    const handleCreateDataDoc = useCreateDataDoc();
 
     return (
         <IconButton

--- a/querybook/webapp/components/Info/Tours.tsx
+++ b/querybook/webapp/components/Info/Tours.tsx
@@ -15,29 +15,10 @@ import { Title } from 'ui/Title/Title';
 import { Card } from 'ui/Card/Card';
 
 import './Tours.scss';
+import { useCreateDataDoc } from 'hooks/dataDoc/useCreateDataDoc';
 
 export const Tours: React.FunctionComponent = () => {
-    const environment = useSelector(currentEnvironmentSelector);
-    const queryEngines = useSelector(queryEngineSelector);
-    const defaultEngineId = useSelector((state: IStoreState) =>
-        getQueryEngineId(
-            state.user.computedSettings['default_query_engine'],
-            queryEngines.map(({ id }) => id)
-        )
-    );
-    const dispatch: Dispatch = useDispatch();
-    const handleDataDocTour = React.useCallback(() => {
-        const cell = {
-            type: 'query',
-            context: '',
-            meta: { engine: defaultEngineId },
-        };
-        dispatch(dataDocActions.createDataDoc([cell])).then((dataDoc) =>
-            history.push(
-                `/${environment.name}/datadoc/${dataDoc.id}/?tour=true`
-            )
-        );
-    }, [environment, defaultEngineId]);
+    const handleDataDocTour = useCreateDataDoc(true);
 
     return (
         <div className="Tours m12">

--- a/querybook/webapp/hooks/dataDoc/useCreateDataDoc.ts
+++ b/querybook/webapp/hooks/dataDoc/useCreateDataDoc.ts
@@ -1,0 +1,43 @@
+import { useSelector, useDispatch } from 'react-redux';
+import history from 'lib/router-history';
+
+import { createDataDoc } from 'redux/dataDoc/action';
+import { currentEnvironmentSelector } from 'redux/environment/selector';
+import { Dispatch, IStoreState } from 'redux/store/types';
+import { queryEngineSelector } from 'redux/queryEngine/selector';
+import { getQueryEngineId } from 'lib/utils';
+import { useCallback } from 'react';
+import toast from 'react-hot-toast';
+
+export function useCreateDataDoc(withTour = false) {
+    const environment = useSelector(currentEnvironmentSelector);
+    const queryEngines = useSelector(queryEngineSelector);
+    const defaultEngineId = useSelector((state: IStoreState) =>
+        getQueryEngineId(
+            state.user.computedSettings['default_query_engine'],
+            queryEngines.map(({ id }) => id)
+        )
+    );
+    const dispatch: Dispatch = useDispatch();
+    return useCallback(() => {
+        if (defaultEngineId == null) {
+            toast.error(
+                'Cannot create a DataDoc because the environment has no query engine.'
+            );
+            return;
+        }
+
+        const cell = {
+            type: 'query',
+            context: '',
+            meta: { engine: defaultEngineId },
+        };
+        dispatch(createDataDoc([cell])).then((dataDoc) =>
+            history.push(
+                `/${environment.name}/datadoc/${dataDoc.id}/${
+                    withTour ? '?tour=true' : ''
+                }`
+            )
+        );
+    }, [environment, defaultEngineId]);
+}


### PR DESCRIPTION
We do not allow datadocs to be created without a query engine (otherwise the default query cell would not work), however the error previously was confusing. I have added a frontend check instead to show a more understandable error.

![image](https://user-images.githubusercontent.com/8283407/114784626-5a113400-9d30-11eb-9eff-9eca3297d4c4.png)
