### PR TITLE
fix: Improve socketio error handling behaivor

### DIFF
--- a/querybook/server/const/data_doc.py
+++ b/querybook/server/const/data_doc.py
@@ -6,3 +6,6 @@ class DataCellType(Enum):
     query = 0
     text = 1
     chart = 2
+
+
+DATA_DOC_NAMESPACE = "/datadoc"

--- a/querybook/server/datasources_socketio/__init__.py
+++ b/querybook/server/datasources_socketio/__init__.py
@@ -1,5 +1,7 @@
 from . import query_execution
 from . import datadoc
+from . import connect
 
+connect
 query_execution
 datadoc

--- a/querybook/server/datasources_socketio/connect.py
+++ b/querybook/server/datasources_socketio/connect.py
@@ -1,0 +1,15 @@
+from flask_login import current_user
+from flask_socketio import ConnectionRefusedError
+
+from app.flask_app import socketio
+from const.data_doc import DATA_DOC_NAMESPACE
+from const.query_execution import QUERY_EXECUTION_NAMESPACE
+
+
+def connect():
+    if not current_user.is_authenticated:
+        raise ConnectionRefusedError("User is not logged in, please refresh the page.")
+
+
+socketio.on("connect", namespace=DATA_DOC_NAMESPACE)(connect)
+socketio.on("connect", namespace=QUERY_EXECUTION_NAMESPACE)(connect)

--- a/querybook/server/datasources_socketio/datadoc.py
+++ b/querybook/server/datasources_socketio/datadoc.py
@@ -7,16 +7,13 @@ from flask_socketio import join_room, leave_room, rooms
 
 from app.auth.permission import verify_environment_permission
 from app.flask_app import socketio
-from app.datasource import register_socket
 from app.db import DBSession
 from clients.redis_client import with_redis
-
+from const.data_doc import DATA_DOC_NAMESPACE
 from logic import datadoc as logic
 from logic import datadoc_collab
 from logic.datadoc_permission import assert_can_read
-
-
-DATA_DOC_NAMESPACE = datadoc_collab.DATA_DOC_NAMESPACE
+from .helper import register_socket
 
 
 def to_string(s):
@@ -119,8 +116,7 @@ def update_user_list(data_doc_id, add=False, redis_conn=None):
 
 @with_redis
 def update_user_cursor(data_doc_id, data_cell_id=None, redis_conn=None):
-    """Update the user cursor in redis
-    """
+    """Update the user cursor in redis"""
     key = f"data_doc/{data_doc_id}/cursors"
     if data_cell_id is not None:
         redis_conn.hset(key, request.sid, data_cell_id)
@@ -130,9 +126,9 @@ def update_user_cursor(data_doc_id, data_cell_id=None, redis_conn=None):
 
 def data_doc_socket(fn):
     """
-        If it is a data_doc_socket,
-        The first argument must be the doc Id.
-        It will then refresh the user's session.
+    If it is a data_doc_socket,
+    The first argument must be the doc Id.
+    It will then refresh the user's session.
     """
 
     @functools.wraps(fn)

--- a/querybook/server/datasources_socketio/helper.py
+++ b/querybook/server/datasources_socketio/helper.py
@@ -1,0 +1,36 @@
+import functools
+import flask
+from flask_login import current_user
+from flask_socketio import disconnect
+
+from app.flask_app import socketio
+from lib.logger import get_logger
+
+LOG = get_logger(__file__)
+
+
+def register_socket(url, namespace=None):
+    def wrapper(fn):
+        @socketio.on(url, namespace=namespace)
+        @functools.wraps(fn)
+        def handler(*args, **kwargs):
+            if not current_user.is_authenticated:
+                LOG.error("Unauthorized websocket access")
+                disconnect()
+            else:
+                try:
+                    fn(*args, **kwargs)
+                except Exception as e:
+                    LOG.error(e, exc_info=True)
+                    socketio.emit(
+                        "error",
+                        str(e),
+                        namespace=namespace,
+                        broadcast=False,
+                        room=flask.request.sid,
+                    )
+
+        handler.__raw__ = fn
+        return handler
+
+    return wrapper

