### PR TITLE
fix: hide stack trace for users

### DIFF
--- a/querybook/server/app/datasource.py
+++ b/querybook/server/app/datasource.py
@@ -80,7 +80,11 @@ def register(url, methods=None, require_auth=True, custom_response=False):
             except Exception as e:
                 LOG.error(e, exc_info=True)
                 status = 500
-                results = {"host": _host, "error": traceback.format_exc()}
+                results = {
+                    "host": _host,
+                    "error": str(e),
+                    "traceback": traceback.format_exc(),
+                }
             finally:
                 if status != 200 and "database_session" in flask.g:
                     flask.g.database_session.rollback()

--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -148,7 +148,7 @@ def update_table(table_id, description=None, golden=None):
 
 @register("/table/<int:table_id>/ownership/", methods=["GET"])
 def get_all_table_ownerships_by_table_id(table_id):
-    """ Add all table ownerships"""
+    """Add all table ownerships"""
     with DBSession() as session:
         verify_data_table_permission(table_id, session=session)
 
@@ -159,7 +159,7 @@ def get_all_table_ownerships_by_table_id(table_id):
 
 @register("/table/<int:table_id>/ownership/", methods=["POST"])
 def create_table_ownership(table_id):
-    """ Add a table ownership"""
+    """Add a table ownership"""
     with DBSession() as session:
         verify_data_table_permission(table_id, session=session)
         return logic.create_table_ownership(
@@ -169,7 +169,7 @@ def create_table_ownership(table_id):
 
 @register("/table/<int:table_id>/ownership/", methods=["DELETE"])
 def remove_table_ownership(table_id):
-    """ Remove a table ownership"""
+    """Remove a table ownership"""
     with DBSession() as session:
         verify_data_table_permission(table_id, session=session)
         return logic.delete_table_ownership(
@@ -504,14 +504,14 @@ def create_table_column_stats(data):
 @admin_only
 def add_lineage(table_id, parent_table_id, job_metadata_id):
     """
-        Adds a table lineage to DB
-        Example data structure:
-        {
-            "table_id": 1,
-            "parent_table_id": 2,
-            "job_metadata_id": 3
-        }
-        Returns new table lineage dictionary
+    Adds a table lineage to DB
+    Example data structure:
+    {
+        "table_id": 1,
+        "parent_table_id": 2,
+        "job_metadata_id": 3
+    }
+    Returns new table lineage dictionary
     """
     with DBSession() as session:
         table_lineage = lineage.add_table_lineage(

--- a/querybook/webapp/__tests__/lib/utils/error.test.ts
+++ b/querybook/webapp/__tests__/lib/utils/error.test.ts
@@ -8,7 +8,5 @@ test('format error object', () => {
 });
 
 test('format error string', () => {
-    expect(formatError('test error message')).toBe(
-        JSON.stringify('test error message')
-    );
+    expect(formatError('test error message')).toBe('test error message');
 });

--- a/querybook/webapp/components/DataDoc/DataDoc.tsx
+++ b/querybook/webapp/components/DataDoc/DataDoc.tsx
@@ -26,7 +26,7 @@ import {
     deserializeCopyCommand,
     serializeCopyCommand,
 } from 'lib/data-doc/copy';
-import { isAxiosError } from 'lib/utils/error';
+import { formatError, isAxiosError } from 'lib/utils/error';
 import { searchDataDocCells, replaceDataDoc } from 'lib/data-doc/search';
 
 import {
@@ -316,7 +316,7 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
                 );
             }
         } catch (e) {
-            toast.error(`Insert cell failed, reason: ${e}`);
+            toast.error(`Insert cell failed, reason: ${formatError(e)}`);
         }
     }
 
@@ -352,7 +352,7 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
                 copy('');
                 toast.success('Pasted');
             } catch (e) {
-                toast.error('Failed to paste, reason: ' + String(e));
+                toast.error('Failed to paste, reason: ' + formatError(e));
             }
         } else {
             toast.error('Nothing to paste, skipping.');
@@ -872,7 +872,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
                     )
                 );
             } catch (e) {
-                toast.error(`Cannot update cell, reason: ${e}`);
+                toast.error(`Cannot update cell, reason: ${formatError(e)}`);
             }
         },
     };

--- a/querybook/webapp/components/DataDocCell/DataDocCell.tsx
+++ b/querybook/webapp/components/DataDocCell/DataDocCell.tsx
@@ -11,6 +11,7 @@ import { useMakeSelector } from 'hooks/redux/useMakeSelector';
 
 import { sendConfirm } from 'lib/querybookUI';
 import { getShareUrl } from 'lib/data-doc/data-doc-utils';
+import { formatError } from 'lib/utils/error';
 
 import { IStoreState } from 'redux/store/types';
 import * as dataDocSelectors from 'redux/dataDoc/selector';
@@ -133,7 +134,11 @@ export const DataDocCell: React.FunctionComponent<IDataDocCellProps> = React.mem
                                     cell.id
                                 );
                             } catch (e) {
-                                toast.error(`Delete cell failed, reason: ${e}`);
+                                toast.error(
+                                    `Delete cell failed, reason: ${formatError(
+                                        e
+                                    )}`
+                                );
                             } finally {
                                 resolve();
                             }

--- a/querybook/webapp/lib/utils/error.ts
+++ b/querybook/webapp/lib/utils/error.ts
@@ -1,6 +1,10 @@
 import { AxiosError } from 'axios';
 
 export function formatError(error: any): string {
+    if (typeof error === 'string') {
+        return error;
+    }
+
     const isErrorObject =
         error != null &&
         typeof error === 'object' &&


### PR DESCRIPTION
1. Hide traceback in error responses to make the actual error message more readable
2. traceback is still viewable as "traceback" field for debugging
3. added formatError for toast.error logging to enable better error message