### PR TITLE
fix: chart metadata handling issue

### DIFF
--- a/querybook/config/datadoc.yaml
+++ b/querybook/config/datadoc.yaml
@@ -43,16 +43,16 @@ cell_types:
                     col_idx: 0
                     label: ''
                     scale: ''
-                    min: 0
-                    max: 0
+                    min: 0.0
+                    max: 0.0
                     sort:
                         idx: 0
                         asc: true
                 y_axis:
                     label: ''
                     scale: ''
-                    min: 0
-                    max: 0
+                    min: 0.0
+                    max: 0.0
                     stack: false
                     series:
                         0:

--- a/querybook/server/lib/data_doc/data_cell.py
+++ b/querybook/server/lib/data_doc/data_cell.py
@@ -3,17 +3,6 @@ from lib.config import get_config_value
 cell_types = get_config_value("datadoc.cell_types")
 
 
-def _validate_series(valid_val, input_val):
-    valid_series_keys = valid_val[0].keys()
-    # Do a shallow key validation
-    if all(
-        all([item_key in valid_series_keys for item_key in series_item])
-        for series_item in input_val.values()
-    ):
-        return True
-    return False
-
-
 def get_valid_meta(input_vals, valid_vals, default_vals=None):
     if input_vals is None:
         return default_vals
@@ -54,6 +43,15 @@ def get_valid_meta(input_vals, valid_vals, default_vals=None):
         ]
     else:
         return input_vals
+
+
+def _validate_series(valid_val, input_val):
+    valid_series_keys = valid_val[0].keys()
+    # Do a shallow key validation
+    return all(
+        all([item_key in valid_series_keys for item_key in series_item])
+        for series_item in input_val.values()
+    )
 
 
 def sanitize_data_cell_meta(cell_type: str, meta):

--- a/querybook/server/lib/data_doc/data_cell.py
+++ b/querybook/server/lib/data_doc/data_cell.py
@@ -3,33 +3,45 @@ from lib.config import get_config_value
 cell_types = get_config_value("datadoc.cell_types")
 
 
+def _validate_series(valid_val, input_val):
+    valid_series_keys = valid_val[0].keys()
+    # Do a shallow key validation
+    if all(
+        all([item_key in valid_series_keys for item_key in series_item])
+        for series_item in input_val.values()
+    ):
+        return True
+    return False
+
+
 def get_valid_meta(input_vals, valid_vals, default_vals=None):
-    if type(input_vals) != type(valid_vals):
+    if input_vals is None:
+        return default_vals
+
+    if not check_type_match(input_vals, valid_vals):
         raise ValueError(
             f"Invalid meta type, expected {type(valid_vals)} actual {type(input_vals)}"
         )
-
-    if input_vals is None:
-        return default_vals
 
     if isinstance(valid_vals, dict):
         return_obj = {}
         for valid_key, valid_val in valid_vals.items():
             if valid_key in input_vals:
