### PR TITLE
ui: Add markdown table css table for content

### DIFF
--- a/querybook/webapp/ui/Content/Content.scss
+++ b/querybook/webapp/ui/Content/Content.scss
@@ -99,4 +99,18 @@
         border: var(--border);
         padding: 4px;
     }
+
+    table {
+        border-collapse: collapse;
+        th {
+            color: var(--title-color);
+            border: 1px solid var(--focus-border-color);
+            padding: 4px;
+        }
+        td {
+            color: var(--text-color);
+            border: 1px solid var(--focus-border-color);
+            padding: 4px;
+        }
+    }
 }


### PR DESCRIPTION
Example:

Light
![image](https://user-images.githubusercontent.com/8283407/117725307-cf3e2080-b199-11eb-887a-650d0faa6901.png)

Dark
![image](https://user-images.githubusercontent.com/8283407/117725286-c8171280-b199-11eb-89f8-4a774e779508.png)
