### PR TITLE
feat: add aws glue data catalog as a metastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Can be used to fetch schema and table information for metadata enrichment.
 
 -   Hive Metastore
 -   Sqlalchemy Inspect
+-   AWS Glue Data Catalog
 
 ### Result Storage
 

--- a/querybook/server/clients/glue_client.py
+++ b/querybook/server/clients/glue_client.py
@@ -40,7 +40,7 @@ class GlueDataCatalogClient:
         databases = self.get_all_databases()
         database_list = databases.get("DatabaseList")
 
-        result = list(map(lambda database: database.get("Name"), database_list))
+        result = [database.get("Name") for database in database_list]
 
         return result
 
@@ -71,7 +71,7 @@ class GlueDataCatalogClient:
         tables = self.get_all_tables(db_name)
         table_list = tables.get("TableList")
 
-        result = list(map(lambda table: table.get("Name"), table_list))
+        result = [table.get("Name") for table in table_list]
 
         return result
 
@@ -87,8 +87,6 @@ class GlueDataCatalogClient:
             CatalogId=self.catalog_id, DatabaseName=db_name, Name=tb_name
         )
 
-    # todo: Find a better way, this takes too long...!
-    # maybe: https://github.com/boto/botocore/issues/1246#issuecomment-696638421
     def get_partitions(self, db_name, tb_name):
         """
         Gets partition information for db_name.tb_name from the Glue Data Catalog
@@ -125,15 +123,13 @@ class GlueDataCatalogClient:
 
         table = self.get_table(db_name, tb_name)
         partition_keys = table.get("Table").get("PartitionKeys")
-        partition_key_names = list(
-            map(lambda partition_key: partition_key.get("Name"), partition_keys)
-        )
+        partition_key_names = [
+            partition_key.get("Name") for partition_key in partition_keys
+        ]
 
         partitions = self.get_partitions(db_name, tb_name)
         partition_list = partitions.get("Partitions")
-        partition_values = list(
-            map(lambda partition: partition.get("Values"), partition_list)
-        )
+        partition_values = [partition.get("Values") for partition in partition_list]
 
         result = []
 

--- a/querybook/server/clients/glue_client.py
+++ b/querybook/server/clients/glue_client.py
@@ -1,0 +1,150 @@
+from typing import List
+
+import boto3
+from lib.logger import get_logger
+
+_LOG = get_logger(__file__)
+
+
+class GlueDataCatalogClient:
+    def __init__(self, catalog_id, region="us-east-1"):
+        self.catalog_id = catalog_id
+        self._glue_client = boto3.client("glue", region_name=region)
+
+    def __del__(self):
+        del self._glue_client
+
+    def get_all_databases(self):
+        """
+        :return: The objects for all the Glue databases
+        """
+        _LOG.info("Get all databases")
+
+        paginator = self._glue_client.get_paginator("get_databases")
+        result = {}
+        database_list = []
+
+        for page in paginator.paginate(CatalogId=self.catalog_id):
+            database_list.extend(page.get("DatabaseList"))
+
+        result["DatabaseList"] = database_list
+
+        return result
+
+    def get_all_database_names(self):
+        """
+        :return: The names of all the Glue databases
+        """
+        _LOG.info("Extracting all databases names")
+
+        databases = self.get_all_databases()
+        database_list = databases.get("DatabaseList")
+
+        result = list(map(lambda database: database.get("Name"), database_list))
+
+        return result
+
+    def get_all_tables(self, db_name):
+        """
+        :param db_name: The nam of the database
+        :return: The Glue table objects for all the Glue tables of db_name
+        """
+        _LOG.info(f"Get all Glue tables for the database ${db_name}")
+        paginator = self._glue_client.get_paginator("get_tables")
+        table_list = []
+        result = {}
+
+        for page in paginator.paginate(CatalogId=self.catalog_id, DatabaseName=db_name):
+            table_list.extend(page.get("TableList"))
+
+        result["TableList"] = table_list
+
+        return result
+
+    def get_all_table_names(self, db_name):
+        """
+        :param db_name: The name of the database
+        :return: The names for all the Glue tables
+        """
+        _LOG.info(f"Get tables names ${db_name}")
+
+        tables = self.get_all_tables(db_name)
+        table_list = tables.get("TableList")
+
+        result = list(map(lambda table: table.get("Name"), table_list))
+
+        return result
+
+    def get_table(self, db_name, tb_name):
+        """
+        :param db_name: The name of the database
+        :param tb_name: The name of the table
+        :return: The Glue table object of db_name.tb_name
+        """
+        _LOG.info(f"Get Glue table information for for ${db_name}.${tb_name}")
+
+        return self._glue_client.get_table(
+            CatalogId=self.catalog_id, DatabaseName=db_name, Name=tb_name
+        )
+
+    # todo: Find a better way, this takes too long...!
+    # maybe: https://github.com/boto/botocore/issues/1246#issuecomment-696638421
+    def get_partitions(self, db_name, tb_name):
+        """
+        Gets partition information for db_name.tb_name from the Glue Data Catalog
+
+        :param db_name: The name of the database
+        :param tb_name: Then name of the table
+        :return: The Glue partition objects of db_name.tb_name
+        """
+        _LOG.info(f"Get Glue partitions for ${db_name}.${tb_name}")
+
+        paginator = self._glue_client.get_paginator("get_partitions")
+        partition_list = []
+        result = {}
+
+        for page in paginator.paginate(
+            CatalogId=self.catalog_id, DatabaseName=db_name, TableName=tb_name
+        ):
+            partition_list.extend(page.get("Partitions", []))
+
+        result["Partitions"] = partition_list
+
+        return result
+
+    def get_hms_style_partitions(self, db_name, tb_name) -> List[str]:
+        """
+        Gets partitiion information for db_name.tb_name from Glue Data Catalog and converts into a
+        Hive Metastore style representation
+
+        :param db_name: The name of the database
+        :param tb_name: The name of the table
+        :return: The partitions of db_name.tb_name in the format ['dt=2016-03-14/hr=00', 'dt=2016-03-14/hr=01', ...]
+        """
+        _LOG.info(f"Get hms style partitions for ${db_name}.${tb_name}")
+
+        table = self.get_table(db_name, tb_name)
+        partition_keys = table.get("Table").get("PartitionKeys")
+        partition_key_names = list(
+            map(lambda partition_key: partition_key.get("Name"), partition_keys)
+        )
+
+        partitions = self.get_partitions(db_name, tb_name)
+        partition_list = partitions.get("Partitions")
+        partition_values = list(
+            map(lambda partition: partition.get("Values"), partition_list)
+        )
+
+        result = []
+
+        for partition_value in partition_values:
+            result.append(
+                "/".join(
+                    [
+                        key_name + "=" + value
+                        for key_name, value in zip(partition_key_names, partition_value)
+                    ]
+                )
+            )
+
+        return result

--- a/querybook/server/lib/metastore/loaders/__init__.py
+++ b/querybook/server/lib/metastore/loaders/__init__.py
@@ -3,6 +3,7 @@ from .hive_metastore_loader import HMSMetastoreLoader
 from .mysql_metastore_loader import MysqlMetastoreLoader
 from .thrifthive_metastore_loader import HMSThriftMetastoreLoader
 from .sqlalchemy_metastore_loader import SqlAlchemyMetastoreLoader
+from .glue_data_catalog_loader import GlueDataCatalogLoader
 
 ALL_PLUGIN_METASTORE_LOADERS = import_plugin(
     "metastore_plugin", "ALL_PLUGIN_METASTORE_LOADERS", []
@@ -14,4 +15,5 @@ ALL_METASTORE_LOADERS = [
     MysqlMetastoreLoader,
     HMSThriftMetastoreLoader,
     SqlAlchemyMetastoreLoader,
+    GlueDataCatalogLoader,
 ] + ALL_PLUGIN_METASTORE_LOADERS

--- a/querybook/server/lib/metastore/loaders/glue_data_catalog_loader.py
+++ b/querybook/server/lib/metastore/loaders/glue_data_catalog_loader.py
@@ -1,0 +1,101 @@
+from datetime import datetime
+from typing import Dict, List, Tuple
+
+from clients.glue_client import GlueDataCatalogClient
+from lib.form import StructFormField, FormField
+from lib.metastore.base_metastore_loader import (
+    BaseMetastoreLoader,
+    DataTable,
+    DataColumn,
+)
+
+
+class GlueDataCatalogLoader(BaseMetastoreLoader):
+    def __init__(self, metastore_dict: Dict):
+        self.catalog_id = metastore_dict.get("metastore_params").get("catalog_id")
+        self.region = metastore_dict.get("metastore_params").get("region")
+        self.load_partitions = eval(
+            metastore_dict.get("metastore_params").get("load_partitions", "False")
+        )
+        self.glue_client = self._get_glue_data_catalog_client(
+            self.catalog_id, self.region
+        )
+        super(GlueDataCatalogLoader, self).__init__(metastore_dict)
+
+    @classmethod
+    def get_metastore_params_template(cls):
+        return StructFormField(
+            catalog_id=FormField(
+                required=True,
+                description="Enter the Glue Data Catalog ID",
+                regex=r"^\d{12}$",
+            ),
+            region=FormField(required=True, description="Enter the AWS Region"),
+            load_partitions=FormField(
+                required=False,
+                description="Enter True or False",
+                regex=r"(True|False)",
+                helper="""In case your data catalog is large, loading all partitions for all tables can be quite time consuming.
+                Skipping partition information can reduce your metastore refresh latency
+                """,
+            ),
+        )
+
+    def get_all_schema_names(self) -> List[str]:
+        return self.glue_client.get_all_database_names()
+
+    def get_all_table_names_in_schema(self, schema_name: str) -> List[str]:
+        return self.glue_client.get_all_table_names(schema_name)
+
+    def get_table_and_columns(
+        self, schema_name: str, table_name: str
+    ) -> Tuple[DataTable, List[DataColumn]]:
+        glue_table = self.glue_client.get_table(schema_name, table_name).get("Table")
+
+        if self.load_partitions:
+            partitions = self.glue_client.get_hms_style_partitions(
+                schema_name, table_name
+            )
+        else:
+            partitions = []
+
+        table = DataTable(
+            name=glue_table.get("Name"),
+            type=glue_table.get("TableType"),
+            owner=glue_table.get("Owner"),
+            table_created_at=int(
+                glue_table.get("CreateTime", datetime(1970, 1, 1)).timestamp()
+            ),
+            table_updated_at=int(
+                glue_table.get("UpdateTime", datetime(1970, 1, 1)).timestamp()
+            ),
+            location=glue_table.get("StorageDescriptor").get("Location"),
+            partitions=partitions,
+            raw_description=glue_table.get("Description"),
+        )
+
+        columns = list(
+            map(
+                lambda col: DataColumn(
+                    col.get("Name"), col.get("Type"), col.get("Comment")
+                ),
+                glue_table.get("StorageDescriptor").get("Columns"),
+            )
+        )
+
+        columns.extend(
+            list(
+                map(
+                    lambda col: DataColumn(
+                        col.get("Name"), col.get("Type"), col.get("Comment")
+                    ),
+                    glue_table.get("PartitionKeys"),
+                )
+            )
+        )
+
+        return table, columns
+
+    @staticmethod
+    def _get_glue_data_catalog_client(catalog_id, region):
+        return GlueDataCatalogClient(catalog_id, region)

--- a/querybook/server/lib/metastore/loaders/glue_data_catalog_loader.py
+++ b/querybook/server/lib/metastore/loaders/glue_data_catalog_loader.py
@@ -33,7 +33,6 @@ class GlueDataCatalogLoader(BaseMetastoreLoader):
             region=FormField(required=True, description="Enter the AWS Region"),
             load_partitions=FormField(
                 required=False,
-                description="Enter True or False",
                 field_type=FormFieldType.Boolean,
                 helper="""In case your data catalog is large, loading all partitions for all tables can be quite time consuming.
                 Skipping partition information can reduce your metastore refresh latency

