### PR TITLE
fix: Force content in container to take full width

### DIFF
--- a/querybook/webapp/components/DataTableView/DataTableView.scss
+++ b/querybook/webapp/components/DataTableView/DataTableView.scss
@@ -1,6 +1,4 @@
 .DataTableView {
-    height: 100%;
-
     .DataTableView-tabs {
         z-index: 10;
         position: sticky;

--- a/querybook/webapp/components/DataTableView/DataTableView.tsx
+++ b/querybook/webapp/components/DataTableView/DataTableView.tsx
@@ -332,9 +332,7 @@ class DataTableViewComponent extends React.PureComponent<
                     onSelect={this.onTabSelected}
                     className="DataTableView-tabs"
                 />
-                <div className="DataTableView-content">
-                    <Container>{contentDOM}</Container>
-                </div>
+                <div className="DataTableView-content">{contentDOM}</div>
             </Container>
         );
     }

--- a/querybook/webapp/ui/Container/Container.scss
+++ b/querybook/webapp/ui/Container/Container.scss
@@ -1,6 +1,9 @@
 .Container {
+    display: flex;
+    justify-content: center;
+
     .Container-content {
         max-width: var(--max-width);
-        margin: 0 auto;
+        flex: 1;
     }
 }


### PR DESCRIPTION
- use flex to center children
- use flex:1 for children so they would take the whole max width
- remain container inside container