### PR TITLE
feat: Add modal to preview templated query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "2.8.1",
+    "version": "2.8.2",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
+++ b/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
@@ -52,6 +52,7 @@ import { Title } from 'ui/Title/Title';
 
 import { ErrorQueryCell } from './ErrorQueryCell';
 import './DataDocQueryCell.scss';
+import { TemplatedQueryView } from 'components/TemplateQueryView/TemplatedQueryView';
 
 const ON_CHANGE_DEBOUNCE_MS = 500;
 const FORMAT_QUERY_SHORTCUT = getShortcutSymbols(
@@ -97,6 +98,7 @@ interface IState {
     selectedRange: ISelectedRange;
     queryCollapsedOverride: boolean;
     showQuerySnippetModal: boolean;
+    showRenderedTemplateModal: boolean;
 }
 
 class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
@@ -113,6 +115,7 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
             selectedRange: null,
             queryCollapsedOverride: null,
             showQuerySnippetModal: false,
+            showRenderedTemplateModal: false,
         };
     }
 
@@ -344,6 +347,12 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
     }
 
     @bind
+    public handleRunFromRenderedTemplateModal() {
+        this.toggleShowRenderedTemplateModal();
+        this.clickOnRunButton();
+    }
+
+    @bind
     public toggleQueryCollapsing(forceCollapse: boolean) {
         const { isEditable } = this.props;
         if (isEditable) {
@@ -391,10 +400,18 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
                 name: 'Explain Query',
                 onClick: this.explainQuery,
                 icon: 'fas fa-info',
-                tooltip: 'Run Query as Explain',
+                tooltip: 'Run query as explain',
                 tooltipPos: 'left',
             });
         }
+
+        additionalButtons.push({
+            name: 'Render template',
+            onClick: this.toggleShowRenderedTemplateModal,
+            icon: 'fas fa-code',
+            tooltip: 'Show the rendered templated query',
+            tooltipPos: 'left',
+        });
 
         additionalButtons.push({
             name: queryCollapsed ? 'Show Query' : 'Hide Query',
@@ -427,6 +444,13 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
     public toggleInsertQuerySnippetModal() {
         this.setState(({ showQuerySnippetModal }) => ({
             showQuerySnippetModal: !showQuerySnippetModal,
+        }));
+    }
+
+    @bind
+    public toggleShowRenderedTemplateModal() {
+        this.setState(({ showRenderedTemplateModal }) => ({
+            showRenderedTemplateModal: !showRenderedTemplateModal,
         }));
     }
 
@@ -531,8 +555,13 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
             isEditable,
             isFullScreen,
             toggleFullScreen,
+            templatedVariables,
         } = this.props;
-        const { query, showQuerySnippetModal } = this.state;
+        const {
+            query,
+            showQuerySnippetModal,
+            showRenderedTemplateModal,
+        } = this.state;
         const queryEngine = queryEngineById[this.engineId];
         const queryCollapsed = this.queryCollapsed;
 
@@ -590,11 +619,25 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
             </Modal>
         ) : null;
 
+        const templatedQueryViewModalDOM = showRenderedTemplateModal ? (
+            <Modal
+                onHide={this.toggleShowRenderedTemplateModal}
+                title="Rendered Templated Query"
+            >
+                <TemplatedQueryView
+                    query={query}
+                    templatedVariables={templatedVariables}
+                    onRunQueryClick={this.handleRunFromRenderedTemplateModal}
+                />
+            </Modal>
+        ) : null;
+
         return (
             <>
                 {editorDOM}
                 {openSnippetDOM}
                 {insertQuerySnippetModalDOM}
+                {templatedQueryViewModalDOM}
             </>
         );
     }

--- a/querybook/webapp/components/TemplateQueryView/TemplatedQueryView.scss
+++ b/querybook/webapp/components/TemplateQueryView/TemplatedQueryView.scss
@@ -1,0 +1,11 @@
+.TemplatedQueryView {
+    .code-wrapper {
+        border: var(--border);
+        max-height: 60vh;
+        overflow: auto;
+
+        &.code-error {
+            border: 1px solid var(--color-false);
+        }
+    }
+}

