### PR TITLE
fix: lower debounce for query cell

### DIFF
--- a/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
+++ b/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
@@ -49,7 +49,7 @@ import { Title } from 'ui/Title/Title';
 
 import './DataDocQueryCell.scss';
 
-const ON_CHANGE_DEBOUNCE_MS = 1000;
+const ON_CHANGE_DEBOUNCE_MS = 500;
 
 type StateProps = ReturnType<typeof mapStateToProps>;
 type DispatchProps = ReturnType<typeof mapDispatchToProps>;


### PR DESCRIPTION
Closes #492

I can't find a good solution for this issue, although the chances of happening are rare. So I lowered the debounce value so that the redux store can save more frequently before navigation.