### PR TITLE
major: add ability to customize download name

### DIFF
--- a/docs_website/docs/changelog/2020-11-30.md
+++ b/docs_website/docs/changelog/2020-11-30.md
@@ -2,7 +2,6 @@
 id: nov_2020_2_4_2
 title: Nov 2020 (version 2.4.2)
 sidebar_label: Nov 2020 (2.4.2)
-slug: /changelog
 ---
 
 Welcome to the last release of Querybook for 2020.

--- a/docs_website/docs/changelog/breaking_change.md
+++ b/docs_website/docs/changelog/breaking_change.md
@@ -1,0 +1,12 @@
+---
+id: breaking_changes
+title: Breaking Changes
+sidebar_label: Breaking Changes
+slug: /changelog
+---
+
+Here are the list of breaking changes that you should be aware of when updating Querybook:
+
+## v2.8.0
+
+Result store plugin change. Now BaseReader::get_download_url requires a custom_name field to rename the download file. You only need to add the `custom_name=None` in the parameters for it to work.

--- a/docs_website/sidebars.json
+++ b/docs_website/sidebars.json
@@ -42,6 +42,7 @@
 
         "User Guide": ["user_guide/api_token", "user_guide/faq"],
         "Changelog": [
+            "changelog/breaking_changes",
             "changelog/nov_2020_2_4_2",
             "changelog/may_2020_2_3_0",
             "changelog/jan_2020_2_1_0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "2.7.1",
+    "version": "2.8.0",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/datasources/query_execution.py
+++ b/querybook/server/datasources/query_execution.py
@@ -197,24 +197,24 @@ def download_statement_execution_result(statement_execution_id):
             statement_execution.query_execution_id, session=session
         )
 
+        download_file_name = f"result_{statement_execution.query_execution_id}_{statement_execution_id}.csv"
+
         reader = GenericReader(statement_execution.result_path)
         response = None
         if reader.has_download_url:
             # If the Reader can generate a download,
             # we let user download the file by redirection
-            download_url = reader.get_download_url()
+            download_url = reader.get_download_url(custom_name=download_file_name)
             response = redirect(download_url)
         else:
             # We read the raw file and download it for the user
             reader.start()
             raw = reader.read_raw()
             response = Response(raw)
-        response.headers["Content-Type"] = "text/plain"
-        response.headers[
-            "Content-Disposition"
-        ] = 'attachment; filename="result_{}_{}.csv"'.format(
-            statement_execution.query_execution_id, statement_execution_id
-        )
+            response.headers["Content-Type"] = "text/csv"
+            response.headers[
+                "Content-Disposition"
+            ] = f'attachment; filename="{download_file_name}"'
         return response
 
 

--- a/querybook/server/lib/result_store/__init__.py
+++ b/querybook/server/lib/result_store/__init__.py
@@ -55,8 +55,8 @@ class GenericReader(BaseReader):
     def has_download_url(self):
         return self._reader.has_download_url
 
-    def get_download_url(self):
-        return self._reader.get_download_url()
+    def get_download_url(self, custom_name=None):
+        return self._reader.get_download_url(custom_name=custom_name)
 
     def end(self):
         self._reader.end()

--- a/querybook/server/lib/result_store/stores/base_store.py
+++ b/querybook/server/lib/result_store/stores/base_store.py
@@ -118,12 +118,12 @@ class BaseReader(ABC):
         pass
 
     @abstractmethod
-    def get_download_url(self) -> str:
+    def get_download_url(self, custom_name=None) -> str:
         """Get the download url as string
 
-        Arguments:
-
+        Args:
+            custom_name (str, optional): Optional name for the file downloaded. You may ignore this field if you don't intend to rename the download. Defaults to None.
         Returns:
-            str -- the downloadable url
+            str: the downloadable url
         """
         pass

--- a/querybook/server/lib/result_store/stores/db_store.py
+++ b/querybook/server/lib/result_store/stores/db_store.py
@@ -47,7 +47,7 @@ class DBReader(BaseReader):
     def has_download_url(self):
         return False
 
-    def get_download_url(self):
+    def get_download_url(self, custom_name=None):
         return None
 
 

--- a/querybook/server/lib/result_store/stores/file_store.py
+++ b/querybook/server/lib/result_store/stores/file_store.py
@@ -86,5 +86,5 @@ class FileReader(BaseReader):
     def has_download_url(self):
         return False
 
-    def get_download_url(self):
+    def get_download_url(self, custom_name=None):
         return None

--- a/querybook/server/lib/result_store/stores/google_store.py
+++ b/querybook/server/lib/result_store/stores/google_store.py
@@ -63,9 +63,17 @@ class GoogleReader(BaseReader):
     def has_download_url(self):
         return True
 
-    def get_download_url(self):
+    def get_download_url(self, custom_name=None):
+        signed_url_params = {}
+        if custom_name is not None:
+            signed_url_params[
+                "response_disposition"
+            ] = f'attachment; filename="{custom_name}"'
+
         key_signer = GoogleKeySigner(QuerybookSettings.STORE_BUCKET_NAME)
-        download_url = key_signer.generate_presigned_url(self.uri)
+        download_url = key_signer.generate_presigned_url(
+            self.uri, params=signed_url_params
+        )
         return download_url
 
     @property

--- a/querybook/server/lib/result_store/stores/s3_store.py
+++ b/querybook/server/lib/result_store/stores/s3_store.py
@@ -56,9 +56,15 @@ class S3Reader(BaseReader):
     def has_download_url(self):
         return True
 
-    def get_download_url(self):
+    def get_download_url(self, custom_name=None):
+        url_params = {}
+        if custom_name is not None:
+            url_params[
+                "ResponseContentDisposition"
+            ] = f'attachment; filename="{custom_name}"'
+
         key_signer = S3KeySigner(QuerybookSettings.STORE_BUCKET_NAME)
-        download_url = key_signer.generate_presigned_url(self.uri)
+        download_url = key_signer.generate_presigned_url(self.uri, params=url_params,)
         return download_url
 
     @property


### PR DESCRIPTION
Since we redirect user to download file directly, s3 signed url requires a content disposition for custom name. Added this change along with documentation which is a breaking change for plugins. 