### PR TITLE
fix: simplify es connection logic

### DIFF
--- a/querybook/server/datasources/search.py
+++ b/querybook/server/datasources/search.py
@@ -92,7 +92,7 @@ def _construct_datadoc_query(
 ):
     # TODO: fields is not used because explicit search for Data Docs is not implemented
     search_query = _match_any_field(
-        keywords, search_fields=["title^5", "cells", "owner",]
+        keywords, search_fields=["title^5", "cells", "owner",],
     )
     search_filter = _match_filters(filters)
     if search_filter == {}:

--- a/querybook/server/logic/elasticsearch.py
+++ b/querybook/server/logic/elasticsearch.py
@@ -41,15 +41,10 @@ ES_CONFIG = get_config_value("elasticsearch")
 def get_hosted_es():
     hosted_es = None
 
-    if ":" in QuerybookSettings.ELASTICSEARCH_HOST:
-        host, port = QuerybookSettings.ELASTICSEARCH_HOST.split(":")
-    else:
-        host = QuerybookSettings.ELASTICSEARCH_HOST
-        port = 9200  # Default port for elasticsearch
-
     if QuerybookSettings.ELASTICSEARCH_CONNECTION_TYPE == "naive":
-        hosted_es = Elasticsearch(hosts=[host], port=port,)
+        hosted_es = Elasticsearch(hosts=QuerybookSettings.ELASTICSEARCH_HOST)
     elif QuerybookSettings.ELASTICSEARCH_CONNECTION_TYPE == "aws":
+
         # TODO: generialize aws region setup
         from boto3 import session as boto_session
         from lib.utils.assume_role_aws4auth import AssumeRoleAWS4Auth
@@ -58,7 +53,6 @@ def get_hosted_es():
         auth = AssumeRoleAWS4Auth(credentials, "us-east-1", "es",)
         hosted_es = Elasticsearch(
             hosts=QuerybookSettings.ELASTICSEARCH_HOST,
-            port=443,
             http_auth=auth,
             connection_class=RequestsHttpConnection,
             use_ssl=True,


### PR DESCRIPTION
Remove parsing of host and port since the python elasticsearch library also does parsing. With the parsing removed, users can specified more details in the connection string such as https and username/password

Now users can connect to https traffic via naive connection type. 