### PR TITLE
fix: product css sourcemap issue

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -243,6 +243,7 @@ module.exports = (env, options) => {
             new webpack.SourceMapDevToolPlugin({
                 filename: '[file].map[query]',
                 exclude: [/vendor/],
+                test: /[jt]sx?/,
             }),
         ],
     };


### PR DESCRIPTION
After the react 17, I am seeing this strange error when running webpack in prod
```
Uncaught ReferenceError: c1ae4 is not defined
```
where the `react_app.c1ae.css` could be reason why it is causing the issue. Updated to only contain source map for css