### PR TITLE
fix: slack invite url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build Status](https://github.com/pinterest/querybook/workflows/Tests/badge.svg)
 [![License](http://img.shields.io/:license-Apache%202-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.txt)
-[![Slack](https://img.shields.io/badge/Slack-Join%20our%20community-brightgreen?style=flat&logo=slack)](https://join.slack.com/t/querybook/shared_invite/zt-dpr988af-9VwGkjcmPhqTmRoA2Tm3gg)
+[![Slack](https://img.shields.io/badge/Slack-Join%20our%20community-brightgreen?style=flat&logo=slack)](https://join.slack.com/t/querybook/shared_invite/zt-se82lvld-yyzRIqvIASsyYozk7jMCYQ)
 
 Querybook is a Big Data IDE that allows you to discover, create, and share data analyses, queries, and tables.
 [Check out the full documentation & feature highlights here.](https://querybook.org)


### PR DESCRIPTION
the previous one expired. This one should last as long as possible.