### PR TITLE
fix: error handling for update cell, insert/delete idempotent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,8 @@ repos:
       hooks:
           - id: black
             files: "^querybook/(server|tests)/.*\\.py$"
-    - repo: https://github.com/prettier/pre-commit
-      rev: v2.0.2
+    - repo: https://github.com/pre-commit/mirrors-prettier
+      rev: v2.3.2
       hooks:
           - id: prettier
             files: "^querybook/webapp/.*\\.(tsx?)$"

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
         "json-loader": "^0.5.7",
         "postcss-loader": "^6.1.0",
         "postcss-preset-env": "6.7.0",
-        "prettier": "2.0.2",
+        "prettier": "2.3.2",
         "prettier-eslint": "^11.0.0",
         "sass-loader": "11.1.0",
         "source-map-loader": "2.0.1",

--- a/querybook/server/datasources/datadoc.py
+++ b/querybook/server/datasources/datadoc.py
@@ -149,9 +149,9 @@ def paste_data_cell(cell_id, cut, doc_id, index):
     return datadoc_collab.paste_data_cell(cell_id, cut, doc_id, index)
 
 
-@register("/datadoc/<int:doc_id>/cell/<int:index>/", methods=["DELETE"])
-def delete_data_cell_from_doc(doc_id, index):
-    return datadoc_collab.delete_data_cell(doc_id, index)
+@register("/datadoc/<int:doc_id>/cell/<int:cell_id>/", methods=["DELETE"])
+def delete_data_cell_from_doc(doc_id, cell_id):
+    return datadoc_collab.delete_data_cell(doc_id, cell_id)
 
 
 @register("/datadoc/<int:id>/clone/", methods=["POST"])

--- a/querybook/server/datasources_socketio/datadoc.py
+++ b/querybook/server/datasources_socketio/datadoc.py
@@ -228,8 +228,8 @@ def update_data_cell(doc_id, cell_id, fields):
 
 @register_socket("delete_data_cell", namespace=DATA_DOC_NAMESPACE)
 @data_doc_socket
-def delete_data_cell(doc_id, index):
-    datadoc_collab.delete_data_cell(doc_id, index, sid=request.sid)
+def delete_data_cell(doc_id, cell_id):
+    datadoc_collab.delete_data_cell(doc_id, cell_id, sid=request.sid)
 
 
 @register_socket("move_data_cell", namespace=DATA_DOC_NAMESPACE)

--- a/querybook/server/lib/data_doc/data_cell.py
+++ b/querybook/server/lib/data_doc/data_cell.py
@@ -1,0 +1,58 @@
+from lib.config import get_config_value
+
+cell_types = get_config_value("datadoc.cell_types")
+
+
+def get_valid_meta(input_vals, valid_vals, default_vals=None):
+    if type(input_vals) != type(valid_vals):
+        raise ValueError(
+            f"Invalid meta type, expected {type(valid_vals)} actual {type(input_vals)}"
+        )
+
+    if input_vals is None:
+        return default_vals
+
+    if isinstance(valid_vals, dict):
+        return_obj = {}
+        for valid_key, valid_val in valid_vals.items():
+            if valid_key in input_vals:
+                return_obj[valid_key] = get_valid_meta(
+                    input_vals=input_vals[valid_key],
+                    valid_vals=valid_val,
+                    default_vals=(
+                        default_vals.get(valid_key) if default_vals else None
+                    ),
+                )
+            # only for series obj
+            elif type(valid_key) == int:
+                valid_keys = list(list(valid_vals.values())[0].keys())
+                if all(
+                    all([i in valid_keys for i in item]) for item in input_vals.values()
+                ):
+                    return input_vals
+        return return_obj
+    elif isinstance(valid_vals, list):
+        return [
+            get_valid_meta(
+                input_vals=input_val,
+                valid_vals=valid_vals[0],
+                default_vals=(default_vals or [None])[0],
+            )
+            for input_val in input_vals
+        ]
+    else:
+        return input_vals
+
+
+def sanitize_data_cell_meta(cell_type: str, meta):
+    cell_type_info = cell_types[cell_type]
+
+    valid_dict = cell_type_info["meta"]
+    default_dict = cell_type_info["meta_default"]
+
+    if meta is None:
+        return default_dict
+
+    return get_valid_meta(
+        input_vals=meta, valid_vals=valid_dict, default_vals=default_dict
+    )

