### PR TITLE
fix: set version of python-socketio to 5.2.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,6 +17,9 @@ alembic==1.4.3
 gevent-websocket==0.10.1
 flask-socketio==5.0.1
 
+# Fixing the version of python-socketio due to change in 5.3.0
+python-socketio==5.2.1
+
 # Query templating
 Jinja2==2.11.3  # From Flask
 


### PR DESCRIPTION
Looks like this PR in python-socketio 5.3.0 broken the websocket connection for Querybook
https://github.com/miguelgrinberg/python-socketio/commit/2538df8bcf0e44881a7653cc684f985252c7fce0


Stack trace:
```
web_1            | Traceback (most recent call last):
web_1            |   File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
web_1            |   File "/usr/local/lib/python3.7/site-packages/socketio/pubsub_manager.py", line 164, in _thread
web_1            |     self._handle_emit(data)
web_1            |   File "/usr/local/lib/python3.7/site-packages/socketio/pubsub_manager.py", line 116, in _handle_emit
web_1            |     callback=callback)
web_1            |   File "/usr/local/lib/python3.7/site-packages/socketio/base_manager.py", line 161, in emit
web_1            |     for sid, eio_sid in self.get_participants(namespace, room):
web_1            |   File "/usr/local/lib/python3.7/site-packages/socketio/base_manager.py", line 45, in get_participants
web_1            |     participants = ns[room[0]]._fwdm.copy() if room[0] in ns else {}
web_1            | TypeError: 'int' object is not subscriptable
web_1            | 2021-05-18T02:09:04Z <Thread at 0x7f9a4b2d4ef0: <bound method PubSubManager._thread of <socketio.redis_manager.RedisManager object at 0x7f9a5b4b0a90>>> failed with TypeError
```

Reverting to version 5.2.1 for now. Moving forward we definitely need something like poetry for python dependencies.

