### PR TITLE
Add moment adapter for impression charts

### DIFF
--- a/querybook/webapp/components/App/App.tsx
+++ b/querybook/webapp/components/App/App.tsx
@@ -6,7 +6,6 @@ import { HTML5Backend } from 'react-dnd-html5-backend';
 import { Provider } from 'react-redux';
 
 import { AppRouter } from 'components/AppRouter/AppRouter';
-
 import { reduxStore } from 'redux/store';
 
 // Make debugging easier

--- a/querybook/webapp/components/ImpressionWidget/ImpressionWidgetMenu.tsx
+++ b/querybook/webapp/components/ImpressionWidget/ImpressionWidgetMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Line } from 'react-chartjs-2';
-
+import 'chartjs-adapter-moment';
 import { generateFormattedDate } from 'lib/utils/datetime';
 import { ImpressionType } from 'const/impression';
 import { useDataFetch } from 'hooks/useDataFetch';


### PR DESCRIPTION
it is not a good fix. But to ensure code splitting, we should import chartjs adapter only when necessary :/ 