-                return_obj[valid_key] = get_valid_meta(
-                    input_vals=input_vals[valid_key],
-                    valid_vals=valid_val,
-                    default_vals=(
-                        default_vals.get(valid_key) if default_vals else None
-                    ),
-                )
-            # only for series obj
-            elif type(valid_key) == int:
-                valid_keys = list(list(valid_vals.values())[0].keys())
-                if all(
-                    all([i in valid_keys for i in item]) for item in input_vals.values()
-                ):
-                    return input_vals
+                # only for series object for chart y_axis
+                if valid_key == "series" and type(valid_val) is dict and 0 in valid_val:
+                    if _validate_series(valid_val, input_vals["series"]):
+                        return_obj[valid_key] = input_vals["series"]
+                    else:
+                        raise ValueError("Invalid meta type for axis series")
+                else:
+                    # Normal case, iterate all keys
+                    return_obj[valid_key] = get_valid_meta(
+                        input_vals=input_vals[valid_key],
+                        valid_vals=valid_val,
+                        default_vals=(
+                            default_vals.get(valid_key) if default_vals else None
+                        ),
+                    )
         return return_obj
     elif isinstance(valid_vals, list):
         return [
@@ -56,3 +68,27 @@ def sanitize_data_cell_meta(cell_type: str, meta):
     return get_valid_meta(
         input_vals=meta, valid_vals=valid_dict, default_vals=default_dict
     )
+
+
+def check_type_match(actual_val, expected_val) -> bool:
+    """Check actual_val matches type of expected_val
+       The exception here is that expected_val can be
+       float, and in that case actual_val can be either
+       int or float
+
+    Args:
+        actual_val (Any): Actual type
+        expected_val (Any): Expected type
+
+    Returns:
+        bool: Whether the type matches
+    """
+    if type(actual_val) == type(expected_val):
+        return True
+
+    # Make an exception here since int can be represented as float
+    # But not vice versa (for example, index)
+    if type(expected_val) == float and type(actual_val) == int:
+        return True
+
+    return False

--- a/querybook/tests/test_lib/test_data_doc/test_data_cell.py
+++ b/querybook/tests/test_lib/test_data_doc/test_data_cell.py
@@ -1,0 +1,94 @@
+from unittest import TestCase
+
+from lib.data_doc.data_cell import get_valid_meta, check_type_match
+
+
+class CheckTypeMatchTestCase(TestCase):
+    def test_check_same(self):
+        self.assertTrue(check_type_match(1, 2))
+        self.assertTrue(check_type_match(1.5, 1.0))
+        self.assertTrue(check_type_match(1, 0.0))
+        self.assertTrue(check_type_match("a", "b"))
+        self.assertTrue(check_type_match({"a": 1}, {"b": 2}))
+        self.assertTrue(check_type_match([0, 1, 2], [3, 4, 5]))
+
+    def test_check_different(self):
+        self.assertFalse(check_type_match(0.0, 1))
+        self.assertFalse(check_type_match(1, "1"))
+        self.assertFalse(check_type_match({}, {"a"}))
+
+
+class GetValidMetaTestCase(TestCase):
+    def test_simple(self):
+        self.assertEqual(get_valid_meta(2, 1), 2)
+        self.assertEqual(get_valid_meta("Hello", "World"), "Hello")
+        self.assertEqual(get_valid_meta(1, 1.5), 1)
+        self.assertEqual(get_valid_meta(0.5, 1.5), 0.5)
+
+    def test_default(self):
+        self.assertEqual(get_valid_meta(None, 1.5, 0.5), 0.5)
+        self.assertEqual(
+            get_valid_meta(
+                {"a": 2, "b": None}, {"a": 1, "b": ""}, {"a": 100, "b": "Hello"}
+            ),
+            {"a": 2, "b": "Hello"},
+        )
+
+    def test_invalid(self):
+        with self.assertRaises(ValueError):
+            get_valid_meta("a", 1)
+
+        with self.assertRaises(ValueError):
+            get_valid_meta(1, "a")
+
+        with self.assertRaises(ValueError):
+            get_valid_meta(1.5, 1)
+
+    def test_nested_dict(self):
+        meta = {"title": "Test", "engine": 20, "meta": {"field1": "a", "field2": "b"}}
+        meta_type = {"title": "", "engine": 0, "meta": {"field1": "", "field2": ""}}
+        self.assertEqual(
+            get_valid_meta(meta, meta_type), meta,
+        )
+
+        # Missing
+        meta = {"title": "Test2"}
+        self.assertEqual(
+            get_valid_meta(meta, meta_type), meta,
+        )
+
+        # Extra
+        meta = {"title": "Test3", "newProp": 2}
+        self.assertEqual(
+            get_valid_meta(meta, meta_type), {"title": "Test3"},
+        )
+
+    def test_nested_array(self):
+        self.assertEqual(
+            get_valid_meta(
+                [
+                    {"title": "Test", "price": 1},
+                    {"title": "Hello", "price": None},
+                    {"title": None, "price": 3},
+                ],
+                [{"title": "", "price": 0}],
+                [{"title": "World", "price": 2}],
+            ),
+            [
+                {"title": "Test", "price": 1},
+                {"title": "Hello", "price": 2},
+                {"title": "World", "price": 3},
+            ],
+        )
+
+    def test_series(self):
+        series_meta = {
+            "series": {
+                "0": {"source": 2, "color": 1},
+                "1": {"source": 3, "color": 4},
+                "3": {"source": 5, "color": 6},
+            }
+        }
+        series_meta_type = {"series": {0: {"source": 0, "color": 0}}}
+        print(get_valid_meta(series_meta, series_meta_type))
+        self.assertDictEqual(get_valid_meta(series_meta, series_meta_type), series_meta)

--- a/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
@@ -281,15 +281,7 @@ const DataDocChartComposerComponent: React.FunctionComponent<
             }));
             return options;
         },
-        [
-            chartData,
-            statementResultData,
-            values.xIndex,
-            values.hiddenSeries,
-            values.coloredSeries,
-            values.aggregate,
-            values.switch,
-        ]
+        [chartData, values.xIndex, values.hiddenSeries, values.coloredSeries]
     );
 
     const getAxesScaleType = React.useCallback(
@@ -323,7 +315,7 @@ const DataDocChartComposerComponent: React.FunctionComponent<
     ) => {
         const hiddenSeries = [];
         const selectedSeries = selectedVals.map((obj) => obj.value);
-        for (let i = 0; i < statementResultData[0].length; i++) {
+        for (let i = 0; i < chartData[0].length; i++) {
             if (i !== values.xIndex && !selectedSeries.includes(i)) {
                 hiddenSeries.push(i);
             }


### PR DESCRIPTION
Make sure backend meta validation would handle float and int as expected. This means
actual: int, expected: float would pass validation
actual: float, expected: int would fail the validation
The old validation logic remains as is.


For frontend, make sure hiddenSeries uses chartData instead of query data to account for transformations. 