### PR TITLE
refactor: moving lineage code into its own plugin

### DIFF
--- a/docs_website/docs/integrations/add_lineage.md
+++ b/docs_website/docs/integrations/add_lineage.md
@@ -1,0 +1,26 @@
+---
+id: add_lineage
+title: Data Lineage
+sidebar_label: Lineage
+---
+
+## Overview
+
+Lineage plugin allows you to extend Querybook to fetch lineage information from a custom data lineage backend.
+Querybook can also update your custom lineage backend with lineage connections created through Querybook.
+
+## Adding a new Lineage backend
+
+To add support for your custom data lineage backend, create a new python file in the plugins directory
+and implement the following functions:
+
+-   `create_table_lineage_from_metadata(job_metadata_id, query_language=None, session=None) -> List[int]`: Used to update the custom lineage backend with lineage connections created from Querybook. Persists all lineage connections, created by the job with the input id, in the lineage backend.
+-   `add_table_lineage(table_id, parent_table_id, job_metadata_id, commit=True, session=None) -> TableLineage`: Used to update the custom lineage backend with lineage connections created from Querybook. Persists the lineage connection, between the input table and the input parent table, in the lineage backend. Returns a `TableLineage` object corresponding the new lineage connection.
+-   `get_table_parent_lineages(table_id, session=None) -> List[TableLineage]`: Used to get the lineage information from the custom lineage backend. Returns a list of `TableLineage` objects corresponding to parent tables of the input table.
+-   `get_table_child_lineages(table_id, session=None) -> List[TableLineage]`: Used to get the lineage information from the custom lineage backend. Returns a list of `TableLineage` objects corresponding to child tables of the input table.
+
+Put the plugin in the plugins directory (see [Plugins Guide](plugins.md) for more details) and set this env variable to tell Querybook to use your plugin for data lineage purposes:
+
+```yaml
+DATA_LINEAGE_BACKEND: 'path.to.plugin' # path to the plugin relative to the plugins directory
+```

--- a/docs_website/docs/integrations/plugins.md
+++ b/docs_website/docs/integrations/plugins.md
@@ -56,6 +56,10 @@ Task plugin lets you implement custom async tasks on querybook. For example, you
 
 Web page plugin allows you to inject custom js, css to Querybook. Place your custom logic under webpage_plugin/custom_script.ts to inject it into the Querybook webapp.
 
+### Lineage plugin
+
+Lineage plugin allows you to extend Querybook to fetch lineage information from a custom data lineage backend. Please check [Add Lineage guide](./add_lineage.md) for more details.
+
 ## Installing Plugins
 
 1. Ensure you can run the vanilla Querybook

--- a/docs_website/sidebars.json
+++ b/docs_website/sidebars.json
@@ -24,6 +24,7 @@
             "integrations/add_auth",
             "integrations/add_query_engine",
             "integrations/add_metastore",
+            "integrations/add_lineage",
             "integrations/add_result_store",
             "integrations/add_exporter",
             "integrations/add_engine_status_checker",

--- a/querybook/config/querybook_default_config.yaml
+++ b/querybook/config/querybook_default_config.yaml
@@ -13,6 +13,9 @@ REDIS_URL: ~
 ELASTICSEARCH_HOST: ~
 ELASTICSEARCH_CONNECTION_TYPE: naive
 
+# --------------- Lineage ---------------
+DATA_LINEAGE_BACKEND: logic.lineage
+
 # --------------- Database ---------------
 DATABASE_CONN: ~
 DATABASE_POOL_SIZE: 10

--- a/querybook/config/querybook_default_config.yaml
+++ b/querybook/config/querybook_default_config.yaml
@@ -14,7 +14,7 @@ ELASTICSEARCH_HOST: ~
 ELASTICSEARCH_CONNECTION_TYPE: naive
 
 # --------------- Lineage ---------------
-DATA_LINEAGE_BACKEND: logic.lineage
+DATA_LINEAGE_BACKEND: lib.lineage.db
 
 # --------------- Database ---------------
 DATABASE_CONN: ~

--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -14,11 +14,11 @@ from app.flask_app import cache
 from const.impression import ImpressionItemType
 from const.metastore import DataTableWarningSeverity
 from const.time import seconds_in_a_day
+from lib.lineage.utils import lineage
 from lib.metastore.utils import DataTableFinder
 from lib.query_analysis.samples import make_samples_query
 from lib.utils import mysql_cache
 from logic import metastore as logic
