### PR TITLE
fix: error handling for update cell, insert/delete idempotent

### DIFF
--- a/querybook/server/datasources/datadoc.py
+++ b/querybook/server/datasources/datadoc.py
@@ -149,9 +149,9 @@ def paste_data_cell(cell_id, cut, doc_id, index):
     return datadoc_collab.paste_data_cell(cell_id, cut, doc_id, index)
 
 
-@register("/datadoc/<int:doc_id>/cell/<int:index>/", methods=["DELETE"])
-def delete_data_cell_from_doc(doc_id, index):
-    return datadoc_collab.delete_data_cell(doc_id, index)
+@register("/datadoc/<int:doc_id>/cell/<int:cell_id>/", methods=["DELETE"])
+def delete_data_cell_from_doc(doc_id, cell_id):
+    return datadoc_collab.delete_data_cell(doc_id, cell_id)
 
 
 @register("/datadoc/<int:id>/clone/", methods=["POST"])

--- a/querybook/server/datasources_socketio/datadoc.py
+++ b/querybook/server/datasources_socketio/datadoc.py
@@ -228,8 +228,8 @@ def update_data_cell(doc_id, cell_id, fields):
 
 @register_socket("delete_data_cell", namespace=DATA_DOC_NAMESPACE)
 @data_doc_socket
-def delete_data_cell(doc_id, index):
-    datadoc_collab.delete_data_cell(doc_id, index, sid=request.sid)
+def delete_data_cell(doc_id, cell_id):
+    datadoc_collab.delete_data_cell(doc_id, cell_id, sid=request.sid)
 
 
 @register_socket("move_data_cell", namespace=DATA_DOC_NAMESPACE)

--- a/querybook/server/lib/data_doc/data_cell.py
+++ b/querybook/server/lib/data_doc/data_cell.py
@@ -1,0 +1,58 @@
+from lib.config import get_config_value
+
+cell_types = get_config_value("datadoc.cell_types")
+
+
+def get_valid_meta(input_vals, valid_vals, default_vals=None):
+    if type(input_vals) != type(valid_vals):
+        raise ValueError(
+            f"Invalid meta type, expected {type(valid_vals)} actual {type(input_vals)}"
+        )
+
+    if input_vals is None:
+        return default_vals
+
+    if isinstance(valid_vals, dict):
+        return_obj = {}
+        for valid_key, valid_val in valid_vals.items():
+            if valid_key in input_vals:
+                return_obj[valid_key] = get_valid_meta(
+                    input_vals=input_vals[valid_key],
+                    valid_vals=valid_val,
+                    default_vals=(
+                        default_vals.get(valid_key) if default_vals else None
+                    ),
+                )
+            # only for series obj
+            elif type(valid_key) == int:
+                valid_keys = list(list(valid_vals.values())[0].keys())
+                if all(
+                    all([i in valid_keys for i in item]) for item in input_vals.values()
+                ):
+                    return input_vals
+        return return_obj
+    elif isinstance(valid_vals, list):
+        return [
+            get_valid_meta(
+                input_vals=input_val,
+                valid_vals=valid_vals[0],
+                default_vals=(default_vals or [None])[0],
+            )
+            for input_val in input_vals
+        ]
+    else:
+        return input_vals
+
+
+def sanitize_data_cell_meta(cell_type: str, meta):
+    cell_type_info = cell_types[cell_type]
+
+    valid_dict = cell_type_info["meta"]
+    default_dict = cell_type_info["meta_default"]
+
+    if meta is None:
+        return default_dict
+
+    return get_valid_meta(
+        input_vals=meta, valid_vals=valid_dict, default_vals=default_dict
+    )

--- a/querybook/server/logic/datadoc.py
+++ b/querybook/server/logic/datadoc.py
@@ -4,8 +4,8 @@ from sqlalchemy import func
 from app.db import with_session
 from const.elasticsearch import ElasticsearchItem
 from const.impression import ImpressionItemType
