### PR TITLE
ui: update pagination

### DIFF
--- a/querybook/webapp/__tests__/ui/__snapshots__/Pagination.test.js.snap
+++ b/querybook/webapp/__tests__/ui/__snapshots__/Pagination.test.js.snap
@@ -2,28 +2,36 @@
 
 exports[`matches enzyme snapshots matches snapshot 1`] = `
 <nav
-  className="Pagination horizontal-space-between flex-row"
+  className="Pagination"
 >
-  <Button
+  <div
     className="Pagination-previous"
-    color="default"
-    disabled={false}
-    key="previous"
-    onClick={[Function]}
-    size="medium"
-    theme="outline"
-    title="Previous"
-  />
-  <Button
+    key="previous-div"
+  >
+    <Button
+      className=""
+      color="default"
+      key="previous"
+      onClick={[Function]}
+      size="medium"
+      theme="outline"
+      title="Previous"
+    />
+  </div>
+  <div
     className="Pagination-next"
-    color="default"
-    disabled={false}
-    key="next"
-    onClick={[Function]}
-    size="medium"
-    theme="outline"
-    title="Next"
-  />
+    key="next-div"
+  >
+    <Button
+      className=""
+      color="default"
+      key="next"
+      onClick={[Function]}
+      size="medium"
+      theme="outline"
+      title="Next"
+    />
+  </div>
   <ul
     className="Pagination-pages flex-row"
   >
@@ -76,30 +84,36 @@ exports[`matches enzyme snapshots matches snapshot 1`] = `
 
 exports[`matches test renderer snapshot serializes the styles 1`] = `
 <nav
-  className="Pagination horizontal-space-between flex-row"
+  className="Pagination"
 >
-  <span
-    className="StyledButton-aqwbwz-0 eZYUp Button Pagination-previous"
-    color="var(--text-color)"
-    disabled={false}
-    onClick={[Function]}
-    size="medium"
+  <div
+    className="Pagination-previous"
   >
-    <span>
-      Previous
+    <span
+      className="StyledButton-aqwbwz-0 eZYUp Button"
+      color="var(--text-color)"
+      onClick={[Function]}
+      size="medium"
+    >
+      <span>
+        Previous
+      </span>
     </span>
-  </span>
-  <span
-    className="StyledButton-aqwbwz-0 eZYUp Button Pagination-next"
-    color="var(--text-color)"
-    disabled={false}
-    onClick={[Function]}
-    size="medium"
+  </div>
+  <div
+    className="Pagination-next"
   >
-    <span>
-      Next
+    <span
+      className="StyledButton-aqwbwz-0 eZYUp Button"
+      color="var(--text-color)"
+      onClick={[Function]}
+      size="medium"
+    >
+      <span>
+        Next
+      </span>
     </span>
-  </span>
+  </div>
   <ul
     className="Pagination-pages flex-row"
   >

--- a/querybook/webapp/__tests__/ui/__snapshots__/Pagination.test.js.snap
+++ b/querybook/webapp/__tests__/ui/__snapshots__/Pagination.test.js.snap
@@ -11,7 +11,6 @@ exports[`matches enzyme snapshots matches snapshot 1`] = `
     <Button
       className=""
       color="default"
-      key="previous"
       onClick={[Function]}
       size="medium"
       theme="outline"
@@ -25,7 +24,6 @@ exports[`matches enzyme snapshots matches snapshot 1`] = `
     <Button
       className=""
       color="default"
-      key="next"
       onClick={[Function]}
       size="medium"
       theme="outline"
@@ -33,7 +31,7 @@ exports[`matches enzyme snapshots matches snapshot 1`] = `
     />
   </div>
   <ul
-    className="Pagination-pages flex-row"
+    className="Pagination-pages flex-center"
   >
     <PageButton
       className=""
@@ -115,7 +113,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
     </span>
   </div>
   <ul
-    className="Pagination-pages flex-row"
+    className="Pagination-pages flex-center"
   >
     <li>
       <span

--- a/querybook/webapp/redux/search/types.ts
+++ b/querybook/webapp/redux/search/types.ts
@@ -3,7 +3,7 @@ import { ThunkAction } from 'redux-thunk';
 import { IStoreState } from '../store/types';
 import { ICancelablePromise } from 'lib/datasource';
 
