### PR TITLE
fix: redirect user for download instead of proxy

### DIFF
--- a/querybook/server/datasources/query_execution.py
+++ b/querybook/server/datasources/query_execution.py
@@ -1,11 +1,7 @@
 from typing import Dict
 
-from flask import (
-    abort,
-    Response,
-)
+from flask import abort, Response, redirect
 from flask_login import current_user
-import requests
 
 from app.flask_app import socketio
 from app.datasource import register, api_assert, RequestException
@@ -205,12 +201,9 @@ def download_statement_execution_result(statement_execution_id):
         response = None
         if reader.has_download_url:
             # If the Reader can generate a download,
-            # we proxy download the file
+            # we let user download the file by redirection
             download_url = reader.get_download_url()
-            req = requests.get(download_url, stream=True)
-
-            # 10 KB size
-            response = Response(req.iter_content(chunk_size=10 * 1024))
+            response = redirect(download_url)
         else:
             # We read the raw file and download it for the user
             reader.start()


### PR DESCRIPTION
Since flask stream download is prone to breaking, share the URL directly with the user instead