### PR TITLE
feat: support progressPercentage in hive thrift response 

### DIFF
--- a/querybook/server/lib/query_executor/clients/hive.py
+++ b/querybook/server/lib/query_executor/clients/hive.py
@@ -117,8 +117,10 @@ class HiveCursor(CursorBaseClass):
 
     def _update_percent_complete(self, poll_result):
         # Hive 2.3+ includes progressUpdateResponse to provide overall % completion
-        if poll_result.progressUpdateResponse and poll_result.progressUpdateResponse.progressedPercentage:
-            percent_complete = poll_result.progressUpdateResponse.progressedPercentage
+        if getattr(poll_result, 'progressUpdateResponse', None):
+            update_resp = poll_result.progressUpdateResponse
+            percent_complete = update_resp.progressedPercentage if hasattr(update_resp, 'progressedPercentage') \
+                else 0
             self._percent_complete = round(percent_complete, 2) * 100
         else:
             # this is the fallback (in case no progressUpdateResponse is included)

--- a/querybook/server/lib/query_executor/clients/hive.py
+++ b/querybook/server/lib/query_executor/clients/hive.py
@@ -116,10 +116,13 @@ class HiveCursor(CursorBaseClass):
         return self._tracking_url
 
     def _update_percent_complete(self, poll_result):
+        # Hive 2.3+ includes progressUpdateResponse to provide overall % completion
         if poll_result.progressUpdateResponse and poll_result.progressUpdateResponse.progressedPercentage:
             percent_complete = poll_result.progressUpdateResponse.progressedPercentage
             self._percent_complete = round(percent_complete, 2) * 100
         else:
+            # this is the fallback (in case no progressUpdateResponse is included)
+            # Hive <= 1.2.1. Fallback is to check map/reduce completed tasks
             task_status = poll_result.taskStatus
             if task_status:
                 try:

--- a/querybook/server/lib/query_executor/clients/hive.py
+++ b/querybook/server/lib/query_executor/clients/hive.py
@@ -116,11 +116,14 @@ class HiveCursor(CursorBaseClass):
         return self._tracking_url
 
     def _update_percent_complete(self, poll_result):
-        # Hive 2.3+ includes progressUpdateResponse to provide overall % completion
-        if getattr(poll_result, 'progressUpdateResponse', None):
+        # Hive 2.3+ includes progressUpdateResponse to provide % completion
+        if getattr(poll_result, "progressUpdateResponse", None):
             update_resp = poll_result.progressUpdateResponse
-            percent_complete = update_resp.progressedPercentage if hasattr(update_resp, 'progressedPercentage') \
+            percent_complete = (
+                update_resp.progressedPercentage
+                if hasattr(update_resp, "progressedPercentage")
                 else 0
+            )
             self._percent_complete = round(percent_complete, 2) * 100
         else:
             # this is the fallback (in case no progressUpdateResponse is included)
@@ -143,7 +146,9 @@ class HiveCursor(CursorBaseClass):
                             )
                         )
                         # Because each stage sum is a total of 200
-                        self._percent_complete = stage_sum / (len(map_reduce_stages) * 2)
+                        self._percent_complete = stage_sum / (
+                            len(map_reduce_stages) * 2
+                        )
                 except Exception as e:
                     e  # to get rid of lint error
 

--- a/querybook/tests/test_lib/test_query_executor/test_clients/test_hive_progress_percentage.py
+++ b/querybook/tests/test_lib/test_query_executor/test_clients/test_hive_progress_percentage.py
@@ -1,14 +1,19 @@
 from unittest import TestCase
 from lib.query_executor.clients.hive import HiveCursor
-from TCLIService.ttypes import *
-import json
+from TCLIService.ttypes import (
+    TProgressUpdateResp,
+    TGetOperationStatusResp,
+    TOperationState,
+)
 
 
 class ProgressPercentageTestCase(TestCase):
     def test_progress_percentage_reported(self):
         progress_resp = TProgressUpdateResp(progressedPercentage=0.65)
