### PR TITLE
feat: added size attribute to chart meta

### DIFF
--- a/querybook/config/datadoc.yaml
+++ b/querybook/config/datadoc.yaml
@@ -70,6 +70,7 @@ cell_types:
                     display: 0
                     position: 'center'
                     alignment: 'center'
+                size: 'auto' # Can be one of 'sm' | 'md' | 'lg' | 'auto'
             collapsed: false
         meta_default:
             title: ''

--- a/querybook/webapp/components/DataDocChartCell/DataDocChart.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChart.tsx
@@ -11,6 +11,7 @@ import { mapMetaToChartOptions } from 'lib/chart/chart-meta-processing';
 import { getDefaultScaleType } from 'lib/chart/chart-utils';
 import { processChartJSData } from 'lib/chart/chart-data-processing';
 import { IStoreState } from 'redux/store/types';
+import { DataDocChartWrapper } from './DataDocChartWrapper';
 
 interface IDataDocChartProps {
     meta: IDataChartCellMeta;
@@ -165,5 +166,9 @@ export const DataDocChart: React.FunctionComponent<IDataDocChartProps> = ({
         chartDOM = <Bubble {...chartProps} />;
     }
 
-    return chartDOM;
+    return (
+        <DataDocChartWrapper size={meta.visual.size}>
+            {chartDOM}
+        </DataDocChartWrapper>
+    );
 };

--- a/querybook/webapp/components/DataDocChartCell/DataDocChartCell.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChartCell.tsx
@@ -11,8 +11,7 @@ import { IDataChartCellMeta } from 'const/datadoc';
 import { StatementExecutionPicker } from 'components/ExecutionPicker/StatementExecutionPicker';
 import { QueryExecutionPicker } from 'components/ExecutionPicker/QueryExecutionPicker';
 
-import { Button, TextButton } from 'ui/Button/Button';
-import { ErrorBoundary } from 'ui/ErrorBoundary/ErrorBoundary';
+import { TextButton } from 'ui/Button/Button';
 import { DataDocChart } from './DataDocChart';
 import { DataDocChartCellTable } from './DataDocChartCellTable';
 import { DataDocChartComposer } from './DataDocChartComposer';
@@ -203,7 +202,7 @@ export const DataDocChartCell: React.FunctionComponent<IProps> = ({
             );
         }
 
-        return <ErrorBoundary>{visualizationDOM}</ErrorBoundary>;
+        return visualizationDOM;
     };
 
     const chartComposerDOM = showChartComposer ? (

--- a/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.scss
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.scss
@@ -26,11 +26,13 @@
                 overflow-y: hidden;
                 .DataDocChartComposer-chart-sizer {
                     flex: 1;
-                    position: relative;
-                    display: flex;
-                    flex-direction: column;
-                    overflow: hidden;
                     width: 100%;
+                    display: flex;
+                    overflow-y: auto;
+
+                    .DataDocChartWrapper {
+                        flex: 1;
+                    }
                 }
                 .DataDocChartComposer-exec-picker {
                     margin-left: 4px;

--- a/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
@@ -18,9 +18,10 @@ import {
     aggTypes,
     IChartAxisMeta,
     ChartScaleType,
-    chartValueDisplayType,
+    ChartValueDisplayType,
     ChartScaleOptions,
     chartTypeToAllowedAxisType,
+    ChartSize,
 } from 'const/dataDocChart';
 import { colorPalette, colorPaletteNames } from 'const/chartColors';
 
@@ -36,7 +37,6 @@ import { queryCellSelector } from 'redux/dataDoc/selector';
 
 import { SoftButton } from 'ui/Button/Button';
 import { IconButton } from 'ui/Button/IconButton';
-import { ErrorBoundary } from 'ui/ErrorBoundary/ErrorBoundary';
 import { FormField, FormSectionHeader } from 'ui/Form/FormField';
 import { Tabs } from 'ui/Tabs/Tabs';
 
@@ -727,6 +727,31 @@ const DataDocChartComposerComponent: React.FunctionComponent<
                         />
                     </>
                 )}