-export const RESULT_PER_PAGE = 20;
+export const RESULT_PER_PAGE = 1;
 export enum SearchOrder {
     Recency = 'Recency',
     Relevance = 'Relevance',

--- a/querybook/webapp/ui/Pagination/Pagination.scss
+++ b/querybook/webapp/ui/Pagination/Pagination.scss
@@ -32,16 +32,16 @@
             .Pagination-page-button {
                 margin: 0 4px;
                 &.current {
-                    border-color: var(--border-color-select);
+                    border-color: var(--select-border-color);
                 }
                 &:hover {
-                    border-color: var(--border-color-hover);
+                    border-color: var(--hover-border-color);
                 }
             }
         }
         .Pagination-ellipsis {
-            margin: 5px;
-            color: var(--text-light);
+            margin: 4px;
+            color: var(--light-text-color);
         }
     }
 }

--- a/querybook/webapp/ui/Pagination/Pagination.scss
+++ b/querybook/webapp/ui/Pagination/Pagination.scss
@@ -25,8 +25,6 @@
 
     .Pagination-pages {
         order: 2;
-        align-items: center;
-        justify-content: center;
         > li {
             display: flex;
             .Pagination-page-button {

--- a/querybook/webapp/ui/Pagination/Pagination.scss
+++ b/querybook/webapp/ui/Pagination/Pagination.scss
@@ -1,30 +1,47 @@
 .Pagination {
-    margin: 15px 0px;
-    .Pagination-next {
-        order: 3;
-        margin-right: 0px;
+    margin: 16px 0px;
+    display: flex;
+    flex-direction: row;
+
+    .Pagination-previous,
+    .Pagination-next,
+    .Pagination-pages {
+        flex: 1;
+        display: flex;
     }
+
     .Pagination-previous {
         order: 1;
+        justify-content: flex-start;
         margin-left: 0px;
+        margin-right: auto;
+    }
+    .Pagination-next {
+        order: 3;
+        justify-content: flex-end;
+        margin-left: auto;
+        margin-right: 0px;
     }
 
     .Pagination-pages {
         order: 2;
+        align-items: center;
+        justify-content: center;
         > li {
             display: flex;
             .Pagination-page-button {
+                margin: 0 4px;
                 &.current {
-                    border-color: var(--select-border-color);
+                    border-color: var(--border-color-select);
                 }
                 &:hover {
-                    border-color: var(--hover-border-color);
+                    border-color: var(--border-color-hover);
                 }
             }
         }
         .Pagination-ellipsis {
             margin: 5px;
-            color: var(--light-text-color);
+            color: var(--text-light);
         }
     }
 }

--- a/querybook/webapp/ui/Pagination/Pagination.tsx
+++ b/querybook/webapp/ui/Pagination/Pagination.tsx
@@ -47,7 +47,7 @@ export const Pagination: React.FunctionComponent<IPaginationProps> = ({
     padding = 2, // number of page on the left and right of current page
     hideNavButton = false,
 }) => {
-    const paginationListDOM: React.ReactElement[] = [];
+    const paginationListDOM: React.ReactNode[] = [];
 
     const pageRanges: number[] = [];
     for (
@@ -108,7 +108,6 @@ export const Pagination: React.FunctionComponent<IPaginationProps> = ({
         <div key="previous-div" className="Pagination-previous">
             {isFirstPage ? null : (
                 <Button
-                    key="previous"
                     title="Previous"
                     onClick={onPageClick.bind(null, currentPage - 1)}
                 />
@@ -120,7 +119,6 @@ export const Pagination: React.FunctionComponent<IPaginationProps> = ({
         <div key="next-div" className="Pagination-next">
             {isLastPage || totalPage === 0 ? null : (
                 <Button
-                    key="next"
                     title="Next"
                     onClick={onPageClick.bind(null, currentPage + 1)}
                 />

--- a/querybook/webapp/ui/Pagination/Pagination.tsx
+++ b/querybook/webapp/ui/Pagination/Pagination.tsx
@@ -136,7 +136,9 @@ export const Pagination: React.FunctionComponent<IPaginationProps> = ({
             })}
         >
             {navButtons}
-            <ul className="Pagination-pages flex-row">{paginationListDOM}</ul>
+            <ul className="Pagination-pages flex-center">
+                {paginationListDOM}
+            </ul>
         </nav>
     );
 };

--- a/querybook/webapp/ui/Pagination/Pagination.tsx
+++ b/querybook/webapp/ui/Pagination/Pagination.tsx
@@ -47,9 +47,9 @@ export const Pagination: React.FunctionComponent<IPaginationProps> = ({
     padding = 2, // number of page on the left and right of current page
     hideNavButton = false,
 }) => {
-    const paginationListDOM = [];
+    const paginationListDOM: React.ReactElement[] = [];
 
-    const pageRanges = [];
+    const pageRanges: number[] = [];
     for (
         let i = Math.max(currentPage - padding, 0);
         i >= 0 && i < Math.min(totalPage, currentPage + padding + 1);
@@ -62,11 +62,13 @@ export const Pagination: React.FunctionComponent<IPaginationProps> = ({
         paginationListDOM.push(
             <PageButton page={0} key={0} onClick={onPageClick} shift={shift} />
         );
-        paginationListDOM.push(
-            <li key={'first'}>
-                <span className="Pagination-ellipsis">&hellip;</span>
-            </li>
-        );
+        if (pageRanges[0] > 1) {
+            paginationListDOM.push(
+                <li key="first">
+                    <span className="Pagination-ellipsis">&hellip;</span>
+                </li>
+            );
+        }
     }
 
     pageRanges.forEach((page) => {
@@ -82,11 +84,13 @@ export const Pagination: React.FunctionComponent<IPaginationProps> = ({
     });
 
     if (pageRanges[pageRanges.length - 1] < totalPage - 1) {
-        paginationListDOM.push(
-            <li key={'last'}>
-                <span className="Pagination-ellipsis">&hellip;</span>
-            </li>
-        );
+        if (pageRanges[pageRanges.length - 1] < totalPage - 2) {
+            paginationListDOM.push(
+                <li key="last">
+                    <span className="Pagination-ellipsis">&hellip;</span>
+                </li>
+            );
+        }
         paginationListDOM.push(
             <PageButton
                 key={totalPage - 1}
@@ -101,27 +105,27 @@ export const Pagination: React.FunctionComponent<IPaginationProps> = ({
     const isLastPage = currentPage === totalPage - 1;
 
     const previousButton = (
-        <Button
-            key="previous"
-            title="Previous"
-            className="Pagination-previous"
-            onClick={
-                isFirstPage ? null : onPageClick.bind(null, currentPage - 1)
-            }
-            disabled={isFirstPage}
-        />
+        <div key="previous-div" className="Pagination-previous">
+            {isFirstPage ? null : (
+                <Button
+                    key="previous"
+                    title="Previous"
+                    onClick={onPageClick.bind(null, currentPage - 1)}
+                />
+            )}
+        </div>
     );
 
     const nextButton = (
-        <Button
-            key="next"
-            title="Next"
-            className="Pagination-next"
-            onClick={
-                isLastPage ? null : onPageClick.bind(null, currentPage + 1)
-            }
-            disabled={isLastPage}
-        />
+        <div key="next-div" className="Pagination-next">
+            {isLastPage || totalPage === 0 ? null : (
+                <Button
+                    key="next"
+                    title="Next"
+                    onClick={onPageClick.bind(null, currentPage + 1)}
+                />
+            )}
+        </div>
     );
 
     const navButtons = !hideNavButton ? [previousButton, nextButton] : null;
@@ -130,8 +134,6 @@ export const Pagination: React.FunctionComponent<IPaginationProps> = ({
         <nav
             className={clsx({
                 Pagination: true,
-                'horizontal-space-between': true,
-                'flex-row': true,
                 [className]: Boolean(className),
             })}
         >


### PR DESCRIPTION
make it so that the next/prev buttons are only shown when applicable
make ellipses only appear when applicable

![Screen Shot 2021-04-22 at 4 24 03 PM](https://user-images.githubusercontent.com/29313935/115796808-55c7c500-a387-11eb-8ebc-0508598add05.png)
![Screen Shot 2021-04-22 at 4 24 11 PM](https://user-images.githubusercontent.com/29313935/115796806-55c7c500-a387-11eb-82f7-b904421e20d7.png)
![Screen Shot 2021-04-22 at 4 24 15 PM](https://user-images.githubusercontent.com/29313935/115796801-552f2e80-a387-11eb-8374-f7017e03eca2.png)

![Screen Shot 2021-04-22 at 4 26 49 PM](https://user-images.githubusercontent.com/29313935/115796936-8f003500-a387-11eb-816c-c1dc3cb0c29a.png)
