### PR TITLE
fix: use phrase match to improve table name search

### DIFF
--- a/querybook/server/datasources/search.py
+++ b/querybook/server/datasources/search.py
@@ -143,8 +143,8 @@ def _match_table_fields(fields):
     for field in fields:
         # 'table_name', 'description', and 'column' are fields used by Table search
         if field == "table_name":
-            search_fields.append("full_name^10")
-            search_fields.append("full_name_ngram^15")
+            search_fields.append("full_name^15")
+            search_fields.append("full_name_ngram")
         elif field == "description":
             search_fields.append("description")
         elif field == "column":
@@ -171,14 +171,15 @@ def _construct_tables_query(
     keywords, filters, fields, limit, offset, concise, sort_key=None, sort_order=None,
 ):
 
-    search_fields = _match_table_fields(fields)
-
     search_query = {}
     if keywords:
+        search_fields = _match_table_fields(fields)
         search_query["multi_match"] = {
             "query": keywords,
             "fields": search_fields,
             "minimum_should_match": "100%",
+            "type": "phrase",
+            "operator": "and",
         }
     else:
         search_query["match_all"] = {}

--- a/querybook/webapp/redux/dataTableSearch/action.ts
+++ b/querybook/webapp/redux/dataTableSearch/action.ts
@@ -20,7 +20,7 @@ function mapStateToSearch(state: IDataTableSearchState) {
     const matchSchemaName = searchString.match(/(\w+)\.(\w*)/);
     if (matchSchemaName) {
         filters.push(['schema', matchSchemaName[1]]);
-        searchString = matchSchemaName[2];
+        searchString = searchString.replace(/(\w+)\.(\w*)/, '$2');
     }
 
     const searchParam = {

--- a/querybook/webapp/redux/dataTableSearch/action.ts
+++ b/querybook/webapp/redux/dataTableSearch/action.ts
@@ -11,15 +11,16 @@ import {
 const BATCH_LOAD_SIZE = 100;
 
 function mapStateToSearch(state: IDataTableSearchState) {
-    const searchString = state.searchString;
+    let searchString = state.searchString;
 
     const filters = Object.entries(state.searchFilters).filter(
         ([_, filterValue]) => filterValue != null
     );
 
-    const matchSchemaName = searchString.match(/(\w+)\.\w*/);
+    const matchSchemaName = searchString.match(/(\w+)\.(\w*)/);
     if (matchSchemaName) {
         filters.push(['schema', matchSchemaName[1]]);
+        searchString = matchSchemaName[2];
     }
 
     const searchParam = {


### PR DESCRIPTION
Phrase match allows much more accurate result if the table name is directly pasted. Also boost the full name match more than ngram match as it returns much more accurate results. 
On the client side, if the schema name is extracted then we remove it from the keywords to avoid duplication