+                <SimpleField
+                    stacked
+                    label="Chart Height"
+                    name="size"
+                    type="react-select"
+                    help="If set from not auto to auto height, refresh the page to see change."
+                    options={[
+                        {
+                            value: ChartSize.SMALL,
+                            label: 'Small (1/3 height)',
+                        },
+                        {
+                            value: ChartSize.MEDIUM,
+                            label: 'Medium (1/2 height)',
+                        },
+                        {
+                            value: ChartSize.LARGE,
+                            label: 'Large (full height)',
+                        },
+                        {
+                            value: ChartSize.AUTO,
+                            label: 'Auto height',
+                        },
+                    ]}
+                />
                 <FormSectionHeader>Legend</FormSectionHeader>
                 <SimpleField
                     label="Visible"
@@ -749,15 +774,15 @@ const DataDocChartComposerComponent: React.FunctionComponent<
                     type="react-select"
                     options={[
                         {
-                            value: chartValueDisplayType.FALSE,
+                            value: ChartValueDisplayType.FALSE,
                             label: 'Hide Values',
                         },
                         {
-                            value: chartValueDisplayType.TRUE,
+                            value: ChartValueDisplayType.TRUE,
                             label: 'Show Values',
                         },
                         {
-                            value: chartValueDisplayType.AUTO,
+                            value: ChartValueDisplayType.AUTO,
                             label: 'Show Values without Overlap',
                         },
                     ]}
@@ -930,7 +955,7 @@ const DataDocChartComposerComponent: React.FunctionComponent<
             <div className="DataDocChartComposer-chart">
                 {renderPickerDOM()}
                 <div className="DataDocChartComposer-chart-sizer">
-                    <ErrorBoundary>{chartData ? chartDOM : null}</ErrorBoundary>
+                    {chartData ? chartDOM : null}
                 </div>
             </div>
             {tableDOM}
