### PR TITLE
Feat: support catalog and schema in metadata

### DIFF
--- a/querybook/server/lib/metastore/utils.py
+++ b/querybook/server/lib/metastore/utils.py
@@ -11,7 +11,7 @@ class MetastoreTableACLChecker(object):
     def process_tables(self, tables: List[str]):
         tables_by_schema = {}
         for table in tables:
-            full_name = table.split(".")
+            full_name = table.rsplit(".", 1)
             if len(full_name) == 1:
                 full_name.insert(0, "default")
 

--- a/querybook/server/lib/query_executor/executor_factory.py
+++ b/querybook/server/lib/query_executor/executor_factory.py
@@ -90,7 +90,7 @@ def _assert_safe_query(query, engine_id, session=None):
         acl_checker = MetastoreTableACLChecker(metastore.acl_control)
 
         for table in all_tables:
-            schema_name, table_name = table.split(".")
+            schema_name, table_name = table.rsplit(".", 1)
             if not acl_checker.is_table_valid(schema_name, table_name):
                 raise InvalidQueryExecution(
                     f"Table {table} is not allowed by metastore"

--- a/querybook/server/tasks/log_query_per_table.py
+++ b/querybook/server/tasks/log_query_per_table.py
@@ -100,7 +100,7 @@ def sync_table_to_metastore(
                     else:
                         # Otherwise for things like insert/select we only update
                         # if it doesn't exist in the metastore
-                        schema_name, table_name = table.split(".")
+                        schema_name, table_name = table.rsplit(".", 1)
                         query_table = m_logic.get_table_by_name(
                             schema_name,
                             table_name,
@@ -111,11 +111,11 @@ def sync_table_to_metastore(
                             tables_to_add.add(table)
 
     for table in tables_to_remove:
-        schema_name, table_name = table.split(".")
+        schema_name, table_name = table.rsplit(".", 1)
         metastore_loader.sync_delete_table(schema_name, table_name, session=session)
 
     for table in tables_to_add:
-        schema_name, table_name = table.split(".")
+        schema_name, table_name = table.rsplit(".", 1)
         metastore_loader.sync_create_or_update_table(
             schema_name, table_name, session=session
         )
@@ -140,7 +140,7 @@ def log_table_per_statement(
             all_tables.update(tables)
 
     for table in all_tables:
-        schema_name, table_name = table.split(".")
+        schema_name, table_name = table.rsplit(".", 1)
         query_table = m_logic.get_table_by_name(
             schema_name, table_name, metastore_id=metastore_id, session=session
         )

--- a/querybook/webapp/lib/sql-helper/sql-lexer.ts
+++ b/querybook/webapp/lib/sql-helper/sql-lexer.ts
@@ -287,6 +287,9 @@ function sanitizeTable(tableToken: IToken, defaultSchema: string) {
     } else if (parts.length === 2) {
         schema = parts[0];
         table = parts[1];
+    } else if (parts.length === 3) {
+        schema = parts[0] + '.' + parts[1];
+        table = parts[2];
     } else {
         console.error('Erroneous Input');
         console.error(tableToken);


### PR DESCRIPTION
Fixes: #565

For sources where `schemas` live under a `catalog`, like `Presto`,  catalog and schema can be merged into a single name `catalog.schema` and stored in the database. 