### PR TITLE
fix: use http instead of ws to updateCell

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/datasources/datadoc.py
+++ b/querybook/server/datasources/datadoc.py
@@ -173,8 +173,8 @@ def clone_data_doc(id):
 
 
 @register("/data_cell/<int:cell_id>/", methods=["PUT"])
-def update_data_cell(cell_id, **fields):
-    return datadoc_collab.update_data_cell(cell_id, fields,)
+def update_data_cell(cell_id, fields={}, sid=""):
+    return datadoc_collab.update_data_cell(cell_id, fields, sid=sid)
 
 
 @register("/data_cell/<int:id>/query_execution/", methods=["GET"])

--- a/querybook/webapp/lib/batch/datadoc-save-manager.ts
+++ b/querybook/webapp/lib/batch/datadoc-save-manager.ts
@@ -78,13 +78,9 @@ export class DataCellSaveManager {
                     };
 
                     if (dataDocSocket.activeDataDocId === docId) {
-                        return dataDocSocket.updateDataCell(
-                            docId,
-                            cellId,
-                            fields
-                        );
+                        return dataDocSocket.updateDataCell(cellId, fields);
                     } else {
-                        return ds.update(`/data_cell/${cellId}/`, fields);
+                        return ds.update(`/data_cell/${cellId}/`, { fields });
                     }
                 },
                 batchFrequency: frequency,

--- a/querybook/webapp/lib/data-doc/datadoc-socketio.ts
+++ b/querybook/webapp/lib/data-doc/datadoc-socketio.ts
@@ -1,7 +1,9 @@
 import type { Socket } from 'socket.io-client';
-import SocketIOManager from 'lib/socketio-manager';
-import { IDataDocEditor, IDataCellMeta } from 'const/datadoc';
+
 import { IAccessRequest } from 'const/accessRequest';
+import { IDataDocEditor, IDataCellMeta } from 'const/datadoc';
+import ds from 'lib/datasource';
+import SocketIOManager from 'lib/socketio-manager';
 import { IQueryExecution } from 'redux/queryExecutions/types';
 
 interface IDataDocSocketPromise<T> {
@@ -160,15 +162,12 @@ export class DataDocSocket {
     };
 
     public updateDataCell = (
-        docId: number,
         cellId: number,
         fields: { meta?: IDataCellMeta; context?: string }
-    ) => {
-        this.socket.emit('update_data_cell', docId, cellId, fields);
-        return this.makePromise<IDataDocSocketPromise<[rawDataCell: any]>>(
-            'updateDataCell'
-        );
-    };
+    ) =>
+        ds
+            .update(`/data_cell/${cellId}/`, { fields, sid: this.socketId })
+            .then((resp) => resp.data);
 
     public deleteDataCell = (docId: number, cellId: number) => {
         this.socket.emit('delete_data_cell', docId, cellId);


### PR DESCRIPTION
This change will reduce the amount of information send via websockets and rely on HTTP instead which has a much larger limit on size. Using HTTP is also more reliable to prevent loss of work.

Potential future work items:
1. Use HTTP on the send side, and use ws for the receive side
2. Allow ways to send partial information between clients and servers to reduce the data load