### PR TITLE
fix: Use moment to parse date

### DIFF
--- a/querybook/webapp/lib/chart/chart-data-processing.ts
+++ b/querybook/webapp/lib/chart/chart-data-processing.ts
@@ -19,7 +19,7 @@ function processDataPoint(val: any, scale: ChartScaleType) {
     if (scale === 'category') {
         return val;
     } else if (scale === 'time' && isNaN(val)) {
-        return new Date(val);
+        return val;
     }
 
     // by default, a point is a number


### PR DESCRIPTION
If the date is a time string, do no processing and let moment handle the parsing