--- a/querybook/server/logic/datadoc.py
+++ b/querybook/server/logic/datadoc.py
@@ -4,8 +4,8 @@ from sqlalchemy import func
 from app.db import with_session
 from const.elasticsearch import ElasticsearchItem
 from const.impression import ImpressionItemType
-from lib.config import get_config_value
 from lib.sqlalchemy import update_model_fields
+from lib.data_doc.data_cell import cell_types, sanitize_data_cell_meta
 from models.datadoc import (
     DataDoc,
     DataDocDataCell,
@@ -19,8 +19,6 @@ from models.datadoc import (
 from models.access_request import AccessRequest
 from models.impression import Impression
 from tasks.sync_elasticsearch import sync_elasticsearch
-
-cell_types = get_config_value("datadoc.cell_types")
 
 
 """
@@ -233,59 +231,6 @@ def clone_data_doc(id, owner_uid, commit=True, session=None):
 """
 
 
-def get_valid_meta(input_vals, valid_vals, default_vals=None):
-    if type(input_vals) != type(valid_vals):
-        raise ValueError("Invalid meta type")
-
-    if input_vals is None:
-        return default_vals
-
-    if isinstance(valid_vals, dict):
-        return_obj = {}
-        for valid_key, valid_val in valid_vals.items():
-            if valid_key in input_vals:
-                return_obj[valid_key] = get_valid_meta(
-                    input_vals=input_vals[valid_key],
-                    valid_vals=valid_val,
-                    default_vals=(
-                        default_vals.get(valid_key) if default_vals else None
-                    ),
-                )
-            # only for series obj
-            elif type(valid_key) == int:
-                valid_keys = list(list(valid_vals.values())[0].keys())
-                if all(
-                    all([i in valid_keys for i in item]) for item in input_vals.values()
-                ):
-                    return input_vals
-        return return_obj
-    elif isinstance(valid_vals, list):
-        return [
-            get_valid_meta(
-                input_vals=input_val,
-                valid_vals=valid_vals[0],
-                default_vals=(default_vals or [None])[0],
-            )
-            for input_val in input_vals
-        ]
-    else:
-        return input_vals
-
-
-def sanitize_data_cell_meta(cell_type: str, meta):
-    cell_type_info = cell_types[cell_type]
-
-    valid_dict = cell_type_info["meta"]
-    default_dict = cell_type_info["meta_default"]
-
-    if meta is None:
-        return default_dict
-
-    return get_valid_meta(
-        input_vals=meta, valid_vals=valid_dict, default_vals=default_dict
-    )
-
-
 @with_session
 def create_data_cell(
     cell_type=None, context=None, meta=None, commit=True, session=None
@@ -410,14 +355,22 @@ def insert_data_doc_cell(data_doc_id, cell_id, index, commit=True, session=None)
 
 
 @with_session
-def delete_data_doc_cell(data_doc_id, index, commit=True, session=None):
+def delete_data_doc_cell(data_doc_id, data_cell_id, commit=True, session=None):
     data_doc = get_data_doc_by_id(data_doc_id, session=session)
-    assert index >= 0 and index < len(data_doc.cells), "Invalid cell index to delete"
 
-    session.query(DataDocDataCell).filter(
-        DataDocDataCell.data_doc_id == data_doc_id
-    ).filter(DataDocDataCell.cell_order == index).delete()
+    data_doc_data_cell = (
+        session.query(DataDocDataCell)
+        .filter_by(data_doc_id=data_doc_id, data_cell_id=data_cell_id)
+        .first()
+    )
 
+    assert data_doc_data_cell is not None, "Invalid cell to delete"
+
+    index = data_doc_data_cell.cell_order
+    # Remove the cell from the doc
+    session.delete(data_doc_data_cell)
+
+    # Shift cells below up by 1
     session.query(DataDocDataCell).filter(
         DataDocDataCell.data_doc_id == data_doc_id
     ).filter(DataDocDataCell.cell_order > index).update(

--- a/querybook/server/logic/datadoc_collab.py
+++ b/querybook/server/logic/datadoc_collab.py
@@ -139,7 +139,7 @@ def paste_data_cell(
             )
             socketio.emit(
                 "data_cell_deleted",
-                (sid, index,),
+                (sid, cell_id,),
                 namespace=DATA_DOC_NAMESPACE,
                 room=old_data_doc.id,
                 broadcast=True,
@@ -191,14 +191,16 @@ def update_data_cell(cell_id, fields, sid="", session=None):
 
 
 @with_session
-def delete_data_cell(doc_id, index, sid="", session=None):
+def delete_data_cell(doc_id, cell_id, sid="", session=None):
     assert_can_write(doc_id, session=session)
     verify_data_doc_permission(doc_id, session=session)
-    logic.delete_data_doc_cell(data_doc_id=doc_id, index=int(index), session=session)
+    logic.delete_data_doc_cell(
+        data_doc_id=doc_id, data_cell_id=int(cell_id), session=session
+    )
 
     socketio.emit(
         "data_cell_deleted",
-        (sid, index,),
+        (sid, cell_id,),
         namespace=DATA_DOC_NAMESPACE,
         room=doc_id,
         broadcast=True,

--- a/querybook/webapp/components/DataDoc/DataDoc.tsx
+++ b/querybook/webapp/components/DataDoc/DataDoc.tsx
@@ -841,13 +841,15 @@ function mapDispatchToProps(dispatch: Dispatch) {
                 )
             ),
 
-        updateDataDocCell: (
+        updateDataDocCell: async (
             docId: number,
             cellId: number,
             fields: DataCellUpdateFields
         ) => {
             try {
-                return dispatch(
+                // Await the result so it can be caught by
+                // try catch
+                return await dispatch(
                     dataDocActions.updateDataDocCell(
                         docId,
                         cellId,

--- a/querybook/webapp/components/DataDocCell/DataDocCell.tsx
+++ b/querybook/webapp/components/DataDocCell/DataDocCell.tsx
@@ -50,244 +50,256 @@ function getEstimatedCellHeight(cell: IDataCell) {
 }
 
 // renders cell
-export const DataDocCell: React.FunctionComponent<IDataDocCellProps> = React.memo(
-    ({
-        docId,
-        numberOfCells,
-        templatedVariables,
+export const DataDocCell: React.FunctionComponent<IDataDocCellProps> =
+    React.memo(
+        ({
+            docId,
+            numberOfCells,
+            templatedVariables,
 
-        cell,
-        index,
-        lastQueryCellId,
-        queryIndexInDoc,
-        isFocused,
-    }) => {
-        const {
-            cellIdToExecutionId,
+            cell,
+            index,
+            lastQueryCellId,
+            queryIndexInDoc,
+            isFocused,
+        }) => {
+            const {
+                cellIdToExecutionId,
 
-            insertCellAt,
-            updateCell,
-            copyCellAt,
-            pasteCellAt,
-            fullScreenCellAt,
+                insertCellAt,
+                updateCell,
+                copyCellAt,
+                pasteCellAt,
+                fullScreenCellAt,
 
-            cellFocus,
-            defaultCollapse,
-            isEditable,
-            highlightCellIndex,
-            fullScreenCellIndex,
-        } = useContext(DataDocContext);
-
-        const cellIdtoUid = useMakeSelector(
-            dataDocSelectors.makeDataDocCursorByCellIdSelector,
-            docId
-        );
-
-        const arrowKeysEnabled = useSelector(
-            (state: IStoreState) =>
-                state.user.computedSettings.datadoc_arrow_key === 'enabled'
-        );
-
-        const [showCollapsed, setShowCollapsed] = React.useState(undefined);
-        useEffect(() => {
-            if (defaultCollapse != null) {
-                setShowCollapsed(defaultCollapse);
-            } else {
-                setShowCollapsed(
-                    cell.cell_type === 'query'
-                        ? Boolean(cell.meta.collapsed)
-                        : undefined
-                );
-            }
-        }, [defaultCollapse]);
-        const uncollapseCell = useCallback(() => setShowCollapsed(false), []);
-
-        const handleUpdateCell = React.useCallback(
-            async (fields: DataCellUpdateFields) => updateCell(cell.id, fields),
-            [cell.id]
-        );
-
-        const handleMoveCell = React.useCallback(
-            (fromIndex: number, toIndex: number) => {
-                dataDocActions.moveDataDocCell(docId, fromIndex, toIndex);
-            },
-            [docId]
-        );
-
-        const handleDefaultCollapseChange = React.useCallback(
-            () =>
-                handleUpdateCell({
-                    meta: { ...cell.meta, collapsed: !cell.meta.collapsed },
-                }),
-            [cell]
-        );
-
-        const handleDeleteCell = React.useCallback(
-            () =>
-                new Promise<void>((resolve) => {
-                    if (numberOfCells > 0) {
-                        const deleteCell = async () => {
-                            try {
-                                await dataDocActions.deleteDataDocCell(
-                                    docId,
-                                    index
-                                );
-                            } catch (e) {
-                                toast.error(`Delete cell failed, reason: ${e}`);
-                            } finally {
-                                resolve();
-                            }
-                        };
-                        sendConfirm({
-                            header: 'Delete Cell?',
-                            message: 'Deleted cells cannot be recovered',
-                            onConfirm: deleteCell,
-                            onHide: resolve,
-                        });
-                    } else {
-                        resolve();
-                    }
-                }),
-            [docId, numberOfCells, index]
-        );
-
-        const shareUrl = useMemo(
-            () => getShareUrl(cell.id, cellIdToExecutionId[cell.id]),
-            [cell.id, cellIdToExecutionId[cell.id]]
-        );
-
-        const isFullScreen = index === fullScreenCellIndex;
-        const toggleFullScreen = useCallback(() => {
-            fullScreenCellAt(isFullScreen ? null : index);
-        }, [isFullScreen, fullScreenCellAt, index]);
-        const handleFocus = useBoundFunc(cellFocus.onFocus, index);
-        const handleBlur = useBoundFunc(cellFocus.onBlur, index);
-        const handleUpKeyPressed = useBoundFunc(
-            cellFocus.onUpKeyPressed,
-            index
-        );
-        const handleDownKeyPressed = useBoundFunc(
-            cellFocus.onDownKeyPressed,
-            index
-        );
-
-        const renderCell = () => {
-            const onCellKeyArrowKeyPressed = arrowKeysEnabled
-                ? {
-                      onUpKeyPressed: handleUpKeyPressed,
-                      onDownKeyPressed: handleDownKeyPressed,
-                  }
-                : {};
-
-            // If we are printing, then print readonly cells
-            const cellProps = {
-                meta: cell.meta,
+                cellFocus,
+                defaultCollapse,
                 isEditable,
+                highlightCellIndex,
+                fullScreenCellIndex,
+            } = useContext(DataDocContext);
 
-                shouldFocus: isFocused,
-                showCollapsed,
+            const cellIdtoUid = useMakeSelector(
+                dataDocSelectors.makeDataDocCursorByCellIdSelector,
+                docId
+            );
 
-                onChange: handleUpdateCell,
-                onDeleteKeyPressed: handleDeleteCell,
+            const arrowKeysEnabled = useSelector(
+                (state: IStoreState) =>
+                    state.user.computedSettings.datadoc_arrow_key === 'enabled'
+            );
 
-                onFocus: handleFocus,
-                onBlur: handleBlur,
-                ...onCellKeyArrowKeyPressed,
+            const [showCollapsed, setShowCollapsed] = React.useState(undefined);
+            useEffect(() => {
+                if (defaultCollapse != null) {
+                    setShowCollapsed(defaultCollapse);
+                } else {
+                    setShowCollapsed(
+                        cell.cell_type === 'query'
+                            ? Boolean(cell.meta.collapsed)
+                            : undefined
+                    );
+                }
+            }, [defaultCollapse]);
+            const uncollapseCell = useCallback(
+                () => setShowCollapsed(false),
+                []
+            );
+
+            const handleUpdateCell = React.useCallback(
+                async (fields: DataCellUpdateFields) =>
+                    updateCell(cell.id, fields),
+                [cell.id]
+            );
+
+            const handleMoveCell = React.useCallback(
+                (fromIndex: number, toIndex: number) => {
+                    dataDocActions.moveDataDocCell(docId, fromIndex, toIndex);
+                },
+                [docId]
+            );
+
+            const handleDefaultCollapseChange = React.useCallback(
+                () =>
+                    handleUpdateCell({
+                        meta: { ...cell.meta, collapsed: !cell.meta.collapsed },
+                    }),
+                [cell]
+            );
+
+            const handleDeleteCell = React.useCallback(
+                () =>
+                    new Promise<void>((resolve) => {
+                        if (numberOfCells > 0) {
+                            const deleteCell = async () => {
+                                try {
+                                    await dataDocActions.deleteDataDocCell(
+                                        docId,
+                                        cell.id
+                                    );
+                                } catch (e) {
+                                    toast.error(
+                                        `Delete cell failed, reason: ${e}`
+                                    );
+                                } finally {
+                                    resolve();
+                                }
+                            };
+                            sendConfirm({
+                                header: 'Delete Cell?',
+                                message: 'Deleted cells cannot be recovered',
+                                onConfirm: deleteCell,
+                                onHide: resolve,
+                            });
+                        } else {
+                            resolve();
+                        }
+                    }),
+                [docId, numberOfCells, cell.id]
+            );
+
+            const shareUrl = useMemo(
+                () => getShareUrl(cell.id, cellIdToExecutionId[cell.id]),
+                [cell.id, cellIdToExecutionId[cell.id]]
+            );
+
+            const isFullScreen = index === fullScreenCellIndex;
+            const toggleFullScreen = useCallback(() => {
+                fullScreenCellAt(isFullScreen ? null : index);
+            }, [isFullScreen, fullScreenCellAt, index]);
+            const handleFocus = useBoundFunc(cellFocus.onFocus, index);
+            const handleBlur = useBoundFunc(cellFocus.onBlur, index);
+            const handleUpKeyPressed = useBoundFunc(
+                cellFocus.onUpKeyPressed,
+                index
+            );
+            const handleDownKeyPressed = useBoundFunc(
+                cellFocus.onDownKeyPressed,
+                index
+            );
+
+            const renderCell = () => {
+                const onCellKeyArrowKeyPressed = arrowKeysEnabled
+                    ? {
+                          onUpKeyPressed: handleUpKeyPressed,
+                          onDownKeyPressed: handleDownKeyPressed,
+                      }
+                    : {};
+
+                // If we are printing, then print readonly cells
+                const cellProps = {
+                    meta: cell.meta,
+                    isEditable,
+
+                    shouldFocus: isFocused,
+                    showCollapsed,
+
+                    onChange: handleUpdateCell,
+                    onDeleteKeyPressed: handleDeleteCell,
+
+                    onFocus: handleFocus,
+                    onBlur: handleBlur,
+                    ...onCellKeyArrowKeyPressed,
+                };
+
+                let cellDOM = null;
+                if (cell.cell_type === 'query') {
+                    const allProps = {
+                        ...cellProps,
+                        query: cell.context,
+                        docId,
+                        cellId: cell.id,
+                        queryIndexInDoc,
+                        templatedVariables,
+                        isFullScreen,
+                        toggleFullScreen,
+                    };
+                    cellDOM = <DataDocQueryCell {...allProps} />;
+                } else if (cell.cell_type === 'chart') {
+                    cellDOM = (
+                        <DataDocChartCell
+                            {...cellProps}
+                            previousQueryCellId={lastQueryCellId}
+                            context={cell.context}
+                            meta={cell.meta}
+                            dataDocId={docId}
+                        />
+                    );
+                } else if (cell.cell_type === 'text') {
+                    // default text
+                    cellDOM = (
+                        <DataDocTextCell
+                            {...cellProps}
+                            cellId={cell.id}
+                            context={cell.context}
+                        />
+                    );
+                }
+
+                return cellDOM;
             };
 
-            let cellDOM = null;
-            if (cell.cell_type === 'query') {
-                const allProps = {
-                    ...cellProps,
-                    query: cell.context,
-                    docId,
-                    cellId: cell.id,
-                    queryIndexInDoc,
-                    templatedVariables,
-                    isFullScreen,
-                    toggleFullScreen,
-                };
-                cellDOM = <DataDocQueryCell {...allProps} />;
-            } else if (cell.cell_type === 'chart') {
-                cellDOM = (
-                    <DataDocChartCell
-                        {...cellProps}
-                        previousQueryCellId={lastQueryCellId}
-                        context={cell.context}
-                        meta={cell.meta}
-                        dataDocId={docId}
+            const renderCellControlDOM = (
+                idx: number,
+                isHeaderParam: boolean
+            ) => (
+                <div className={'data-doc-cell-divider-container'}>
+                    <DataDocCellControl
+                        index={idx}
+                        numberOfCells={numberOfCells}
+                        moveCellAt={handleMoveCell}
+                        pasteCellAt={pasteCellAt}
+                        copyCellAt={copyCellAt}
+                        insertCellAt={insertCellAt}
+                        deleteCellAt={handleDeleteCell}
+                        isHeader={isHeaderParam}
+                        isEditable={isEditable}
+                        showCollapsed={showCollapsed}
+                        setShowCollapsed={setShowCollapsed}
+                        isCollapsedDefault={
+                            Boolean(cell.meta.collapsed) === showCollapsed
+                        }
+                        toggleDefaultCollapsed={handleDefaultCollapseChange}
+                        shareUrl={shareUrl}
                     />
-                );
-            } else if (cell.cell_type === 'text') {
-                // default text
-                cellDOM = (
-                    <DataDocTextCell
-                        {...cellProps}
-                        cellId={cell.id}
-                        context={cell.context}
-                    />
-                );
-            }
-
-            return cellDOM;
-        };
-
-        const renderCellControlDOM = (idx: number, isHeaderParam: boolean) => (
-            <div className={'data-doc-cell-divider-container'}>
-                <DataDocCellControl
-                    index={idx}
-                    numberOfCells={numberOfCells}
-                    moveCellAt={handleMoveCell}
-                    pasteCellAt={pasteCellAt}
-                    copyCellAt={copyCellAt}
-                    insertCellAt={insertCellAt}
-                    deleteCellAt={handleDeleteCell}
-                    isHeader={isHeaderParam}
-                    isEditable={isEditable}
-                    showCollapsed={showCollapsed}
-                    setShowCollapsed={setShowCollapsed}
-                    isCollapsedDefault={
-                        Boolean(cell.meta.collapsed) === showCollapsed
-                    }
-                    toggleDefaultCollapsed={handleDefaultCollapseChange}
-                    shareUrl={shareUrl}
-                />
-            </div>
-        );
-        const uids = cellIdtoUid[cell.id] || [];
-        const uidDOM = uids.map((uid) => (
-            <UserAvatar key={uid} uid={uid} tiny />
-        ));
-        const dataDocCellClassName = showCollapsed
-            ? 'DataDocCell collapsed'
-            : 'DataDocCell';
-        const innerCellClassName = clsx({
-            'highlight-cell': highlightCellIndex === index,
-            'data-doc-cell-container-pair': true,
-        });
-
-        const innerCellContentDOM = (
-            <div className={innerCellClassName}>
-                <div className="data-doc-cell-users flex-column">{uidDOM}</div>
-                {renderCellControlDOM(index, true)}
-                <div
-                    className={dataDocCellClassName}
-                    onClick={showCollapsed ? uncollapseCell : null}
-                >
-                    {renderCell()}
                 </div>
-                {renderCellControlDOM(index + 1, false)}
-            </div>
-        );
+            );
+            const uids = cellIdtoUid[cell.id] || [];
+            const uidDOM = uids.map((uid) => (
+                <UserAvatar key={uid} uid={uid} tiny />
+            ));
+            const dataDocCellClassName = showCollapsed
+                ? 'DataDocCell collapsed'
+                : 'DataDocCell';
+            const innerCellClassName = clsx({
+                'highlight-cell': highlightCellIndex === index,
+                'data-doc-cell-container-pair': true,
+            });
 
-        return (
-            <DataDocCellWrapper
-                cellKey={String(cell.id)}
-                placeholderHeight={getEstimatedCellHeight(cell)}
-                key={cell.id}
-            >
-                {innerCellContentDOM}
-            </DataDocCellWrapper>
-        );
-    }
-);
+            const innerCellContentDOM = (
+                <div className={innerCellClassName}>
+                    <div className="data-doc-cell-users flex-column">
+                        {uidDOM}
+                    </div>
+                    {renderCellControlDOM(index, true)}
+                    <div
+                        className={dataDocCellClassName}
+                        onClick={showCollapsed ? uncollapseCell : null}
+                    >
+                        {renderCell()}
+                    </div>
+                    {renderCellControlDOM(index + 1, false)}
+                </div>
+            );
+
+            return (
+                <DataDocCellWrapper
+                    cellKey={String(cell.id)}
+                    placeholderHeight={getEstimatedCellHeight(cell)}
+                    key={cell.id}
+                >
+                    {innerCellContentDOM}
+                </DataDocCellWrapper>
+            );
+        }
+    );

--- a/querybook/webapp/redux/dataDoc/action.ts
+++ b/querybook/webapp/redux/dataDoc/action.ts
@@ -56,7 +56,7 @@ const dataCellSaveManager = new DataCellSaveManager();
 
 export function deserializeCell(cell: IDataCell) {
     if (cell.cell_type === 'text') {
-        const rawContext = (cell.context as any) as string;
+        const rawContext = cell.context as any as string;
         const context: ContentState = convertRawToContentState(rawContext);
 
         const newCell: IDataTextCell = {
@@ -304,17 +304,11 @@ export function insertDataDocCell(
     };
 }
 
-export function deleteDataDocCell(
-    docId: number,
-    index: number
-): Promise<Record<string, unknown>> {
-    return dataDocSocket.deleteDataCell(docId, index);
+export function deleteDataDocCell(docId: number, cellId: number) {
+    return dataDocSocket.deleteDataCell(docId, cellId);
 }
 
-export function moveDataDocCursor(
-    docId: number,
-    cellId?: number
-): Promise<any> {
+export function moveDataDocCursor(docId: number, cellId?: number) {
     return dataDocSocket.moveDataDocCursor(docId, cellId);
 }
 
@@ -322,7 +316,7 @@ export function moveDataDocCell(
     docId: number,
     fromIndex: number,
     toIndex: number
-): Promise<any> {
+) {
     return dataDocSocket.moveDataDocCell(docId, fromIndex, toIndex);
 }
 
@@ -331,7 +325,7 @@ export function pasteDataCell(
     cut: boolean,
     docId: number,
     index: number
-): Promise<any> {
+) {
     return dataDocSocket.pasteDataCell(cellId, cut, docId, index);
 }
 
@@ -363,7 +357,8 @@ export function updateDataDocCell(
         return dataCellSaveManager
             .saveDataCell(docId, id, context, meta, saveCellTimeout)
             .then(onSave.bind(null, false), (e) => {
-                onSave.bind(null, false); // on failure, we pretend it saved!
+                // Clear the saving status
+                onSave(false);
                 throw e; // keep it up with the rejection chain
             });
     };

--- a/querybook/webapp/redux/dataDoc/reducer.ts
+++ b/querybook/webapp/redux/dataDoc/reducer.ts
@@ -113,15 +113,16 @@ function dataDocCellsArrayHelper(cells: number[] = [], action: DataDocAction) {
                 cell: { id },
                 index,
             } = action.payload;
-
-            return [...cells.slice(0, index), id, ...cells.slice(index)];
+            const filteredCells = cells.filter((cell) => cell !== id);
+            return [
+                ...filteredCells.slice(0, index),
+                id,
+                ...filteredCells.slice(index),
+            ];
         }
         case '@@dataDoc/DELETE_DATA_DOC_CELL': {
-            const { index } = action.payload;
-            const newCells = [...cells];
-            newCells.splice(index, 1);
-
-            return newCells;
+            const { cellId } = action.payload;
+            return cells.filter((id) => id !== cellId);
         }
         case '@@dataDoc/MOVE_DATA_DOC_CELL': {
             const { fromIndex, toIndex } = action.payload;

--- a/querybook/webapp/redux/dataDoc/types.ts
+++ b/querybook/webapp/redux/dataDoc/types.ts
@@ -86,7 +86,7 @@ export interface IInsertDataDocCellAction extends Action {
 export interface IDeleteDataDocCellAction extends Action {
     type: '@@dataDoc/DELETE_DATA_DOC_CELL';
     payload: {
-        index: number;
+        cellId: number;
         docId: number;
     };
 }

--- a/querybook/webapp/redux/dataDocWebsocket/dataDocWebsocket.ts
+++ b/querybook/webapp/redux/dataDocWebsocket/dataDocWebsocket.ts
@@ -20,9 +20,8 @@ export function openDataDoc(docId: number): ThunkResult<Promise<any>> {
         const dataDocEventMap: IDataDocSocketEvent = {
             receiveDataDoc: {
                 resolve: (rawDataDoc) => {
-                    const { dataDoc, dataDocCellById } = normalizeRawDataDoc(
-                        rawDataDoc
-                    );
+                    const { dataDoc, dataDocCellById } =
+                        normalizeRawDataDoc(rawDataDoc);
                     dispatch(receiveDataDoc(dataDoc, dataDocCellById));
                 },
             },
@@ -95,12 +94,12 @@ export function openDataDoc(docId: number): ThunkResult<Promise<any>> {
             },
 
             deleteDataCell: {
-                resolve: (index) => {
+                resolve: (cellId) => {
                     dispatch({
                         type: '@@dataDoc/DELETE_DATA_DOC_CELL',
                         payload: {
                             docId,
-                            index,
+                            cellId,
                         },
                     });
                 },
@@ -171,8 +170,7 @@ export function openDataDoc(docId: number): ThunkResult<Promise<any>> {
                     if (!isSameOrigin) {
                         if (request) {
                             dispatch({
-                                type:
-                                    '@@dataDoc/RECEIVE_DATA_DOC_ACCESS_REQUEST',
+                                type: '@@dataDoc/RECEIVE_DATA_DOC_ACCESS_REQUEST',
                                 payload: {
                                     docId: requestDocId,
                                     request,
@@ -180,8 +178,7 @@ export function openDataDoc(docId: number): ThunkResult<Promise<any>> {
                             });
                         } else {
                             dispatch({
-                                type:
-                                    '@@dataDoc/REMOVE_DATA_DOC_ACCESS_REQUEST',
+                                type: '@@dataDoc/REMOVE_DATA_DOC_ACCESS_REQUEST',
                                 payload: {
                                     docId: requestDocId,
                                     uid,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14072,10 +14072,10 @@ prettier-eslint@^11.0.0:
     typescript "^3.9.3"
     vue-eslint-parser "~7.1.0"
 
-prettier@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
-  integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==
+prettier@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 prettier@^2.0.0:
   version "2.0.5"


### PR DESCRIPTION
- Error for updating cell will show properly, and the error message will display
- Insert is now server side idempotent. If the server sends multiple insert. Only the last one will be applied
- delete is now idempotent, both server send and client send event will only be processed once