### PR TITLE
fix: make link left click only, update style

### DIFF
--- a/querybook/webapp/ui/Link/Link.tsx
+++ b/querybook/webapp/ui/Link/Link.tsx
@@ -7,7 +7,10 @@ const StyledLink = styled('a')`
     ${({ naturalLink }) =>
         naturalLink &&
         `
-        color: inherit;
+        color: var(--color-accent-text);
+        &:hover {
+            opacity: 0.9;
+        }
         text-decoration: underline;
     `};
 `;
@@ -45,9 +48,15 @@ const openInTab = (url: string) => (window.location.href = url);
 
 export class Link extends React.PureComponent<ILinkProps> {
     public handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+        if (e.button !== 0) {
+            // If it is not a left click, ignore
+            return;
+        }
+
         e.preventDefault();
         const { to, onClick, newTab } = this.props;
         const isCmdDown = e.metaKey;
+
         if (onClick) {
             onClick(e);
         } else if (to && typeof to === 'string') {

--- a/querybook/webapp/ui/Markdown/Markdown.tsx
+++ b/querybook/webapp/ui/Markdown/Markdown.tsx
@@ -8,7 +8,7 @@ const MarkdownLink: React.FC<{ title: string; href: string }> = ({
     href,
     children,
 }) => (
-    <Link to={href} title={title} newTab>
+    <Link to={href} title={title} newTab naturalLink>
         {children}
     </Link>
 );


### PR DESCRIPTION
Now right click, middle click would not trigger the custom link handler.
Updated the style of the link to make it more obvious in the markdown
![image](https://user-images.githubusercontent.com/8283407/123342114-0414f580-d504-11eb-9881-58cdf329cd7a.png)
Hovered
![image](https://user-images.githubusercontent.com/8283407/123342129-0a0ad680-d504-11eb-89b2-ea38fa8d1b95.png)

