### PR TITLE
fix: add time scale for bar charts

### DIFF
--- a/querybook/webapp/components/DataDocChartCell/DataDocChart.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChart.tsx
@@ -9,7 +9,10 @@ import { IDataChartCellMeta } from 'const/datadoc';
 import { ChartScaleType, chartTypeToAllowedAxisType } from 'const/dataDocChart';
 import { fontColor } from 'const/chartColors';
 import { mapMetaToChartOptions } from 'lib/chart/chart-meta-processing';
-import { getDefaultScaleType } from 'lib/chart/chart-utils';
+import {
+    getAutoDetectedScaleType,
+    getDefaultScaleType,
+} from 'lib/chart/chart-utils';
 import { processChartJSData } from 'lib/chart/chart-data-processing';
 import { IStoreState } from 'redux/store/types';
 import { DataDocChartWrapper } from './DataDocChartWrapper';
@@ -87,10 +90,10 @@ const useChartScale = (meta: IDataChartCellMeta, data?: any[][]) => {
                     j !== xIndex &&
                     !isChartValNull(val)
                 ) {
-                    const defaultScale = getDefaultScaleType(val);
-                    return allowedYAxisType.includes(defaultScale)
-                        ? defaultScale
-                        : allowedYAxisType[0];
+                    return getAutoDetectedScaleType(
+                        allowedYAxisType,
+                        getDefaultScaleType(val)
+                    );
                 }
             }
         }

--- a/querybook/webapp/components/DataDocChartCell/DataDocChart.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChart.tsx
@@ -63,9 +63,7 @@ const useChartScale = (meta: IDataChartCellMeta, data?: any[][]) => {
 
         // If the configured scale is not allowed, then just pick the first
         // one from the allowed axis type
-        return allowedXAxisType.includes(defaultScale)
-            ? defaultScale
-            : allowedXAxisType[0];
+        return getAutoDetectedScaleType(allowedXAxisType, defaultScale);
     }, [data, xIndex, xScale]);
 
     const yScale = meta?.chart?.y_axis?.scale;

--- a/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
@@ -578,6 +578,7 @@ const DataDocChartComposerComponent: React.FunctionComponent<
                 {getAxisDOM(
                     'xAxis',
                     values.xAxis,
+
                     detectedXAxisScale === 'linear'
                         ? 'category'
                         : detectedXAxisScale,

--- a/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChartComposer.tsx
@@ -42,7 +42,10 @@ import { Tabs } from 'ui/Tabs/Tabs';
 
 import { Level, LevelItem } from 'ui/Level/Level';
 import { SimpleReactSelect } from 'ui/SimpleReactSelect/SimpleReactSelect';
-import { getDefaultScaleType } from 'lib/chart/chart-utils';
+import {
+    getAutoDetectedScaleType,
+    getDefaultScaleType,
+} from 'lib/chart/chart-utils';
 import { NumberField } from 'ui/FormikField/NumberField';
 import { ReactSelectField } from 'ui/FormikField/ReactSelectField';
 import { FormWrapper } from 'ui/Form/FormWrapper';
@@ -514,6 +517,8 @@ const DataDocChartComposerComponent: React.FunctionComponent<
             if (noAxesConfig) {
                 return null;
             }
+
+            scaleType = getAutoDetectedScaleType(scaleOptions, scaleType);
 
             const allScaleOptions = [
                 {

--- a/querybook/webapp/const/dataDocChart.ts
+++ b/querybook/webapp/const/dataDocChart.ts
@@ -81,11 +81,11 @@ export const chartTypeToAllowedAxisType: Partial<
         y: ['linear', 'logarithmic'],
     },
     bar: {
-        x: ['category'],
+        x: ['time', 'category'],
         y: ['linear', 'logarithmic'],
     },
     histogram: {
-        x: ['category'],
+        x: ['time', 'category'],
         y: ['linear', 'logarithmic'],
     },
     pie: {

--- a/querybook/webapp/lib/chart/chart-utils.ts
+++ b/querybook/webapp/lib/chart/chart-utils.ts
@@ -35,6 +35,25 @@ export function getDefaultScaleType(value: any): ChartScaleType {
     }
 }
 
+/**
+ * Sometimes, the detected scale type from
+ * the input cannot be used for the chart.
+ *
+ * This function provides a default behavior to pick
+ * from the list of allowed options
+ *
+ * @param allowedScaleType list of scale type supported by chart
+ * @param detectedScaleType auto detected scale type
+ */
+export function getAutoDetectedScaleType(
+    allowedScaleType: ChartScaleType[],
+    detectedScaleType: ChartScaleType
+) {
+    return allowedScaleType.includes(detectedScaleType)
+        ? detectedScaleType
+        : allowedScaleType[0];
+}
+
 export function sortTable(
     tableRows: any[][],
     columnIndex: number = 0,


### PR DESCRIPTION
Using category axis for timeseries in bar charts would cause the date range to collapse. Now we allow time scale x axis.
Also updated the auto detect display so it shows the correct behavior