### PR TITLE
fix: multiple charting bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "axios": "0.21.1",
         "bignumber.js": "^9.0.1",
         "chart.js": "^3.5.0",
+        "chartjs-adapter-moment": "^1.0.0",
         "chartjs-plugin-datalabels": "^2.0.0",
         "clean-webpack-plugin": "3.0.0",
         "clsx": "^1.1.1",

--- a/querybook/webapp/components/DataDocChartCell/DataDocChart.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChart.tsx
@@ -2,10 +2,15 @@ import { Line, Bar, Pie, Scatter, Doughnut, Bubble } from 'react-chartjs-2';
 import React, { MutableRefObject, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { Chart, ChartOptions } from 'chart.js';
+import 'chartjs-adapter-moment';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 
 import { IDataChartCellMeta } from 'const/datadoc';
-import { ChartScaleType, chartTypeToAllowedAxisType } from 'const/dataDocChart';
+import {
+    ChartScaleType,
+    ChartSize,
+    chartTypeToAllowedAxisType,
+} from 'const/dataDocChart';
 import { fontColor } from 'const/chartColors';
 import { mapMetaToChartOptions } from 'lib/chart/chart-meta-processing';
 import { getDefaultScaleType } from 'lib/chart/chart-utils';

--- a/querybook/webapp/components/DataDocChartCell/DataDocChartCell.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChartCell.tsx
@@ -240,7 +240,7 @@ export const DataDocChartCell: React.FunctionComponent<IProps> = ({
                     </InfoButton>
                 </div>
             </div>
-            <div>{renderChartDOM()}</div>
+            {renderChartDOM()}
             {chartComposerDOM}
         </div>
     );

--- a/querybook/webapp/components/DataDocChartCell/DataDocChartWrapper.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChartWrapper.tsx
@@ -27,11 +27,11 @@ const StyledChartWrapper = styled.div<{ size: ChartSize }>`
 export const DataDocChartWrapper: React.FC<IDataDocChartWrapper> = ({
     children,
     className,
-    size = ChartSize.AUTO,
+    size,
 }) => (
     <StyledChartWrapper
         className={clsx(className, 'DataDocChartWrapper')}
-        size={size}
+        size={size ?? ChartSize.AUTO}
     >
         <ErrorBoundary>{children}</ErrorBoundary>
     </StyledChartWrapper>

--- a/querybook/webapp/components/ImpressionWidget/ImpressionWidgetMenu.tsx
+++ b/querybook/webapp/components/ImpressionWidget/ImpressionWidgetMenu.tsx
@@ -127,25 +127,19 @@ const ImpressionWidgetTimeseries: React.FC<IProps> = ({ type, itemId }) => {
                     },
                 },
                 scales: {
-                    xAxes: [
-                        {
-                            type: 'time',
+                    x: {
+                        type: 'time',
 
-                            time: {
-                                unit: 'week',
-                                displayFormats: {
-                                    week: 'l',
-                                },
+                        time: {
+                            unit: 'week',
+                            displayFormats: {
+                                week: 'l',
                             },
                         },
-                    ],
-                    yAxes: [
-                        {
-                            ticks: {
-                                min: 0,
-                            },
-                        },
-                    ],
+                    },
+                    y: {
+                        beginAtZero: 0,
+                    },
                 },
             }}
         />

--- a/querybook/webapp/lib/chart/chart-meta-processing.ts
+++ b/querybook/webapp/lib/chart/chart-meta-processing.ts
@@ -215,7 +215,8 @@ export function mapMetaToChartOptions(
 
     // If auto size, then let aspect ratio be auto maintained, otherwise
     // fit the content to the height, so no need to maintain ratio
-    if (meta.visual.size !== ChartSize.AUTO) {
+    const chartSize = meta.visual?.size ?? ChartSize.AUTO;
+    if (chartSize !== ChartSize.AUTO) {
         optionsObj.maintainAspectRatio = false;
     }
 
@@ -347,6 +348,12 @@ function computeScaleOptions(
             // for yAxis, make sure 0 is shown unless specificed
             (axis as LinearScaleOptions).beginAtZero = true;
         }
+
+        // Prevent ticks from erroring out if there is no data provided
+        // See https://github.com/chartjs/Chart.js/issues/8092
+        axis.ticks = {
+            callback: (val) => val,
+        };
     }
 
     return axis;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5966,6 +5966,11 @@ chart.js@^3.5.0:
   resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.5.0.tgz#6eb075332d4ebbbb20a94e5a07a234052ed6c4fb"
   integrity sha512-J1a4EAb1Gi/KbhwDRmoovHTRuqT8qdF0kZ4XgwxpGethJHUdDrkqyPYwke0a+BuvSeUxPf8Cos6AX2AB8H8GLA==
 
+chartjs-adapter-moment@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chartjs-adapter-moment/-/chartjs-adapter-moment-1.0.0.tgz#9174b1093c68bcfe285aff24f7388ad60d44e8f7"
+  integrity sha512-PqlerEvQcc5hZLQ/NQWgBxgVQ4TRdvkW3c/t+SUEQSj78ia3hgLkf2VZ2yGJtltNbEEFyYGm+cA6XXevodYvWA==
+
 chartjs-plugin-datalabels@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.0.0.tgz#caacefb26803d968785071eab012dde8746c5939"


### PR DESCRIPTION
Fixed multiple bugs related to chartjs 3 update
1. Updated axis config for impressions chart
2. Fixed time axis display with moment adapter
3. Fixed chart sizing to default to auto
4. Fixed axis ticks issue when there are no ticks to display