@@ -1052,9 +1077,10 @@ function formValsToMeta(vals: IChartFormValues, meta: IDataChartCellMeta) {
         draft.visual.legend_position = vals.legendPosition;
         draft.visual.legend_display = vals.legendDisplay;
         draft.visual.connect_missing = vals.connectMissing;
+        draft.visual.size = vals.size;
 
         draft.visual.values = {
-            display: vals.valueDisplay ?? chartValueDisplayType.FALSE,
+            display: vals.valueDisplay ?? ChartValueDisplayType.FALSE,
             position: vals.valuePosition,
             alignment: vals.valueAlignment,
         };

--- a/querybook/webapp/components/DataDocChartCell/DataDocChartWrapper.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChartWrapper.tsx
@@ -1,0 +1,38 @@
+import clsx from 'clsx';
+import React from 'react';
+import styled from 'styled-components';
+
+import { ChartSize } from 'const/dataDocChart';
+import { ErrorBoundary } from 'ui/ErrorBoundary/ErrorBoundary';
+
+export interface IDataDocChartWrapper {
+    size?: ChartSize;
+    className?: string;
+}
+
+const StyledChartWrapper = styled.div<{ size: ChartSize }>`
+    position: relative;
+    ${(props) =>
+        props.size === ChartSize.AUTO
+            ? ''
+            : `height: ${
+                  props.size === ChartSize.SMALL
+                      ? '30vh'
+                      : props.size === ChartSize.MEDIUM
+                      ? '60vh'
+                      : '90vh'
+              }`}
+`;
+
+export const DataDocChartWrapper: React.FC<IDataDocChartWrapper> = ({
+    children,
+    className,
+    size = ChartSize.AUTO,
+}) => (
+    <StyledChartWrapper
+        className={clsx(className, 'DataDocChartWrapper')}
+        size={size}
+    >
+        <ErrorBoundary>{children}</ErrorBoundary>
+    </StyledChartWrapper>
+);

--- a/querybook/webapp/const/dataDocChart.ts
+++ b/querybook/webapp/const/dataDocChart.ts
@@ -150,19 +150,27 @@ export interface IChartChartMeta {
 
 export type ChartLegendPositionType = 'top' | 'bottom' | 'right' | 'left';
 
-export enum chartValueDisplayType {
+export enum ChartValueDisplayType {
     FALSE = 0,
     TRUE,
     AUTO,
+}
+
+export enum ChartSize {
+    SMALL = 'sm',
+    MEDIUM = 'md',
+    LARGE = 'lg',
+    AUTO = 'auto',
 }
 
 export interface IChartVisualMeta {
     legend_position?: ChartLegendPositionType;
     legend_display?: boolean;
     connect_missing?: boolean;
+    size?: ChartSize;
 
     values: {
-        display: chartValueDisplayType;
+        display: ChartValueDisplayType;
         position: 'center' | 'start' | 'end';
         alignment:
             | 'center'
@@ -231,8 +239,9 @@ export interface IChartFormValues {
     legendPosition: 'top' | 'bottom' | 'right' | 'left';
     legendDisplay: boolean;
     connectMissing: boolean;
+    size: ChartSize;
 
-    valueDisplay: chartValueDisplayType;
+    valueDisplay: ChartValueDisplayType;
     valuePosition: 'center' | 'start' | 'end';
     valueAlignment:
         | 'center'

--- a/querybook/webapp/lib/chart/chart-meta-processing.ts
+++ b/querybook/webapp/lib/chart/chart-meta-processing.ts
@@ -11,11 +11,12 @@ import {
     IChartAxisMeta,
     IChartFormValues,
     ChartScaleType,
-    chartValueDisplayType,
+    ChartValueDisplayType,
+    ChartSize,
 } from 'const/dataDocChart';
 import { fontColor, fillColor, backgroundColor } from 'const/chartColors';
+import type { DeepPartial } from 'lib/typescript';
 import { formatNumber } from 'lib/utils/number';
-import { DeepPartial } from 'redux';
 
 function filterSeries<T, K extends keyof T>(
     series: Record<number, T>,
@@ -136,9 +137,10 @@ export function mapMetaToFormVals(
         legendPosition: meta.visual.legend_position ?? 'top',
         legendDisplay: meta.visual.legend_display ?? true,
         connectMissing: meta.visual.connect_missing ?? false,
+        size: meta.visual.size ?? ChartSize.AUTO,
 
         valueDisplay:
-            meta.visual.values?.display ?? chartValueDisplayType.FALSE,
+            meta.visual.values?.display ?? ChartValueDisplayType.FALSE,
         valuePosition: meta.visual.values?.position,
         valueAlignment: meta.visual.values?.alignment,
     };
@@ -186,10 +188,10 @@ export function mapMetaToChartOptions(
             },
             datalabels: {
                 display:
-                    meta.visual.values?.display === chartValueDisplayType.TRUE
+                    meta.visual.values?.display === ChartValueDisplayType.TRUE
                         ? true
                         : meta.visual.values?.display ===
-                          chartValueDisplayType.AUTO
+                          ChartValueDisplayType.AUTO
                         ? 'auto'
                         : false,
                 anchor: meta.visual.values?.position,
@@ -209,6 +211,12 @@ export function mapMetaToChartOptions(
             },
         },
     };
+
+    // If auto size, then let aspect ratio be auto maintained, otherwise
+    // fit the content to the height, so no need to maintain ratio
+    if (meta.visual.size !== ChartSize.AUTO) {
+        optionsObj.maintainAspectRatio = false;
+    }
 
     if (meta.visual.connect_missing != null) {
         (optionsObj as LineControllerDatasetOptions).spanGaps =


### PR DESCRIPTION
Now you can set the size of the Querybook chart. This would be useful for graphs that have a lot of metrics.

Sizing options:
small <- 30vh
medium <- 60vh
large <- 90vh
auto <- same as before

![image](https://user-images.githubusercontent.com/8283407/127063953-a4d2bf62-08b1-4cc3-b765-59d3fb8aa484.png)