--- a/querybook/server/datasources_socketio/query_execution.py
+++ b/querybook/server/datasources_socketio/query_execution.py
@@ -2,12 +2,12 @@ from flask_socketio import join_room, leave_room, emit
 
 
 from app.auth.permission import verify_query_engine_permission
-from app.datasource import register_socket, api_assert
 from app.db import DBSession
 from const.query_execution import QueryExecutionStatus, QUERY_EXECUTION_NAMESPACE
 from lib.logger import get_logger
 from logic import query_execution as qe_logic
 from tasks import run_query as tasks
+from .helper import register_socket
 
 LOG = get_logger(__file__)
 
@@ -18,7 +18,7 @@ def on_join_room(query_execution_id):
         execution = qe_logic.get_query_execution_by_id(
             query_execution_id, session=session
         )
-        api_assert(execution, "Invalid execution")
+        assert execution, "Invalid execution"
         verify_query_engine_permission(execution.engine_id, session=session)
 
         execution_dict = execution.to_dict(True) if execution is not None else None

--- a/querybook/server/logic/datadoc_collab.py
+++ b/querybook/server/logic/datadoc_collab.py
@@ -4,11 +4,9 @@ from app.auth.permission import (
 )
 from app.flask_app import socketio
 from app.db import with_session
-
+from const.data_doc import DATA_DOC_NAMESPACE
 from logic import datadoc as logic
 from logic.datadoc_permission import assert_can_read, assert_can_write
-
-DATA_DOC_NAMESPACE = "/datadoc"
 
 
 @with_session

--- a/querybook/webapp/lib/socketio-manager.ts
+++ b/querybook/webapp/lib/socketio-manager.ts
@@ -1,4 +1,4 @@
-import { throttle } from 'lodash';
+import { debounce } from 'lodash';
 import toast from 'react-hot-toast';
 import { Manager } from 'socket.io-client';
 /*
@@ -19,9 +19,13 @@ function getSocketFromManager(nameSpace: string) {
     return socketIOManager.socket(nameSpace);
 }
 
-const sendToastForError = throttle((error) => {
-    toast.error(String(error));
-}, 3000);
+const sendToastForError = debounce(
+    (error) => {
+        toast.error(String(error));
+    },
+    1500,
+    { maxWait: 3000 }
+);
 
 export default {
     getSocket: async (
@@ -35,6 +39,7 @@ export default {
             // wait for connection
             await new Promise<void>((resolve) => {
                 socket.on('connect', () => {
+                    sendToastForError.cancel();
                     if (onConnection) {
                         onConnection(socket);
                     }
@@ -51,11 +56,12 @@ export default {
 
                 socket.on('disconnect', (reason: string) => {
                     if (reason === 'io server disconnect') {
-                        toast.error(
+                        sendToastForError(
                             'Websocket was disconnected due to authentication issue. Please try to refresh the page.'
                         );
+                        setTimeout(() => socket.connect(), 3000);
                     } else {
-                        toast.error(
+                        sendToastForError(
                             `Websocket was disconnected due to: ${reason}`
                         );
                     }

--- a/querybook/webapp/lib/socketio-manager.ts
+++ b/querybook/webapp/lib/socketio-manager.ts
@@ -23,7 +23,7 @@ const sendToastForError = debounce(
     (error) => {
         toast.error(String(error));
     },
-    1500,
+    2000,
     { maxWait: 3000 }
 );
 
@@ -59,7 +59,6 @@ export default {
                         sendToastForError(
                             'Websocket was disconnected due to authentication issue. Please try to refresh the page.'
                         );
-                        setTimeout(() => socket.connect(), 3000);
                     } else {
                         sendToastForError(
                             `Websocket was disconnected due to: ${reason}`


### PR DESCRIPTION
- Refactored socket io datasource code
- Require socket.io connection to be always authenticated
- Debounce the error message on disconnect event, if they are reconnected with 2 seconds, then do not show the error message to the user