-from lib.config import get_config_value
 from lib.sqlalchemy import update_model_fields
+from lib.data_doc.data_cell import cell_types, sanitize_data_cell_meta
 from models.datadoc import (
     DataDoc,
     DataDocDataCell,
@@ -19,8 +19,6 @@ from models.datadoc import (
 from models.access_request import AccessRequest
 from models.impression import Impression
 from tasks.sync_elasticsearch import sync_elasticsearch
-
-cell_types = get_config_value("datadoc.cell_types")
 
 
 """
@@ -233,59 +231,6 @@ def clone_data_doc(id, owner_uid, commit=True, session=None):
 """
 
 
-def get_valid_meta(input_vals, valid_vals, default_vals=None):
-    if type(input_vals) != type(valid_vals):
-        raise ValueError("Invalid meta type")
-
-    if input_vals is None:
-        return default_vals
-
-    if isinstance(valid_vals, dict):
-        return_obj = {}
-        for valid_key, valid_val in valid_vals.items():
-            if valid_key in input_vals:
-                return_obj[valid_key] = get_valid_meta(
-                    input_vals=input_vals[valid_key],
-                    valid_vals=valid_val,
-                    default_vals=(
-                        default_vals.get(valid_key) if default_vals else None
-                    ),
-                )
-            # only for series obj
-            elif type(valid_key) == int:
-                valid_keys = list(list(valid_vals.values())[0].keys())
-                if all(
-                    all([i in valid_keys for i in item]) for item in input_vals.values()
-                ):
-                    return input_vals
-        return return_obj
-    elif isinstance(valid_vals, list):
-        return [
-            get_valid_meta(
-                input_vals=input_val,
-                valid_vals=valid_vals[0],
-                default_vals=(default_vals or [None])[0],
-            )
-            for input_val in input_vals
-        ]
-    else:
-        return input_vals
-
-
-def sanitize_data_cell_meta(cell_type: str, meta):
-    cell_type_info = cell_types[cell_type]
-
-    valid_dict = cell_type_info["meta"]
-    default_dict = cell_type_info["meta_default"]
-
-    if meta is None:
-        return default_dict
-
-    return get_valid_meta(
-        input_vals=meta, valid_vals=valid_dict, default_vals=default_dict
-    )
-
-
 @with_session
 def create_data_cell(
     cell_type=None, context=None, meta=None, commit=True, session=None
@@ -410,14 +355,22 @@ def insert_data_doc_cell(data_doc_id, cell_id, index, commit=True, session=None)
 
 
 @with_session
-def delete_data_doc_cell(data_doc_id, index, commit=True, session=None):
+def delete_data_doc_cell(data_doc_id, data_cell_id, commit=True, session=None):
     data_doc = get_data_doc_by_id(data_doc_id, session=session)
-    assert index >= 0 and index < len(data_doc.cells), "Invalid cell index to delete"
 
-    session.query(DataDocDataCell).filter(
-        DataDocDataCell.data_doc_id == data_doc_id
-    ).filter(DataDocDataCell.cell_order == index).delete()
+    data_doc_data_cell = (
+        session.query(DataDocDataCell)
+        .filter_by(data_doc_id=data_doc_id, data_cell_id=data_cell_id)
+        .first()
+    )
 
+    assert data_doc_data_cell is not None, "Invalid cell to delete"
+
+    index = data_doc_data_cell.cell_order
+    # Remove the cell from the doc
+    session.delete(data_doc_data_cell)
+
+    # Shift cells below up by 1
     session.query(DataDocDataCell).filter(
         DataDocDataCell.data_doc_id == data_doc_id
     ).filter(DataDocDataCell.cell_order > index).update(

--- a/querybook/server/logic/datadoc_collab.py
+++ b/querybook/server/logic/datadoc_collab.py
@@ -139,7 +139,7 @@ def paste_data_cell(
             )
             socketio.emit(
                 "data_cell_deleted",
-                (sid, index,),
+                (sid, cell_id,),
                 namespace=DATA_DOC_NAMESPACE,
                 room=old_data_doc.id,
                 broadcast=True,
@@ -191,14 +191,16 @@ def update_data_cell(cell_id, fields, sid="", session=None):
 
 
 @with_session
-def delete_data_cell(doc_id, index, sid="", session=None):
+def delete_data_cell(doc_id, cell_id, sid="", session=None):
     assert_can_write(doc_id, session=session)
     verify_data_doc_permission(doc_id, session=session)
-    logic.delete_data_doc_cell(data_doc_id=doc_id, index=int(index), session=session)
+    logic.delete_data_doc_cell(
+        data_doc_id=doc_id, data_cell_id=int(cell_id), session=session
+    )
 
     socketio.emit(
         "data_cell_deleted",
-        (sid, index,),
+        (sid, cell_id,),
         namespace=DATA_DOC_NAMESPACE,
         room=doc_id,
         broadcast=True,

--- a/querybook/webapp/components/DataDoc/DataDoc.tsx
+++ b/querybook/webapp/components/DataDoc/DataDoc.tsx
@@ -841,13 +841,15 @@ function mapDispatchToProps(dispatch: Dispatch) {
                 )
             ),
 
-        updateDataDocCell: (
+        updateDataDocCell: async (
             docId: number,
             cellId: number,
             fields: DataCellUpdateFields
         ) => {
             try {
-                return dispatch(
+                // Await the result so it can be caught by
+                // try catch
+                return await dispatch(
                     dataDocActions.updateDataDocCell(
                         docId,
                         cellId,

--- a/querybook/webapp/components/DataDocCell/DataDocCell.tsx
+++ b/querybook/webapp/components/DataDocCell/DataDocCell.tsx
@@ -130,7 +130,7 @@ export const DataDocCell: React.FunctionComponent<IDataDocCellProps> = React.mem
                             try {
                                 await dataDocActions.deleteDataDocCell(
                                     docId,
-                                    index
+                                    cell.id
                                 );
                             } catch (e) {
                                 toast.error(`Delete cell failed, reason: ${e}`);
@@ -148,7 +148,7 @@ export const DataDocCell: React.FunctionComponent<IDataDocCellProps> = React.mem
                         resolve();
                     }
                 }),
-            [docId, numberOfCells, index]
+            [docId, numberOfCells, cell.id]
         );
 
         const shareUrl = useMemo(

--- a/querybook/webapp/lib/batch/batch-manager.ts
+++ b/querybook/webapp/lib/batch/batch-manager.ts
@@ -7,7 +7,7 @@ export interface IBatchManagerOptions<T, M> {
 interface IBatchPromise<T> {
     data: T;
     onSuccess: () => void;
-    onFailure: () => void;
+    onFailure: (e: unknown) => void;
 }
 
 export function pickLastMergeFunction<T, M>(changes: Array<IBatchPromise<T>>) {
@@ -37,7 +37,7 @@ export function mergeSetFunction<T>(changes: Array<IBatchPromise<T>>) {
     return {
         data: [...new Set(changes.map((c) => c.data))],
         onSuccess: () => changes.forEach((c) => c.onSuccess()),
-        onFailure: () => changes.forEach((c) => c.onFailure()),
+        onFailure: (e: unknown) => changes.forEach((c) => c.onFailure(e)),
     };
 }
 
@@ -112,7 +112,7 @@ export class BatchManager<T, M> {
             await this.processRequest;
             onSuccess();
         } catch (e) {
-            onFailure();
+            onFailure(e);
         } finally {
             this.processRequest = null;
         }

--- a/querybook/webapp/redux/dataDoc/action.ts
+++ b/querybook/webapp/redux/dataDoc/action.ts
@@ -304,17 +304,11 @@ export function insertDataDocCell(
     };
 }
 
-export function deleteDataDocCell(
-    docId: number,
-    index: number
-): Promise<Record<string, unknown>> {
-    return dataDocSocket.deleteDataCell(docId, index);
+export function deleteDataDocCell(docId: number, cellId: number) {
+    return dataDocSocket.deleteDataCell(docId, cellId);
 }
 
-export function moveDataDocCursor(
-    docId: number,
-    cellId?: number
-): Promise<any> {
+export function moveDataDocCursor(docId: number, cellId?: number) {
     return dataDocSocket.moveDataDocCursor(docId, cellId);
 }
 
@@ -322,7 +316,7 @@ export function moveDataDocCell(
     docId: number,
     fromIndex: number,
     toIndex: number
-): Promise<any> {
+) {
     return dataDocSocket.moveDataDocCell(docId, fromIndex, toIndex);
 }
 
@@ -331,7 +325,7 @@ export function pasteDataCell(
     cut: boolean,
     docId: number,
     index: number
-): Promise<any> {
+) {
     return dataDocSocket.pasteDataCell(cellId, cut, docId, index);
 }
 
@@ -363,7 +357,8 @@ export function updateDataDocCell(
         return dataCellSaveManager
             .saveDataCell(docId, id, context, meta, saveCellTimeout)
             .then(onSave.bind(null, false), (e) => {
-                onSave.bind(null, false); // on failure, we pretend it saved!
+                // Clear the saving status
+                onSave(false);
                 throw e; // keep it up with the rejection chain
             });
     };

--- a/querybook/webapp/redux/dataDoc/reducer.ts
+++ b/querybook/webapp/redux/dataDoc/reducer.ts
@@ -113,15 +113,16 @@ function dataDocCellsArrayHelper(cells: number[] = [], action: DataDocAction) {
                 cell: { id },
                 index,
             } = action.payload;
-
-            return [...cells.slice(0, index), id, ...cells.slice(index)];
+            const filteredCells = cells.filter((cell) => cell !== id);
+            return [
+                ...filteredCells.slice(0, index),
+                id,
+                ...filteredCells.slice(index),
+            ];
         }
         case '@@dataDoc/DELETE_DATA_DOC_CELL': {
-            const { index } = action.payload;
-            const newCells = [...cells];
-            newCells.splice(index, 1);
-
-            return newCells;
+            const { cellId } = action.payload;
+            return cells.filter((id) => id !== cellId);
         }
         case '@@dataDoc/MOVE_DATA_DOC_CELL': {
             const { fromIndex, toIndex } = action.payload;

--- a/querybook/webapp/redux/dataDoc/types.ts
+++ b/querybook/webapp/redux/dataDoc/types.ts
@@ -86,7 +86,7 @@ export interface IInsertDataDocCellAction extends Action {
 export interface IDeleteDataDocCellAction extends Action {
     type: '@@dataDoc/DELETE_DATA_DOC_CELL';
     payload: {
-        index: number;
+        cellId: number;
         docId: number;
     };
 }

--- a/querybook/webapp/redux/dataDocWebsocket/dataDocWebsocket.ts
+++ b/querybook/webapp/redux/dataDocWebsocket/dataDocWebsocket.ts
@@ -95,12 +95,12 @@ export function openDataDoc(docId: number): ThunkResult<Promise<any>> {
             },
 
             deleteDataCell: {
-                resolve: (index) => {
+                resolve: (cellId) => {
                     dispatch({
                         type: '@@dataDoc/DELETE_DATA_DOC_CELL',
                         payload: {
                             docId,
-                            index,
+                            cellId,
                         },
                     });
                 },


### PR DESCRIPTION
- Error for updating cell will show properly, and the error message will display
- Insert is now server side idempotent. If the server sends multiple insert. Only the last one will be applied
- delete is now idempotent, both server send and client send event will only be processed once