### PR TITLE
ui: fix chart legend color update lag

### DIFF
--- a/querybook/webapp/components/DataDocChartCell/DataDocChart.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChart.tsx
@@ -25,6 +25,7 @@ interface IDataDocChartProps {
     meta: IDataChartCellMeta;
     data?: any[][];
     chartJSOptions?: ChartOptions;
+    setChartReference?: (reference) => void;
 }
 
 Chart.plugins.unregister(ChartDataLabels);
@@ -109,6 +110,7 @@ export const DataDocChart: React.FunctionComponent<IDataDocChartProps> = ({
     meta,
     data = [],
     chartJSOptions = {},
+    setChartReference,
 }) => {
     const theme = useSelector(
         (state: IStoreState) => state.user.computedSettings.theme
@@ -156,9 +158,27 @@ export const DataDocChart: React.FunctionComponent<IDataDocChartProps> = ({
     if (meta.chart.type === 'line' || meta.chart.type === 'area') {
         chartDOM = <Line {...chartProps} />;
     } else if (meta.chart.type === 'bar') {
-        chartDOM = <Bar {...chartProps} />;
+        chartDOM = (
+            <Bar
+                {...chartProps}
+                ref={
+                    setChartReference
+                        ? (reference) => setChartReference(reference)
+                        : null
+                }
+            />
+        );
     } else if (meta.chart.type === 'histogram') {
-        chartDOM = <HorizontalBar {...chartProps} />;
+        chartDOM = (
+            <HorizontalBar
+                {...chartProps}
+                ref={
+                    setChartReference
+                        ? (reference) => setChartReference(reference)
+                        : null
+                }
+            />
+        );
     } else if (meta.chart.type === 'pie') {
         chartDOM = <Pie {...chartProps} />;
     } else if (meta.chart.type === 'doughnut') {
@@ -166,7 +186,16 @@ export const DataDocChart: React.FunctionComponent<IDataDocChartProps> = ({
     } else if (meta.chart.type === 'scatter') {
         chartDOM = <Scatter {...chartProps} />;
     } else if (meta.chart.type === 'bubble') {
-        chartDOM = <Bubble {...chartProps} />;
+        chartDOM = (
+            <Bubble
+                {...chartProps}
+                ref={
+                    setChartReference
+                        ? (reference) => setChartReference(reference)
+                        : null
+                }
+            />
+        );
     }
 
     return chartDOM;

--- a/querybook/webapp/components/DataDocChartCell/DataDocChart.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChart.tsx
@@ -1,4 +1,4 @@
-import {
+import ChartComponent, {
     Line,
     Bar,
     HorizontalBar,
@@ -7,8 +7,9 @@ import {
     Doughnut,
     Bubble,
     defaults,
+    ChartComponentProps,
 } from 'react-chartjs-2';
-import React, { useMemo } from 'react';
+import React, { MutableRefObject, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import Chart, { ChartOptions } from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
@@ -25,7 +26,7 @@ interface IDataDocChartProps {
     meta: IDataChartCellMeta;
     data?: any[][];
     chartJSOptions?: ChartOptions;
-    setChartReference?: (reference) => void;
+    chartJSRef?: MutableRefObject<ChartComponent<ChartComponentProps>>;
 }
 
 Chart.plugins.unregister(ChartDataLabels);
@@ -110,7 +111,7 @@ export const DataDocChart: React.FunctionComponent<IDataDocChartProps> = ({
     meta,
     data = [],
     chartJSOptions = {},
-    setChartReference,
+    chartJSRef,
 }) => {
     const theme = useSelector(
         (state: IStoreState) => state.user.computedSettings.theme
@@ -152,33 +153,16 @@ export const DataDocChart: React.FunctionComponent<IDataDocChartProps> = ({
         data: chartData,
         plugins: [ChartDataLabels],
         options: combinedChartJSOptions,
+        ref: chartJSRef,
     };
 
     let chartDOM = null;
     if (meta.chart.type === 'line' || meta.chart.type === 'area') {
         chartDOM = <Line {...chartProps} />;
     } else if (meta.chart.type === 'bar') {
-        chartDOM = (
-            <Bar
-                {...chartProps}
-                ref={
-                    setChartReference
-                        ? (reference) => setChartReference(reference)
-                        : null
-                }
-            />
-        );
+        chartDOM = <Bar {...chartProps} />;
     } else if (meta.chart.type === 'histogram') {
-        chartDOM = (
-            <HorizontalBar
-                {...chartProps}
-                ref={
-                    setChartReference
-                        ? (reference) => setChartReference(reference)
-                        : null
-                }
-            />
-        );
+        chartDOM = <HorizontalBar {...chartProps} />;
     } else if (meta.chart.type === 'pie') {
         chartDOM = <Pie {...chartProps} />;
     } else if (meta.chart.type === 'doughnut') {
@@ -186,16 +170,7 @@ export const DataDocChart: React.FunctionComponent<IDataDocChartProps> = ({
     } else if (meta.chart.type === 'scatter') {
         chartDOM = <Scatter {...chartProps} />;
     } else if (meta.chart.type === 'bubble') {
-        chartDOM = (
-            <Bubble
-                {...chartProps}
-                ref={
-                    setChartReference
-                        ? (reference) => setChartReference(reference)
-                        : null
-                }
-            />
-        );
+        chartDOM = <Bubble {...chartProps} />;
     }
 
     return chartDOM;

--- a/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
@@ -5,6 +5,7 @@ import { Field, withFormik, FormikProps } from 'formik';
 import produce from 'immer';
 import { isEmpty, range } from 'lodash';
 import Select from 'react-select';
+import ChartComponent, { ChartComponentProps } from 'react-chartjs-2';
 
 import { IStoreState } from 'redux/store/types';
 import { IDataChartCellMeta } from 'const/datadoc';
@@ -91,7 +92,9 @@ const DataDocChartComposerComponent: React.FunctionComponent<
     const [displayStatementId, setDisplayStatementId] = React.useState(
         undefined
     );
-    const [chartReference, setChartReference] = React.useState();
+    const [chartReference, setChartReference] = React.useState<
+        ChartComponent<ChartComponentProps>
+    >();
 
     // making sure legend color updated for bar/horiz bar/bubble charts
     React.useEffect(() => {

--- a/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
@@ -91,6 +91,15 @@ const DataDocChartComposerComponent: React.FunctionComponent<
     const [displayStatementId, setDisplayStatementId] = React.useState(
         undefined
     );
+    const [chartReference, setChartReference] = React.useState();
+
+    // making sure legend color updated for bar/horiz bar/bubble charts
+    React.useEffect(() => {
+        if (chartReference) {
+            const chart = chartReference.chartInstance;
+            chart.update();
+        }
+    }, [values.coloredSeries, chartReference]);
 
     const {
         statementResultData,
@@ -929,6 +938,7 @@ const DataDocChartComposerComponent: React.FunctionComponent<
                 data={chartData}
                 meta={formValsToMeta(values, meta)}
                 chartJSOptions={{ maintainAspectRatio: false }}
+                setChartReference={setChartReference}
             />
         );
 

--- a/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
@@ -92,17 +92,16 @@ const DataDocChartComposerComponent: React.FunctionComponent<
     const [displayStatementId, setDisplayStatementId] = React.useState(
         undefined
     );
-    const [chartReference, setChartReference] = React.useState<
-        ChartComponent<ChartComponentProps>
-    >();
+
+    const chartJSRef = React.useRef<ChartComponent<ChartComponentProps>>(null);
 
     // making sure legend color updated for bar/horiz bar/bubble charts
     React.useEffect(() => {
-        if (chartReference) {
-            const chart = chartReference.chartInstance;
+        if (chartJSRef.current) {
+            const chart = chartJSRef.current.chartInstance;
             chart.update();
         }
-    }, [values.coloredSeries, chartReference]);
+    }, [values.coloredSeries]);
 
     const {
         statementResultData,
@@ -941,7 +940,7 @@ const DataDocChartComposerComponent: React.FunctionComponent<
                 data={chartData}
                 meta={formValsToMeta(values, meta)}
                 chartJSOptions={{ maintainAspectRatio: false }}
-                setChartReference={setChartReference}
+                chartJSRef={chartJSRef}
             />
         );
 

--- a/querybook/webapp/lib/chart/chart-data-processing.ts
+++ b/querybook/webapp/lib/chart/chart-data-processing.ts
@@ -56,7 +56,6 @@ export function processChartJSData(
             coloredSeries[seriesIdx] = chartMeta.y_axis.series[seriesIdx].color;
         }
     }
-    console.log('coloredSeries', coloredSeries);
 
     const useXYDataPoint =
         xAxesScaleType === 'linear' ||

--- a/querybook/webapp/lib/chart/chart-data-processing.ts
+++ b/querybook/webapp/lib/chart/chart-data-processing.ts
@@ -56,6 +56,7 @@ export function processChartJSData(
             coloredSeries[seriesIdx] = chartMeta.y_axis.series[seriesIdx].color;
         }
     }
+    console.log('coloredSeries', coloredSeries);
 
     const useXYDataPoint =
         xAxesScaleType === 'linear' ||


### PR DESCRIPTION
since `chartData` should be the data used for both the bar color & legend, we can assume that it's being updated correctly. according to what i've read updating the legend requires an `update` but i guess the color change doesn't necessarily need one for bar/horiz bar/bubble charts. (+ also found the legend doesn't update for bubble charts)