-from logic.metastore import lineage
 from logic import admin as admin_logic
 from models.metastore import (
     DataTableWarning,
@@ -308,7 +308,7 @@ def get_table_query_examples(
             environment_id, session=session
         )
         engine_ids = [engine.id for engine in engines]
-        query_logs = lineage.get_table_query_examples(
+        query_logs = logic.get_table_query_examples(
             table_id,
             engine_ids,
             uid=uid,
@@ -329,7 +329,7 @@ def get_table_query_examples_users(table_id, environment_id, limit=5):
     verify_data_table_permission(table_id)
     engines = admin_logic.get_query_engines_by_environment(environment_id)
     engine_ids = [engine.id for engine in engines]
-    users = lineage.get_query_example_users(table_id, engine_ids, limit=limit)
+    users = logic.get_query_example_users(table_id, engine_ids, limit=limit)
 
     return [{"uid": r[0], "count": r[1]} for r in users]
 
@@ -338,7 +338,7 @@ def get_table_query_examples_users(table_id, environment_id, limit=5):
 def get_table_query_examples_concurrences(table_id, limit=5):
     api_assert(limit <= 10)
     verify_data_table_permission(table_id)
-    concurrences = lineage.get_query_example_concurrences(table_id, limit=limit)
+    concurrences = logic.get_query_example_concurrences(table_id, limit=limit)
     return [{"table_id": r[0], "count": r[1]} for r in concurrences]
 
 

--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -18,6 +18,7 @@ from lib.metastore.utils import DataTableFinder
 from lib.query_analysis.samples import make_samples_query
 from lib.utils import mysql_cache
 from logic import metastore as logic
+from logic.metastore import lineage
 from logic import admin as admin_logic
 from models.metastore import (
     DataTableWarning,
@@ -118,7 +119,7 @@ def add_data_job_metadata(
         )
         table_lineage_ids = None
         if query_text:
-            table_lineage_ids = logic.create_table_lineage_from_metadata(
+            table_lineage_ids = lineage.create_table_lineage_from_metadata(
                 data_job_metadata.id
             )
         return {
@@ -307,7 +308,7 @@ def get_table_query_examples(
             environment_id, session=session
         )
         engine_ids = [engine.id for engine in engines]
-        query_logs = logic.get_table_query_examples(
+        query_logs = lineage.get_table_query_examples(
             table_id,
             engine_ids,
             uid=uid,
@@ -328,7 +329,7 @@ def get_table_query_examples_users(table_id, environment_id, limit=5):
     verify_data_table_permission(table_id)
     engines = admin_logic.get_query_engines_by_environment(environment_id)
     engine_ids = [engine.id for engine in engines]
-    users = logic.get_query_example_users(table_id, engine_ids, limit=limit)
+    users = lineage.get_query_example_users(table_id, engine_ids, limit=limit)
 
     return [{"uid": r[0], "count": r[1]} for r in users]
 
@@ -337,7 +338,7 @@ def get_table_query_examples_users(table_id, environment_id, limit=5):
 def get_table_query_examples_concurrences(table_id, limit=5):
     api_assert(limit <= 10)
     verify_data_table_permission(table_id)
-    concurrences = logic.get_query_example_concurrences(table_id, limit=limit)
+    concurrences = lineage.get_query_example_concurrences(table_id, limit=limit)
     return [{"table_id": r[0], "count": r[1]} for r in concurrences]
 
 
@@ -513,7 +514,7 @@ def add_lineage(table_id, parent_table_id, job_metadata_id):
         Returns new table lineage dictionary
     """
     with DBSession() as session:
-        table_lineage = logic.add_table_lineage(
+        table_lineage = lineage.add_table_lineage(
             table_id, parent_table_id, job_metadata_id, True, session=session
         )
         return table_lineage.to_dict()
@@ -522,13 +523,13 @@ def add_lineage(table_id, parent_table_id, job_metadata_id):
 @register("/lineage/<int:table_id>/parent/", methods=["GET"])
 def get_table_parent_lineages(table_id):
     with DBSession() as session:
-        return logic.get_table_parent_lineages(table_id, session=session)
+        return lineage.get_table_parent_lineages(table_id, session=session)
 
 
 @register("/lineage/<int:table_id>/child/", methods=["GET"])
 def get_table_child_lineages(table_id):
     with DBSession() as session:
-        return logic.get_table_child_lineages(table_id, session=session)
+        return lineage.get_table_child_lineages(table_id, session=session)
 
 
 @register("/table_warning/", methods=["POST"])

--- a/querybook/server/env.py
+++ b/querybook/server/env.py
@@ -48,6 +48,9 @@ class QuerybookSettings(object):
     ELASTICSEARCH_HOST = get_env_config("ELASTICSEARCH_HOST", optional=False)
     ELASTICSEARCH_CONNECTION_TYPE = get_env_config("ELASTICSEARCH_CONNECTION_TYPE")
 
+    # Lineage
+    DATA_LINEAGE_BACKEND = get_env_config("DATA_LINEAGE_BACKEND")
+
     # Database
     DATABASE_CONN = get_env_config("DATABASE_CONN", optional=False)
     DATABASE_POOL_SIZE = int(get_env_config("DATABASE_POOL_SIZE"))

--- a/querybook/server/lib/lineage/db.py
+++ b/querybook/server/lib/lineage/db.py
@@ -1,0 +1,30 @@
+from app.db import with_session
+from logic import lineage
+
+
+@with_session
+def create_table_lineage_from_metadata(
+    job_metadata_id, query_language=None, session=None
+):
+    lineage.create_table_lineage_from_metadata(
+        job_metadata_id, query_language=query_language, session=session
+    )
+
+
+@with_session
+def add_table_lineage(
+    table_id, parent_table_id, job_metadata_id, commit=True, session=None
+):
+    return lineage.add_table_lineage(
+        table_id, parent_table_id, job_metadata_id, commit=commit, session=session
+    )
+
+
+@with_session
+def get_table_parent_lineages(table_id, session=None):
+    return lineage.get_table_parent_lineages(table_id, session=session)
+
+
+@with_session
+def get_table_child_lineages(table_id, session=None):
+    return lineage.get_table_child_lineages(table_id, session=session)

--- a/querybook/server/lib/lineage/utils.py
+++ b/querybook/server/lib/lineage/utils.py
@@ -1,0 +1,5 @@
+from env import QuerybookSettings
+
+from lib.utils.plugin import import_plugin
+
+lineage = import_plugin(QuerybookSettings.DATA_LINEAGE_BACKEND)

--- a/querybook/server/logic/demo.py
+++ b/querybook/server/logic/demo.py
@@ -6,6 +6,7 @@ from logic import (
     user as user_logic,
 )
 
+from logic.metastore import lineage as lineage_logic
 
 @with_session
 def create_demo_table_stats(table_id, uid, session=None):
@@ -74,7 +75,7 @@ FROM
         is_adhoc=True,
         session=session,
     )
-    m_logic.create_table_lineage_from_metadata(
+    lineage_logic.create_table_lineage_from_metadata(
         data_job_metadata.id, "sqlite", session=session
     )
 

--- a/querybook/server/logic/demo.py
+++ b/querybook/server/logic/demo.py
@@ -6,7 +6,8 @@ from logic import (
     user as user_logic,
 )
 
-from logic.metastore import lineage as lineage_logic
+from lib.lineage.utils import lineage as lineage_logic
+
 
 @with_session
 def create_demo_table_stats(table_id, uid, session=None):

--- a/querybook/server/logic/elasticsearch.py
+++ b/querybook/server/logic/elasticsearch.py
@@ -23,7 +23,7 @@ from logic.datadoc import (
 from logic.metastore import (
     get_all_table,
     get_table_by_id,
-    lineage
+    get_table_query_samples_count,
 )
 
 from logic.impression import (
@@ -198,7 +198,7 @@ def get_table_weight(table_id: int, session=None) -> int:
     Returns:
         int -- The integer weight
     """
-    num_samples = lineage.get_table_query_samples_count(table_id, session=session)
+    num_samples = get_table_query_samples_count(table_id, session=session)
     num_impressions = get_viewers_count_by_item_after_date(
         ImpressionItemType.DATA_TABLE,
         table_id,

--- a/querybook/server/logic/elasticsearch.py
+++ b/querybook/server/logic/elasticsearch.py
@@ -23,8 +23,9 @@ from logic.datadoc import (
 from logic.metastore import (
     get_all_table,
     get_table_by_id,
-    get_table_query_samples_count,
+    lineage
 )
+
 from logic.impression import (
     get_viewers_count_by_item_after_date,
     get_last_impressions_date,
@@ -197,7 +198,7 @@ def get_table_weight(table_id: int, session=None) -> int:
     Returns:
         int -- The integer weight
     """
-    num_samples = get_table_query_samples_count(table_id, session=session)
+    num_samples = lineage.get_table_query_samples_count(table_id, session=session)
     num_impressions = get_viewers_count_by_item_after_date(
         ImpressionItemType.DATA_TABLE,
         table_id,

--- a/querybook/server/logic/lineage.py
+++ b/querybook/server/logic/lineage.py
@@ -1,0 +1,202 @@
+from sqlalchemy import func, and_
+from sqlalchemy.orm import aliased
+
+from app.db import with_session
+from lib.query_analysis.lineage import process_query
+from models.metastore import (
+    DataTableQueryExecution,
+    DataJobMetadata,
+    TableLineage,
+)
+from models.query_execution import QueryExecution
+
+from logic import metastore
+
+@with_session
+def get_all_table_lineages(session=None):
+    db_dumps = session.query(TableLineage).all()
+    return db_dumps
+
+
+@with_session
+def create_table_lineage_from_metadata(
+    job_metadata_id, query_language=None, session=None
+):
+    job_metadata = session.query(DataJobMetadata).get(job_metadata_id)
+    if job_metadata is None:
+        return
+
+    _, lineage_per_statement = process_query(job_metadata.query_text, query_language)
+
+    lineage_ids = []
+    for statement_lineage in lineage_per_statement:
+        if len(statement_lineage):
+            for lineage in statement_lineage:
+                if "source" in lineage:
+                    source_string = lineage["source"].split(".")
+                    parent_table = metastore.get_table_by_name(
+                        source_string[0],
+                        source_string[1],
+                        job_metadata.metastore_id,
+                        session=session,
+                    )
+
+                    target_string = lineage["target"].split(".")
+                    child_table = metastore.get_table_by_name(
+                        target_string[0],
+                        target_string[1],
+                        job_metadata.metastore_id,
+                        session=session,
+                    )
+
+                    if parent_table and child_table:
+                        lineage_ids.append(
+                            add_table_lineage(
+                                child_table.id,
+                                parent_table.id,
+                                job_metadata_id,
+                                session=session,
+                            ).id
+                        )
+
+    return lineage_ids
+
+
+@with_session
+def add_table_lineage(
+    table_id, parent_table_id, job_metadata_id, commit=True, session=None
+):
+    table_lineage = TableLineage(
+        table_id=table_id,
+        parent_table_id=parent_table_id,
+        job_metadata_id=job_metadata_id,
+    )
+    session.add(table_lineage)
+    if commit:
+        session.commit()
+        table_lineage.id
+    # FIXME: not sure why we need this but new data cannot be added to DB without it
+    session.flush()
+    return table_lineage
+
+
+@with_session
+def get_table_parent_lineages(table_id, session=None):
+    parent_lineages = (
+        session.query(TableLineage).filter(TableLineage.table_id == table_id).all()
+    )
+    return parent_lineages
+
+
+@with_session
+def get_table_child_lineages(table_id, session=None):
+    child_lineages = (
+        session.query(TableLineage)
+        .filter(TableLineage.parent_table_id == table_id)
+        .all()
+    )
+    return child_lineages
+
+
+@with_session
+def create_table_query_execution_log(
+    table_id, cell_id, query_execution_id, commit=True, session=None
+):
+    return DataTableQueryExecution.create(
+        fields={
+            "table_id": table_id,
+            "cell_id": cell_id,
+            "query_execution_id": query_execution_id,
+        },
+        commit=commit,
+        session=session,
+    )
+
+
+@with_session
+def delete_old_able_query_execution_log(
+    cell_id, query_execution_id, commit=True, session=None
+):
+    session.query(DataTableQueryExecution).filter(
+        DataTableQueryExecution.cell_id == cell_id
+    ).filter(DataTableQueryExecution.query_execution_id < query_execution_id).delete()
+
+    if commit:
+        session.commit()
+    else:
+        session.flush()
+
+
+@with_session
+def get_table_query_examples(
+    table_id, engine_ids, uid=None, with_table_id=None, limit=5, offset=0, session=None
+):
+    main_table_qe = aliased(DataTableQueryExecution)
+    query = (
+        session.query(main_table_qe)
+        .join(QueryExecution)
+        .filter(main_table_qe.table_id == table_id)
+        .filter(QueryExecution.engine_id.in_(engine_ids))
+    )
+
+    if uid is not None:
+        query = query.filter(QueryExecution.uid == uid)
+
+    if with_table_id is not None:
+        join_table_qe = aliased(DataTableQueryExecution)
+        query = query.join(
+            join_table_qe,
+            and_(
+                main_table_qe.id != join_table_qe.id,
+                main_table_qe.query_execution_id == join_table_qe.query_execution_id,
+            ),
+        ).filter(join_table_qe.table_id == with_table_id)
+
+    return query.order_by(main_table_qe.id.desc()).limit(limit).offset(offset).all()
+
+
+@with_session
+def get_query_example_users(table_id, engine_ids, limit=5, session=None):
+    users = (
+        session.query(QueryExecution.uid, func.count(QueryExecution.id))
+        .select_from(DataTableQueryExecution)
+        .join(QueryExecution)
+        .filter(DataTableQueryExecution.table_id == table_id)
+        .filter(QueryExecution.engine_id.in_(engine_ids))
+        .group_by(QueryExecution.uid)
+        .order_by(func.count(QueryExecution.id).desc())
+        .limit(limit)
+        .all()
+    )
+
+    return users
+
+
+@with_session
+def get_query_example_concurrences(table_id, limit=5, session=None):
+    main_table_qe = aliased(DataTableQueryExecution)
+    join_table_qe = aliased(DataTableQueryExecution)
+
+    concurrences = (
+        session.query(join_table_qe.table_id, func.count(join_table_qe.id))
+        .select_from(main_table_qe)
+        .join(
+            join_table_qe,
+            and_(
+                main_table_qe.id != join_table_qe.id,
+                main_table_qe.query_execution_id == join_table_qe.query_execution_id,
+            ),
+        )
+        .filter(main_table_qe.table_id == table_id)
+        .group_by(join_table_qe.table_id)
+        .order_by(func.count(join_table_qe.id).desc())
+        .limit(limit)
+        .all()
+    )
+
+    return concurrences
+
+
+@with_session
+def get_table_query_samples_count(table_id, session):
+    return session.query(DataTableQueryExecution).filter_by(table_id=table_id).count()

--- a/querybook/server/logic/lineage.py
+++ b/querybook/server/logic/lineage.py
@@ -1,21 +1,10 @@
-from sqlalchemy import func, and_
-from sqlalchemy.orm import aliased
-
 from app.db import with_session
 from lib.query_analysis.lineage import process_query
 from models.metastore import (
-    DataTableQueryExecution,
     DataJobMetadata,
     TableLineage,
 )
-from models.query_execution import QueryExecution
-
 from logic import metastore
-
-@with_session
-def get_all_table_lineages(session=None):
-    db_dumps = session.query(TableLineage).all()
-    return db_dumps
 
 
 @with_session
@@ -96,107 +85,3 @@ def get_table_child_lineages(table_id, session=None):
         .all()
     )
     return child_lineages
-
-
-@with_session
-def create_table_query_execution_log(
-    table_id, cell_id, query_execution_id, commit=True, session=None
-):
-    return DataTableQueryExecution.create(
-        fields={
-            "table_id": table_id,
-            "cell_id": cell_id,
-            "query_execution_id": query_execution_id,
-        },
-        commit=commit,
-        session=session,
-    )
-
-
-@with_session
-def delete_old_able_query_execution_log(
-    cell_id, query_execution_id, commit=True, session=None
-):
-    session.query(DataTableQueryExecution).filter(
-        DataTableQueryExecution.cell_id == cell_id
-    ).filter(DataTableQueryExecution.query_execution_id < query_execution_id).delete()
-
-    if commit:
-        session.commit()
-    else:
-        session.flush()
-
-
-@with_session
-def get_table_query_examples(
-    table_id, engine_ids, uid=None, with_table_id=None, limit=5, offset=0, session=None
-):
-    main_table_qe = aliased(DataTableQueryExecution)
-    query = (
-        session.query(main_table_qe)
-        .join(QueryExecution)
-        .filter(main_table_qe.table_id == table_id)
-        .filter(QueryExecution.engine_id.in_(engine_ids))
-    )
-
-    if uid is not None:
-        query = query.filter(QueryExecution.uid == uid)
-
-    if with_table_id is not None:
-        join_table_qe = aliased(DataTableQueryExecution)
-        query = query.join(
-            join_table_qe,
-            and_(
-                main_table_qe.id != join_table_qe.id,
-                main_table_qe.query_execution_id == join_table_qe.query_execution_id,
-            ),
-        ).filter(join_table_qe.table_id == with_table_id)
-
-    return query.order_by(main_table_qe.id.desc()).limit(limit).offset(offset).all()
-
-
-@with_session
-def get_query_example_users(table_id, engine_ids, limit=5, session=None):
-    users = (
-        session.query(QueryExecution.uid, func.count(QueryExecution.id))
-        .select_from(DataTableQueryExecution)
-        .join(QueryExecution)
-        .filter(DataTableQueryExecution.table_id == table_id)
-        .filter(QueryExecution.engine_id.in_(engine_ids))
-        .group_by(QueryExecution.uid)
-        .order_by(func.count(QueryExecution.id).desc())
-        .limit(limit)
-        .all()
-    )
-
-    return users
-
-
-@with_session
-def get_query_example_concurrences(table_id, limit=5, session=None):
-    main_table_qe = aliased(DataTableQueryExecution)
-    join_table_qe = aliased(DataTableQueryExecution)
-
-    concurrences = (
-        session.query(join_table_qe.table_id, func.count(join_table_qe.id))
-        .select_from(main_table_qe)
-        .join(
-            join_table_qe,
-            and_(
-                main_table_qe.id != join_table_qe.id,
-                main_table_qe.query_execution_id == join_table_qe.query_execution_id,
-            ),
-        )
-        .filter(main_table_qe.table_id == table_id)
-        .group_by(join_table_qe.table_id)
-        .order_by(func.count(join_table_qe.id).desc())
-        .limit(limit)
-        .all()
-    )
-
-    return concurrences
-
-
-@with_session
-def get_table_query_samples_count(table_id, session):
-    return session.query(DataTableQueryExecution).filter_by(table_id=table_id).count()

--- a/querybook/server/logic/metastore.py
+++ b/querybook/server/logic/metastore.py
@@ -19,12 +19,6 @@ from models.metastore import (
 from models.query_execution import QueryExecution
 from tasks.sync_elasticsearch import sync_elasticsearch
 
-from env import QuerybookSettings
-
-from lib.utils.plugin import import_plugin
-
-lineage = import_plugin(QuerybookSettings.DATA_LINEAGE_BACKEND)
-
 
 @with_session
 def get_all_schema(offset=0, limit=100, session=None):

--- a/querybook/server/logic/metastore.py
+++ b/querybook/server/logic/metastore.py
@@ -1,26 +1,25 @@
 import datetime
-from sqlalchemy import func, and_
-from sqlalchemy.orm import aliased
 
 from app.db import with_session
 from const.elasticsearch import ElasticsearchItem
 from lib.sqlalchemy import update_model_fields
-from lib.query_analysis.lineage import process_query
 from models.metastore import (
     DataSchema,
     DataTable,
     DataTableInformation,
     DataTableColumn,
     DataTableOwnership,
-    DataTableQueryExecution,
     DataJobMetadata,
-    TableLineage,
     DataTableStatistics,
     DataTableColumnStatistics,
 )
-from models.query_execution import QueryExecution
 from tasks.sync_elasticsearch import sync_elasticsearch
 
+from env import QuerybookSettings
+
+from lib.utils.plugin import import_plugin
+
+lineage = import_plugin(QuerybookSettings.DATA_LINEAGE_BACKEND)
 
 @with_session
 def get_all_schema(offset=0, limit=100, session=None):
@@ -531,204 +530,6 @@ def iterate_data_schema(metastore_id, session=None):
     yield from session.query(DataSchema).filter_by(metastore_id=metastore_id).yield_per(
         100
     )
-
-
-"""
-    ---------------------------------------------------------------------------------------------------------
-    DATA LINEAGE
-    ---------------------------------------------------------------------------------------------------------
-"""
-
-
-@with_session
-def get_all_table_lineages(session=None):
-    db_dumps = session.query(TableLineage).all()
-    return db_dumps
-
-
-@with_session
-def create_table_lineage_from_metadata(
-    job_metadata_id, query_language=None, session=None
-):
-    job_metadata = session.query(DataJobMetadata).get(job_metadata_id)
-    if job_metadata is None:
-        return
-
-    _, lineage_per_statement = process_query(job_metadata.query_text, query_language)
-
-    lineage_ids = []
-    for statement_lineage in lineage_per_statement:
-        if len(statement_lineage):
-            for lineage in statement_lineage:
-                if "source" in lineage:
-                    source_string = lineage["source"].split(".")
-                    parent_table = get_table_by_name(
-                        source_string[0],
-                        source_string[1],
-                        job_metadata.metastore_id,
-                        session=session,
-                    )
-
-                    target_string = lineage["target"].split(".")
-                    child_table = get_table_by_name(
-                        target_string[0],
-                        target_string[1],
-                        job_metadata.metastore_id,
-                        session=session,
-                    )
-
-                    if parent_table and child_table:
-                        lineage_ids.append(
-                            add_table_lineage(
-                                child_table.id,
-                                parent_table.id,
-                                job_metadata_id,
-                                session=session,
-                            ).id
-                        )
-
-    return lineage_ids
-
-
-@with_session
-def add_table_lineage(
-    table_id, parent_table_id, job_metadata_id, commit=True, session=None
-):
-    table_lineage = TableLineage(
-        table_id=table_id,
-        parent_table_id=parent_table_id,
-        job_metadata_id=job_metadata_id,
-    )
-    session.add(table_lineage)
-    if commit:
-        session.commit()
-        table_lineage.id
-    # FIXME: not sure why we need this but new data cannot be added to DB without it
-    session.flush()
-    return table_lineage
-
-
-@with_session
-def get_table_parent_lineages(table_id, session=None):
-    parent_lineages = (
-        session.query(TableLineage).filter(TableLineage.table_id == table_id).all()
-    )
-    return parent_lineages
-
-
-@with_session
-def get_table_child_lineages(table_id, session=None):
-    child_lineages = (
-        session.query(TableLineage)
-        .filter(TableLineage.parent_table_id == table_id)
-        .all()
-    )
-    return child_lineages
-
-
-@with_session
-def create_table_query_execution_log(
-    table_id, cell_id, query_execution_id, commit=True, session=None
-):
-    return DataTableQueryExecution.create(
-        fields={
-            "table_id": table_id,
-            "cell_id": cell_id,
-            "query_execution_id": query_execution_id,
-        },
-        commit=commit,
-        session=session,
-    )
-
-
-@with_session
-def delete_old_able_query_execution_log(
-    cell_id, query_execution_id, commit=True, session=None
-):
-    session.query(DataTableQueryExecution).filter(
-        DataTableQueryExecution.cell_id == cell_id
-    ).filter(DataTableQueryExecution.query_execution_id < query_execution_id).delete()
-
-    if commit:
-        session.commit()
-    else:
-        session.flush()
-
-
-@with_session
-def get_table_query_examples(
-    table_id, engine_ids, uid=None, with_table_id=None, limit=5, offset=0, session=None
-):
-    main_table_qe = aliased(DataTableQueryExecution)
-    query = (
-        session.query(main_table_qe)
-        .join(QueryExecution)
-        .filter(main_table_qe.table_id == table_id)
-        .filter(QueryExecution.engine_id.in_(engine_ids))
-    )
-
-    if uid is not None:
-        query = query.filter(QueryExecution.uid == uid)
-
-    if with_table_id is not None:
-        join_table_qe = aliased(DataTableQueryExecution)
-        query = query.join(
-            join_table_qe,
-            and_(
-                main_table_qe.id != join_table_qe.id,
-                main_table_qe.query_execution_id == join_table_qe.query_execution_id,
-            ),
-        ).filter(join_table_qe.table_id == with_table_id)
-
-    return query.order_by(main_table_qe.id.desc()).limit(limit).offset(offset).all()
-
-
-@with_session
-def get_query_example_users(table_id, engine_ids, limit=5, session=None):
-    users = (
-        session.query(QueryExecution.uid, func.count(QueryExecution.id))
-        .select_from(DataTableQueryExecution)
-        .join(QueryExecution)
-        .filter(DataTableQueryExecution.table_id == table_id)
-        .filter(QueryExecution.engine_id.in_(engine_ids))
-        .group_by(QueryExecution.uid)
-        .order_by(func.count(QueryExecution.id).desc())
-        .limit(limit)
-        .all()
-    )
-
-    return users
-
-
-@with_session
-def get_query_example_concurrences(table_id, limit=5, session=None):
-    main_table_qe = aliased(DataTableQueryExecution)
-    join_table_qe = aliased(DataTableQueryExecution)
-
-    concurrences = (
-        session.query(join_table_qe.table_id, func.count(join_table_qe.id))
-        .select_from(main_table_qe)
-        .join(
-            join_table_qe,
-            and_(
-                main_table_qe.id != join_table_qe.id,
-                main_table_qe.query_execution_id == join_table_qe.query_execution_id,
-            ),
-        )
-        .filter(main_table_qe.table_id == table_id)
-        .group_by(join_table_qe.table_id)
-        .order_by(func.count(join_table_qe.id).desc())
-        .limit(limit)
-        .all()
-    )
-
-    return concurrences
-
-
-@with_session
-def get_table_query_samples_count(table_id, session):
-    return session.query(DataTableQueryExecution).filter_by(table_id=table_id).count()
-
 
 """
     ---------------------------------------------------------------------------------------------------------

--- a/querybook/server/logic/metastore.py
+++ b/querybook/server/logic/metastore.py
@@ -1,4 +1,6 @@
 import datetime
+from sqlalchemy import func, and_
+from sqlalchemy.orm import aliased
 
 from app.db import with_session
 from const.elasticsearch import ElasticsearchItem
@@ -10,9 +12,11 @@ from models.metastore import (
     DataTableColumn,
     DataTableOwnership,
     DataJobMetadata,
+    DataTableQueryExecution,
     DataTableStatistics,
     DataTableColumnStatistics,
 )
+from models.query_execution import QueryExecution
 from tasks.sync_elasticsearch import sync_elasticsearch
 
 from env import QuerybookSettings
@@ -20,6 +24,7 @@ from env import QuerybookSettings
 from lib.utils.plugin import import_plugin
 
 lineage = import_plugin(QuerybookSettings.DATA_LINEAGE_BACKEND)
+
 
 @with_session
 def get_all_schema(offset=0, limit=100, session=None):
@@ -530,6 +535,111 @@ def iterate_data_schema(metastore_id, session=None):
     yield from session.query(DataSchema).filter_by(metastore_id=metastore_id).yield_per(
         100
     )
+
+
+@with_session
+def create_table_query_execution_log(
+    table_id, cell_id, query_execution_id, commit=True, session=None
+):
+    return DataTableQueryExecution.create(
+        fields={
+            "table_id": table_id,
+            "cell_id": cell_id,
+            "query_execution_id": query_execution_id,
+        },
+        commit=commit,
+        session=session,
+    )
+
+
+@with_session
+def delete_old_able_query_execution_log(
+    cell_id, query_execution_id, commit=True, session=None
+):
+    session.query(DataTableQueryExecution).filter(
+        DataTableQueryExecution.cell_id == cell_id
+    ).filter(DataTableQueryExecution.query_execution_id < query_execution_id).delete()
+
+    if commit:
+        session.commit()
+    else:
+        session.flush()
+
+
+@with_session
+def get_table_query_examples(
+    table_id, engine_ids, uid=None, with_table_id=None, limit=5, offset=0, session=None
+):
+    main_table_qe = aliased(DataTableQueryExecution)
+    query = (
+        session.query(main_table_qe)
+        .join(QueryExecution)
+        .filter(main_table_qe.table_id == table_id)
+        .filter(QueryExecution.engine_id.in_(engine_ids))
+    )
+
+    if uid is not None:
+        query = query.filter(QueryExecution.uid == uid)
+
+    if with_table_id is not None:
+        join_table_qe = aliased(DataTableQueryExecution)
+        query = query.join(
+            join_table_qe,
+            and_(
+                main_table_qe.id != join_table_qe.id,
+                main_table_qe.query_execution_id == join_table_qe.query_execution_id,
+            ),
+        ).filter(join_table_qe.table_id == with_table_id)
+
+    return query.order_by(main_table_qe.id.desc()).limit(limit).offset(offset).all()
+
+
+@with_session
+def get_query_example_users(table_id, engine_ids, limit=5, session=None):
+    users = (
+        session.query(QueryExecution.uid, func.count(QueryExecution.id))
+        .select_from(DataTableQueryExecution)
+        .join(QueryExecution)
+        .filter(DataTableQueryExecution.table_id == table_id)
+        .filter(QueryExecution.engine_id.in_(engine_ids))
+        .group_by(QueryExecution.uid)
+        .order_by(func.count(QueryExecution.id).desc())
+        .limit(limit)
+        .all()
+    )
+
+    return users
+
+
+@with_session
+def get_query_example_concurrences(table_id, limit=5, session=None):
+    main_table_qe = aliased(DataTableQueryExecution)
+    join_table_qe = aliased(DataTableQueryExecution)
+
+    concurrences = (
+        session.query(join_table_qe.table_id, func.count(join_table_qe.id))
+        .select_from(main_table_qe)
+        .join(
+            join_table_qe,
+            and_(
+                main_table_qe.id != join_table_qe.id,
+                main_table_qe.query_execution_id == join_table_qe.query_execution_id,
+            ),
+        )
+        .filter(main_table_qe.table_id == table_id)
+        .group_by(join_table_qe.table_id)
+        .order_by(func.count(join_table_qe.id).desc())
+        .limit(limit)
+        .all()
+    )
+
+    return concurrences
+
+
+@with_session
+def get_table_query_samples_count(table_id, session):
+    return session.query(DataTableQueryExecution).filter_by(table_id=table_id).count()
+
 
 """
     ---------------------------------------------------------------------------------------------------------

--- a/querybook/server/tasks/log_query_per_table.py
+++ b/querybook/server/tasks/log_query_per_table.py
@@ -10,6 +10,7 @@ from lib.metastore import get_metastore_loader
 from logic import (
     query_execution as qe_logic,
     metastore as m_logic,
+    lineage as lineage_logic,
 )
 
 
@@ -70,7 +71,7 @@ def create_lineage_from_query(
         is_adhoc=True,
         session=session,
     )
-    m_logic.create_table_lineage_from_metadata(
+    lineage_logic.create_table_lineage_from_metadata(
         data_job_metadata.id, query_execution.engine.language, session=session
     )
 
@@ -146,13 +147,13 @@ def log_table_per_statement(
         )
 
         if query_table:  # Sanity check
-            m_logic.delete_old_able_query_execution_log(
+            lineage_logic.delete_old_able_query_execution_log(
                 cell_id=cell_id,
                 query_execution_id=query_execution_id,
                 commit=False,
                 session=session,
             )
-            m_logic.create_table_query_execution_log(
+            lineage_logic.create_table_query_execution_log(
                 table_id=query_table.id,
                 cell_id=cell_id,
                 query_execution_id=query_execution_id,

--- a/querybook/server/tasks/log_query_per_table.py
+++ b/querybook/server/tasks/log_query_per_table.py
@@ -10,8 +10,8 @@ from lib.metastore import get_metastore_loader
 from logic import (
     query_execution as qe_logic,
     metastore as m_logic,
-    lineage as lineage_logic,
 )
+from lib.lineage.utils import lineage as lineage_logic
 
 
 @celery.task(bind=True)
@@ -147,13 +147,13 @@ def log_table_per_statement(
         )
 
         if query_table:  # Sanity check
-            lineage_logic.delete_old_able_query_execution_log(
+            m_logic.delete_old_able_query_execution_log(
                 cell_id=cell_id,
                 query_execution_id=query_execution_id,
                 commit=False,
                 session=session,
             )
-            lineage_logic.create_table_query_execution_log(
+            m_logic.create_table_query_execution_log(
                 table_id=query_table.id,
                 cell_id=cell_id,
                 query_execution_id=query_execution_id,


### PR DESCRIPTION
There are a number of open source data governance platforms available.
Some of the most popular ones are:
* Amundsen: https://www.amundsen.io/
* Atlas: https://atlas.apache.org/
* Marquez: https://marquezproject.github.io/marquez/

They all have data lineage functionality that is exposed via APIs.

This refactor will enable user to replace the default lineage backend.