### PR TITLE
fix: change k8s options to operate

### DIFF
--- a/k8s/web-deployment.yaml
+++ b/k8s/web-deployment.yaml
@@ -16,7 +16,6 @@ spec:
                 - args:
                       - ./querybook/scripts/bundled_docker_run_web
                       - --initdb
-                      - --initweb
                   env:
                       - name: PORT
                         value: '10001'

--- a/k8s/web-deployment.yaml
+++ b/k8s/web-deployment.yaml
@@ -15,6 +15,8 @@ spec:
             containers:
                 - args:
                       - ./querybook/scripts/bundled_docker_run_web
+                      - --initdb
+                      - --initweb
                   env:
                       - name: PORT
                         value: '10001'
@@ -35,6 +37,6 @@ spec:
                           memory: '800Mi'
                           cpu: '500m'
                       limits:
-                          memory: '800Mi'
-                          cpu: '500m'
+                          memory: '3Gi'
+                          cpu: '1'
             restartPolicy: Always

--- a/k8s/web-service.yaml
+++ b/k8s/web-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
     name: web
 spec:
-    type: LoadBalancer
+    type: ClusterIP
     ports:
         - protocol: 'TCP'
           port: 80

--- a/k8s/worker-deployment.yaml
+++ b/k8s/worker-deployment.yaml
@@ -23,8 +23,8 @@ spec:
                           memory: '400Mi'
                           cpu: '500m'
                       limits:
-                          memory: '400Mi'
-                          cpu: '500m'
+                          memory: '800Mi'
+                          cpu: '1'
                   env:
                       - name: FLASK_SECRET_KEY
                         value: SOME_RANDOM_SECRET_KEY


### PR DESCRIPTION
1. Without initdb and initweb options, web will not start properly and cannot start db.
2. LoadBalancer is unnecessary, we can use ClusterIP
3. OOM will occur with current limit

All these commits have been tested already through my own k8s cluster.