--- a/querybook/tests/test_lib/test_metastore/test_loaders/test_glue_data_catalog_loader.py
+++ b/querybook/tests/test_lib/test_metastore/test_loaders/test_glue_data_catalog_loader.py
@@ -1,0 +1,195 @@
+import unittest
+from unittest import TestCase
+
+import boto3
+from datetime import datetime
+
+from lib.metastore.loaders.glue_data_catalog_loader import GlueDataCatalogLoader
+from lib.metastore.base_metastore_loader import DataColumn, DataTable
+
+try:
+    from moto import mock_glue
+except ImportError:
+    mock_glue = None
+
+METASTORE_DICT = {
+    "id": 1,
+    "name": "Test Glue Metastore",
+    "loader": "GlueDataCatalogLoader",
+    "metastore_params": {
+        "catalog_id": "758373708967",
+        "region": "us-east-1",
+        "load_partitions": "True",
+    },
+    "acl_control": {},
+}
+
+# First database with one tables
+DB_NAME_A = "db_a"
+TABLE_NAME_A_1 = "table_a_1"
+TABLE_INPUT_A_1 = {
+    "Name": TABLE_NAME_A_1,
+    "Description": "test description",
+    "Owner": "test owner",
+    "TableType": "EXTERNAL_TABLE",
+    "StorageDescriptor": {
+        "Columns": [
+            {"Name": "col_a", "Type": "string", "Comment": "string"},
+            {"Name": "col_b", "Type": "string", "Comment": "string"},
+            {"Name": "col_c", "Type": "string"},
+        ],
+        "Location": f"s3://mybucket/{DB_NAME_A}/{TABLE_NAME_A_1}",
+    },
+    "PartitionKeys": [
+        {"Name": "partition_date", "Type": "string",},
+        {"Name": "partition_hour", "Type": "string"},
+    ],
+}
+PARTITION_INPUT_A_1 = {"Values": ["2021-01-01", "15"]}
+PARTITION_INPUT_A_2 = {"Values": ["2021-03-03", "20"]}
+
+# Second database with three tables
+DB_NAME_B = "db_b"
+TABLE_NAME_B_1 = "table_b_1"
+TABLE_INPUT_B_1 = {
+    "Name": TABLE_NAME_B_1,
+    "StorageDescriptor": {
+        "Columns": [
+            {"Name": "col_a", "Type": "string", "Comment": "string"},
+            {"Name": "col_b", "Type": "string", "Comment": "string"},
+            {"Name": "col_c", "Type": "string"},
+        ],
+        "Location": f"s3://mybucket/{DB_NAME_B}/{TABLE_NAME_B_1}",
+    },
+    "PartitionKeys": [
+        {"Name": "partition_date", "Type": "string",},
+        {"Name": "partition_hour", "Type": "string"},
+    ],
+}
+TABLE_NAME_B_2 = "table_b_2"
+TABLE_INPUT_B_2 = {
+    "Name": TABLE_NAME_B_2,
+    "StorageDescriptor": {
+        "Columns": [
+            {"Name": "col_a", "Type": "string", "Comment": "string"},
+            {"Name": "col_b", "Type": "string", "Comment": "string"},
+            {"Name": "col_c", "Type": "string"},
+        ],
+        "Location": f"s3://mybucket/{DB_NAME_B}/{TABLE_NAME_B_2}",
+    },
+    "PartitionKeys": [
+        {"Name": "partition_date", "Type": "string",},
+        {"Name": "partition_hour", "Type": "string"},
+    ],
+}
+TABLE_NAME_B_3 = "table_b_3"
+TABLE_INPUT_B_3 = {
+    "Name": TABLE_NAME_B_3,
+    "StorageDescriptor": {
+        "Columns": [
+            {"Name": "col_a", "Type": "string", "Comment": "string"},
+            {"Name": "col_b", "Type": "string", "Comment": "string"},
+            {"Name": "col_c", "Type": "string"},
+        ],
+        "Location": f"s3://mybucket/{DB_NAME_B}/{TABLE_NAME_B_3}",
+    },
+    "PartitionKeys": [
+        {"Name": "partition_date", "Type": "string",},
+        {"Name": "partition_hour", "Type": "string"},
+    ],
+}
+
+
+@unittest.skipIf(
+    mock_glue is None, "Skipping test because moto.mock_glue is not available"
+)
+class GlueDataCatalogLoaderTestCase(TestCase):
+    @mock_glue
+    def setUp(self) -> None:
+        self.client = boto3.client("glue", "us-east-1")
+        self.loader = GlueDataCatalogLoader(METASTORE_DICT)
+
+    @mock_glue
+    def test_get_all_schema_names(self):
+        self.client.create_database(DatabaseInput={"Name": DB_NAME_A})
+        self.client.create_database(DatabaseInput={"Name": DB_NAME_B})
+
+        result = self.loader.get_all_schema_names()
+
+        self.assertEqual(result, [DB_NAME_A, DB_NAME_B])
+
+    @mock_glue
+    def test_get_all_table_names_in_schema(self):
+        self.client.create_database(DatabaseInput={"Name": DB_NAME_B})
+        self.client.create_table(DatabaseName=DB_NAME_B, TableInput=TABLE_INPUT_B_1)
+        self.client.create_table(DatabaseName=DB_NAME_B, TableInput=TABLE_INPUT_B_2)
+        self.client.create_table(DatabaseName=DB_NAME_B, TableInput=TABLE_INPUT_B_3)
+
+        result = self.loader.get_all_table_names_in_schema(DB_NAME_B)
+
+        self.assertEqual(result, [TABLE_NAME_B_1, TABLE_NAME_B_2, TABLE_NAME_B_3])
+
+    @mock_glue
+    def test_get_table_and_columns(self):
+        self.client.create_database(DatabaseInput={"Name": DB_NAME_A})
+        self.client.create_table(DatabaseName=DB_NAME_A, TableInput=TABLE_INPUT_A_1)
+        self.client.create_partition(
+            DatabaseName=DB_NAME_A,
+            TableName=TABLE_NAME_A_1,
+            PartitionInput=PARTITION_INPUT_A_1,
+        )
+        self.client.create_partition(
+            DatabaseName=DB_NAME_A,
+            TableName=TABLE_NAME_A_1,
+            PartitionInput=PARTITION_INPUT_A_2,
+        )
+
+        table = DataTable(
+            name=TABLE_NAME_A_1,
+            type=TABLE_INPUT_A_1.get("TableType"),
+            owner=TABLE_INPUT_A_1.get("Owner"),
+            table_created_at=int(datetime(1970, 1, 1).timestamp()),
+            table_updated_at=int(datetime(1970, 1, 1).timestamp()),
+            location=f"s3://mybucket/{DB_NAME_A}/{TABLE_NAME_A_1}",
+            partitions=[
+                "partition_date=2021-01-01/partition_hour=15",
+                "partition_date=2021-03-03/partition_hour=20",
+            ],
+            raw_description=TABLE_INPUT_A_1.get("Description"),
+        )
+
+        columns = [
+            DataColumn(
+                TABLE_INPUT_A_1.get("StorageDescriptor").get("Columns")[0].get("Name"),
+                TABLE_INPUT_A_1.get("StorageDescriptor").get("Columns")[0].get("Type"),
+                TABLE_INPUT_A_1.get("StorageDescriptor")
+                .get("Columns")[0]
+                .get("Comment"),
+            ),
+            DataColumn(
+                TABLE_INPUT_A_1.get("StorageDescriptor").get("Columns")[1].get("Name"),
+                TABLE_INPUT_A_1.get("StorageDescriptor").get("Columns")[1].get("Type"),
+                TABLE_INPUT_A_1.get("StorageDescriptor")
+                .get("Columns")[1]
+                .get("Comment"),
+            ),
+            DataColumn(
+                TABLE_INPUT_A_1.get("StorageDescriptor").get("Columns")[2].get("Name"),
+                TABLE_INPUT_A_1.get("StorageDescriptor").get("Columns")[2].get("Type"),
+            ),
+            DataColumn(
+                TABLE_INPUT_A_1.get("PartitionKeys")[0].get("Name"),
+                TABLE_INPUT_A_1.get("PartitionKeys")[0].get("Type"),
+            ),
+            DataColumn(
+                TABLE_INPUT_A_1.get("PartitionKeys")[1].get("Name"),
+                TABLE_INPUT_A_1.get("PartitionKeys")[1].get("Type"),
+            ),
+        ]
+
+        result_table, result_columns = self.loader.get_table_and_columns(
+            DB_NAME_A, TABLE_NAME_A_1
+        )
+
+        self.assertEqual(result_table, table)
+        self.assertEqual(result_columns, columns)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -60,6 +60,7 @@ snowflake-sqlalchemy==1.2.4
 requests-aws4auth==0.9
 boto3==1.9.16
 boto==2.49.0
+moto==2.0.7
 
 # Google GCD
 google-cloud-storage==1.37.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -58,7 +58,7 @@ snowflake-sqlalchemy==1.2.4
 # Query Store
 # AWS Support
 requests-aws4auth==0.9
-boto3==1.9.16
+boto3==1.9.201
 boto==2.49.0
 moto==2.0.7
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,4 +5,3 @@ pytest==5.2.2
 black==19.10b0
 pre-commit==2.2.0
 coverage==5.4
-moto==2.0.7

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,3 +5,4 @@ pytest==5.2.2
 black==19.10b0
 pre-commit==2.2.0
 coverage==5.4
+moto==2.0.7


### PR DESCRIPTION
Implements the feature request proposed in #543 

### Changes
* Added an AWS Glue Data Catalog client wrapper using boto3
* Added a BaseMetastoreLoader implementation specific to the AWS Glue Data Catalog
* Added unit test for the newly implemented GlueDataCatalogLoader and used moto to mock remote AWS Glue resources

### Extras
![image](https://user-images.githubusercontent.com/9784890/118566985-44e75500-b775-11eb-8ffc-50803cd32f1e.png)

https://user-images.githubusercontent.com/9784890/118569150-a01b4680-b779-11eb-9e88-e1896a1c6337.mov