### PR TITLE
fix: container ui overflow issue

### DIFF
--- a/querybook/webapp/components/Search/SearchOverview.scss
+++ b/querybook/webapp/components/Search/SearchOverview.scss
@@ -37,8 +37,7 @@
 
     .search-body {
         background-color: var(--light-bg-color);
-        overflow-y: auto;
-        overflow-x: hidden;
+        overflow: auto;
         padding: 12px 16px;
         flex: 1;
 

--- a/querybook/webapp/ui/Container/Container.scss
+++ b/querybook/webapp/ui/Container/Container.scss
@@ -1,9 +1,15 @@
 .Container {
     display: flex;
-    justify-content: center;
+    flex-flow: row nowrap;
 
     .Container-content {
         max-width: var(--max-width);
         flex: 1;
+    }
+
+    &::before,
+    &::after {
+        content: ''; /* Insert pseudo-element */
+        margin: auto; /* Make it push flex items to the center */
     }
 }


### PR DESCRIPTION
Container overflow was clipped because justify-content: center didn't handle overflow well. Use pseudo elements with margin auto instead.

Stackoverflow reference: https://stackoverflow.com/questions/34184535/change-justify-content-value-when-flex-items-overflow-container