--- a/querybook/webapp/components/TemplateQueryView/TemplatedQueryView.scss
+++ b/querybook/webapp/components/TemplateQueryView/TemplatedQueryView.scss
@@ -1,6 +1,5 @@
 .TemplatedQueryView {
     .code-wrapper {
-        border: var(--border);
         max-height: 60vh;
         overflow: auto;
 

--- a/querybook/webapp/components/TemplateQueryView/TemplatedQueryView.tsx
+++ b/querybook/webapp/components/TemplateQueryView/TemplatedQueryView.tsx
@@ -42,7 +42,7 @@ export const TemplatedQueryView: React.FC<ITemplatedQueryViewProps> = ({
                     {formatError(error)}
                 </ErrorMessage>
 
-                <div className="code-wrapper code-error mt4">
+                <div className="code-wrapper code-error mt16">
                     <ThemedCodeHighlight value={query} />
                 </div>
             </div>
@@ -53,7 +53,7 @@ export const TemplatedQueryView: React.FC<ITemplatedQueryViewProps> = ({
                 <div className="code-wrapper">
                     <ThemedCodeHighlight value={renderedQuery} />
                 </div>
-                <div className="flex-right mt8">
+                <div className="flex-right mt16">
                     {onRunQueryClick && (
                         <Button
                             icon="play"
@@ -68,5 +68,5 @@ export const TemplatedQueryView: React.FC<ITemplatedQueryViewProps> = ({
         );
     }
 
-    return <div className="TemplatedQueryView p8">{contentDOM}</div>;
+    return <div className="TemplatedQueryView p16">{contentDOM}</div>;
 };

--- a/querybook/webapp/components/TemplateQueryView/TemplatedQueryView.tsx
+++ b/querybook/webapp/components/TemplateQueryView/TemplatedQueryView.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import { useResource } from 'hooks/useResource';
+import { formatError } from 'lib/utils/error';
+import { TemplatedQueryResource } from 'resource/queryExecution';
+import { Button } from 'ui/Button/Button';
+import { ThemedCodeHighlight } from 'ui/CodeHighlight/ThemedCodeHighlight';
+import { CopyButton } from 'ui/CopyButton/CopyButton';
+import { Loading } from 'ui/Loading/Loading';
+import { ErrorMessage } from 'ui/Message/ErrorMessage';
+import './TemplatedQueryView.scss';
+
+export interface ITemplatedQueryViewProps {
+    query: string;
+    templatedVariables: Record<string, string>;
+    onRunQueryClick?: () => void;
+}
+
+export const TemplatedQueryView: React.FC<ITemplatedQueryViewProps> = ({
+    query,
+    templatedVariables,
+    onRunQueryClick,
+}) => {
+    const { data: renderedQuery, isLoading, error } = useResource(
+        React.useCallback(
+            () =>
+                TemplatedQueryResource.renderTemplatedQuery(
+                    query,
+                    templatedVariables
+                ),
+            [query, templatedVariables]
+        )
+    );
+
+    let contentDOM: React.ReactNode = null;
+    if (isLoading) {
+        contentDOM = <Loading />;
+    } else if (error) {
+        contentDOM = (
+            <div>
+                <ErrorMessage title={'Failed to templatize query.'}>
+                    {formatError(error)}
+                </ErrorMessage>
+
+                <div className="code-wrapper code-error mt4">
+                    <ThemedCodeHighlight value={query} />
+                </div>
+            </div>
+        );
+    } else {
+        contentDOM = (
+            <div>
+                <div className="code-wrapper">
+                    <ThemedCodeHighlight value={renderedQuery} />
+                </div>
+                <div className="flex-right mt8">
+                    {onRunQueryClick && (
+                        <Button
+                            icon="play"
+                            title="Run Query"
+                            onClick={onRunQueryClick}
+                            className="mr4"
+                        />
+                    )}
+                    <CopyButton copyText={renderedQuery} title="Copy" />
+                </div>
+            </div>
+        );
+    }
+
+    return <div className="TemplatedQueryView p8">{contentDOM}</div>;
+};

--- a/querybook/webapp/hooks/useResource.ts
+++ b/querybook/webapp/hooks/useResource.ts
@@ -14,6 +14,7 @@ interface IDataFetchState<T> {
     isLoading: boolean;
     isError: boolean;
     data: T;
+    error: any;
 }
 
 function dataFetchReducer<T>(state: IDataFetchState<T>, action) {
@@ -23,6 +24,7 @@ function dataFetchReducer<T>(state: IDataFetchState<T>, action) {
                 ...state,
                 isLoading: true,
                 isError: false,
+                error: null,
             };
         case 'FETCH_SUCCESS':
             return {
@@ -36,6 +38,7 @@ function dataFetchReducer<T>(state: IDataFetchState<T>, action) {
                 ...state,
                 isLoading: false,
                 isError: true,
+                error: action.payload,
             };
         default:
             throw new Error();
@@ -53,6 +56,7 @@ export function useResource<T>(resource: IResource<T>, args: IFetchArgs = {}) {
         isLoading: true,
         isError: false,
         data: null,
+        error: null,
     };
     const [state, dispatch] = useReducer<Reducer<IDataFetchState<T>, any>>(
         dataFetchReducer,
@@ -96,6 +100,7 @@ export function useResource<T>(resource: IResource<T>, args: IFetchArgs = {}) {
                 if (!didCancel || error.name !== 'AbortError') {
                     dispatch({
                         type: 'FETCH_FAILURE',
+                        payload: error,
                     });
                 }
             }


### PR DESCRIPTION
closes #638 

Users can preview rendered query before running it.

Note you can run directly in modal after viewing the query
![image](https://user-images.githubusercontent.com/8283407/130304424-4b8a4c6b-eb36-4f52-bad2-dd75b9f7682a.png)

If the query failed to render, then the original query is shown
![image](https://user-images.githubusercontent.com/8283407/130304451-eea716b3-6389-4d99-8214-fe51871edba2.png)