-        resp = TGetOperationStatusResp(operationState=TOperationState.RUNNING_STATE,
-                                       progressUpdateResponse=progress_resp)
+        resp = TGetOperationStatusResp(
+            operationState=TOperationState.RUNNING_STATE,
+            progressUpdateResponse=progress_resp,
+        )
         hive_cursor = HiveCursor(None)
         hive_cursor._update_percent_complete(resp)
         self.assertEqual(hive_cursor._percent_complete, 65)
@@ -20,10 +25,13 @@ class ProgressPercentageTestCase(TestCase):
         self.assertEqual(hive_cursor._percent_complete, 0)
 
     def test_progress_old_hive_version(self):
-        task_status_json = '[{"taskType": "MAPRED", "mapProgress": 50, "reduceProgress": 0 }]'
-        resp = TGetOperationStatusResp(operationState=TOperationState.RUNNING_STATE,
-                                       taskStatus=task_status_json)
+        # mock status json
+        task_status_json = (
+            '[{"taskType": "MAPRED", "mapProgress": 50, "reduceProgress": 0 }]'
+        )
+        resp = TGetOperationStatusResp(
+            operationState=TOperationState.RUNNING_STATE, taskStatus=task_status_json
+        )
         hive_cursor = HiveCursor(None)
         hive_cursor._update_percent_complete(resp)
         self.assertEqual(hive_cursor._percent_complete, 25)
-

--- a/querybook/tests/test_lib/test_query_executor/test_clients/test_hive_progress_percentage.py
+++ b/querybook/tests/test_lib/test_query_executor/test_clients/test_hive_progress_percentage.py
@@ -13,6 +13,12 @@ class ProgressPercentageTestCase(TestCase):
         hive_cursor._update_percent_complete(resp)
         self.assertEqual(hive_cursor._percent_complete, 65)
 
+    def test_progress_percentage_partial_reported(self):
+        resp = TGetOperationStatusResp(operationState=TOperationState.RUNNING_STATE)
+        hive_cursor = HiveCursor(None)
+        hive_cursor._update_percent_complete(resp)
+        self.assertEqual(hive_cursor._percent_complete, 0)
+
     def test_progress_old_hive_version(self):
         task_status_json = '[{"taskType": "MAPRED", "mapProgress": 50, "reduceProgress": 0 }]'
         resp = TGetOperationStatusResp(operationState=TOperationState.RUNNING_STATE,

--- a/querybook/tests/test_lib/test_query_executor/test_hive_progress_percentage.py
+++ b/querybook/tests/test_lib/test_query_executor/test_hive_progress_percentage.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+from lib.query_executor.clients.hive import HiveCursor
+from TCLIService.ttypes import *
+import json
+
+
+class ProgressPercentageTestCase(TestCase):
+    def test_progress_percentage_reported(self):
+        progress_resp = TProgressUpdateResp(progressedPercentage=0.65)
+        resp = TGetOperationStatusResp(operationState=TOperationState.RUNNING_STATE,
+                                       progressUpdateResponse=progress_resp)
+        hive_cursor = HiveCursor(None)
+        hive_cursor._update_percent_complete(resp)
+        self.assertEqual(hive_cursor._percent_complete, 65)
+
+    def test_progress_old_hive_version(self):
+        task_status_json = '[{"taskType": "MAPRED", "mapProgress": 50, "reduceProgress": 0 }]'
+        resp = TGetOperationStatusResp(operationState=TOperationState.RUNNING_STATE,
+                                       taskStatus=task_status_json)
+        hive_cursor = HiveCursor(None)
+        hive_cursor._update_percent_complete(resp)
+        self.assertEqual(hive_cursor._percent_complete, 25)
+


### PR DESCRIPTION
Fixes pinterest/querybook#552

Just added a check if progressPercentage is reported by thrift response. If yes, Hive Client uses it to calculate percentage. It falls back on original method of calculating based on map/reduce progress. Added unit tests. 