### PR TITLE
Add option to filter tables by query engines

### DIFF
--- a/querybook/webapp/components/DataTableView/DataTableView.tsx
+++ b/querybook/webapp/components/DataTableView/DataTableView.tsx
@@ -125,10 +125,15 @@ class DataTableViewComponent extends React.PureComponent<
     }
 
     @bind
-    public handleExampleFilter(uid: number, withTableId: number) {
+    public handleExampleFilter(
+        uid: number,
+        engineId: number,
+        withTableId: number
+    ) {
         replaceQueryString({
             tab: 'query_examples',
             uid,
+            engine_id: engineId,
             with_table_id: withTableId,
         });
         this.setState({ selectedTabKey: 'query_examples' });

--- a/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
+++ b/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
@@ -32,6 +32,7 @@ import { DataTableViewOverviewSection } from './DataTableViewOverviewSection';
 import { LoadingRow } from 'ui/Loading/Loading';
 import { DataTableViewQueryConcurrences } from 'components/DataTableViewQueryExample/DataTableViewQueryConcurrences';
 import { Title } from 'ui/Title/Title';
+import { DataTableViewQueryEngines } from 'components/DataTableViewQueryExample/DataTableViewQueryEngines';
 
 const dataTableDetailsColumns = [
     {
@@ -65,7 +66,11 @@ export interface IQuerybookTableViewOverviewProps {
         tableId: number,
         description: DraftJs.ContentState
     ) => any;
-    onExampleFilter: (uid: number, withTableId: number) => any;
+    onExampleFilter: (
+        uid: number,
+        engineId: number,
+        withTableId: number
+    ) => any;
 }
 
 export class DataTableViewOverview extends React.PureComponent<IQuerybookTableViewOverviewProps> {
@@ -76,12 +81,7 @@ export class DataTableViewOverview extends React.PureComponent<IQuerybookTableVi
     }
 
     public render() {
-        const {
-            table,
-            tableName,
-            tableWarnings,
-            onExampleFilter: onExampleUidFilter,
-        } = this.props;
+        const { table, tableName, tableWarnings, onExampleFilter } = this.props;
         const description = table.description ? (
             <EditableTextField
                 value={table.description as DraftJs.ContentState}
@@ -200,7 +200,7 @@ export class DataTableViewOverview extends React.PureComponent<IQuerybookTableVi
                 {descriptionSection}
                 <TableInsightsSection
                     tableId={table.id}
-                    onClick={onExampleUidFilter}
+                    onClick={onExampleFilter}
                 />
                 {detailsSection}
                 <TableStatsSection tableId={table.id} />
@@ -214,18 +214,24 @@ export class DataTableViewOverview extends React.PureComponent<IQuerybookTableVi
 
 const TableInsightsSection: React.FC<{
     tableId: number;
-    onClick: (uid: number, withTableId: number) => any;
+    onClick: (uid: number, engineId: number, withTableId: number) => any;
 }> = ({ tableId, onClick }) => {
     const { loading, topQueryUsers } = useLoadQueryUsers(tableId);
     const handleUserClick = useCallback(
         (uid: number) => {
-            onClick(uid, null);
+            onClick(uid, null, null);
+        },
+        [onClick]
+    );
+    const handleEngineClick = useCallback(
+        (engine_id: number) => {
+            onClick(null, engine_id, null);
         },
         [onClick]
     );
     const handleTableClick = useCallback(
         (tableId: number) => {
-            onClick(null, tableId);
+            onClick(null, null, tableId);
         },
         [onClick]
     );
@@ -242,7 +248,14 @@ const TableInsightsSection: React.FC<{
                 />
             </div>
             <div className="mt8">
-                <Title size={6}>Top co-occuring tables</Title>
+                <Title size={6}>Top Query Engines</Title>
+                <DataTableViewQueryEngines
+                    tableId={tableId}
+                    onClick={handleEngineClick}
+                />
+            </div>
+            <div className="mt8">
+                <Title size={6}>Top Co-occurring Tables</Title>
                 <DataTableViewQueryConcurrences
                     tableId={tableId}
                     onClick={handleTableClick}

--- a/querybook/webapp/components/DataTableViewQueryExample/DataTableViewQueryEngines.tsx
+++ b/querybook/webapp/components/DataTableViewQueryExample/DataTableViewQueryEngines.tsx
@@ -1,0 +1,84 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import { IStoreState, Dispatch } from 'redux/store/types';
+import { fetchTopQueryEnginesIfNeeded } from 'redux/dataSources/action';
+
+import { Loading } from 'ui/Loading/Loading';
+import { Button } from 'ui/Button/Button';
+import { queryEngineByIdEnvSelector } from 'redux/queryEngine/selector';
+
+export function useLoadQueryEngines(tableId: number) {
+    const [loading, setLoading] = useState(false);
+    const topQueryEngines = useSelector(
+        (state: IStoreState) =>
+            state.dataSources.queryTopEnginesByTableId[tableId]
+    );
+
+    const dispatch: Dispatch = useDispatch();
+
+    useEffect(() => {
+        setLoading(true);
+        dispatch(fetchTopQueryEnginesIfNeeded(tableId)).finally(() => {
+            setLoading(false);
+        });
+    }, [tableId]);
+
+    return {
+        loading,
+        topQueryEngines,
+    };
+}
+
+export const DataTableViewQueryEngines: React.FC<{
+    tableId: number;
+    onClick?: (engineId: number) => any;
+    selectedEngineId?: number;
+}> = ({ tableId, onClick = null, selectedEngineId }) => {
+    const { loading, topQueryEngines } = useLoadQueryEngines(tableId);
+
+    const enginesDOM = loading ? (
+        <Loading />
+    ) : !topQueryEngines?.length ? (
+        <div>
+            This table has not been queried by any engines in this environment.
+        </div>
+    ) : (
+        <div className="query-filter-wrapper">
+            {topQueryEngines.map(({ engine_id: engineId, count }) => (
+                <QueryEngineButton
+                    key={engineId}
+                    engineId={engineId}
+                    queryCount={count}
+                    onClick={onClick}
+                    active={selectedEngineId === engineId}
+                />
+            ))}
+        </div>
+    );
+
+    return <div className="DataTableViewQueryEngines">{enginesDOM}</div>;
+};
+
+const QueryEngineButton: React.FC<{
+    engineId: number;
+    onClick?: (engineId: number) => void;
+    queryCount: number;
+    active: boolean;
+}> = ({ engineId, onClick, queryCount, active }) => {
+    const handleClick = useCallback(() => onClick?.(engineId), [
+        onClick,
+        engineId,
+    ]);
+    const queryEngineById = useSelector(queryEngineByIdEnvSelector);
+    const queryEngine = queryEngineById[engineId];
+    const { name: queryEngineName } = queryEngine;
+
+    return (
+        <Button onClick={handleClick} active={active}>
+            <span className="ml4">
+                {queryEngineName} ({queryCount})
+            </span>
+        </Button>
+    );
+};

--- a/querybook/webapp/components/DataTableViewQueryExample/DataTableViewQueryExamples.tsx
+++ b/querybook/webapp/components/DataTableViewQueryExample/DataTableViewQueryExamples.tsx
@@ -28,6 +28,7 @@ import { Loading } from 'ui/Loading/Loading';
 import { Title } from 'ui/Title/Title';
 import { ThemedCodeHighlight } from 'ui/CodeHighlight/ThemedCodeHighlight';
 
+import { DataTableViewQueryEngines } from './DataTableViewQueryEngines';
 import { DataTableViewQueryConcurrences } from './DataTableViewQueryConcurrences';
 
 import './DataTableViewQueryExamples.scss';
@@ -62,11 +63,15 @@ function useQueryExampleState(tableId: number) {
 function getInitialFilterState(): IPaginatedQuerySampleFilters {
     const queryString = getQueryString();
     const uid: string = queryString['uid'];
+    const engineId: string = queryString['engine_id'];
     const withTableId: string = queryString['with_table_id'];
     const filters: IPaginatedQuerySampleFilters = {};
 
     if (uid) {
         filters.uid = Number(uid);
+    }
+    if (engineId) {
+        filters.engine_id = Number(engineId);
     }
     if (withTableId) {
         filters.with_table_id = Number(withTableId);
@@ -120,6 +125,16 @@ export const DataTableViewQueryExamples: React.FunctionComponent<IProps> = ({
         [filters]
     );
 
+    const setEngineIdFilter = React.useCallback(
+        (engineId: number) => {
+            setFilter(
+                'engine_id',
+                engineId === filters.engine_id ? null : engineId
+            );
+        },
+        [filters]
+    );
+
     const setTableIdFilter = React.useCallback(
         (tableId: number) => {
             setFilter(
@@ -149,10 +164,19 @@ export const DataTableViewQueryExamples: React.FunctionComponent<IProps> = ({
                         selectedUid={filters.uid}
                     />
                 </div>
-
                 <div className="mt12">
                     <Title subtitle size={6}>
-                        Top co-occuring tables
+                        Top query engines
+                    </Title>
+                    <DataTableViewQueryEngines
+                        tableId={tableId}
+                        onClick={setEngineIdFilter}
+                        selectedEngineId={filters.engine_id}
+                    />
+                </div>
+                <div className="mt12">
+                    <Title subtitle size={6}>
+                        Top co-occurring tables
                     </Title>
                     <DataTableViewQueryConcurrences
                         tableId={tableId}

--- a/querybook/webapp/const/metastore.ts
+++ b/querybook/webapp/const/metastore.ts
@@ -127,6 +127,7 @@ export type FunctionDocumentationCollection = Record<
 
 export interface IPaginatedQuerySampleFilters {
     uid?: number;
+    engine_id?: number;
     with_table_id?: number;
 }
 
@@ -138,6 +139,11 @@ export interface IPaginatedQuerySamples {
 
 export interface ITopQueryUser {
     uid: number;
+    count: number;
+}
+
+export interface ITopQueryEngine {
+    engine_id: number;
     count: number;
 }
 

--- a/querybook/webapp/redux/dataSources/action.ts
+++ b/querybook/webapp/redux/dataSources/action.ts
@@ -14,6 +14,7 @@ import {
     ITopQueryUser,
     IPaginatedQuerySampleFilters,
     ITopQueryConcurrences,
+    ITopQueryEngine,
     IFunctionDescription,
     IUpdateTableParams,
     IDataTableWarningUpdateFields,
@@ -568,6 +569,37 @@ export function fetchTopQueryUsersIfNeeded(
                 payload: {
                     tableId,
                     users: data,
+                },
+            });
+            return data;
+        } catch (e) {
+            console.error(e);
+        }
+    };
+}
+
+export function fetchTopQueryEnginesIfNeeded(
+    tableId: number,
+    limit = 5
+): ThunkResult<Promise<ITopQueryEngine[]>> {
+    return async (dispatch, getState) => {
+        try {
+            const state = getState();
+            const engines = state.dataSources.queryTopEnginesByTableId[tableId];
+            if (engines != null) {
+                return Promise.resolve(engines);
+            }
+
+            const { data } = await TableQueryExampleResource.getTopEngines(
+                tableId,
+                state.environment.currentEnvironmentId,
+                limit
+            );
+            dispatch({
+                type: '@@dataSources/RECEIVE_TOP_QUERY_ENGINES',
+                payload: {
+                    tableId,
+                    engines: data,
                 },
             });
             return data;

--- a/querybook/webapp/redux/dataSources/reducer.ts
+++ b/querybook/webapp/redux/dataSources/reducer.ts
@@ -25,6 +25,7 @@ const initialState: IDataSourcesState = {
 
     queryExampleIdsById: {},
     queryTopUsersByTableId: {},
+    queryTopEnginesByTableId: {},
     queryTopConcurrencesByTableId: {},
 
     dataTableStatByTableId: {},
@@ -326,6 +327,21 @@ function queryTopUsersByTableIdReducer(
     });
 }
 
+function queryTopEnginesByTableIdReducer(
+    state = initialState.queryTopEnginesByTableId,
+    action: DataSourcesAction
+) {
+    return produce(state, (draft) => {
+        switch (action.type) {
+            case '@@dataSources/RECEIVE_TOP_QUERY_ENGINES': {
+                const { tableId, engines } = action.payload;
+                draft[tableId] = engines;
+                return;
+            }
+        }
+    });
+}
+
 function queryTopConcurrencesByTableIdReducer(
     state = initialState.queryTopConcurrencesByTableId,
     action: DataSourcesAction
@@ -436,6 +452,7 @@ export default combineReducers({
     dataTablesSamplesPollingById: dataTablesSamplesPollingByIdReducer,
     queryExampleIdsById: queryExampleIdsByIdReducer,
     queryTopUsersByTableId: queryTopUsersByTableIdReducer,
+    queryTopEnginesByTableId: queryTopEnginesByTableIdReducer,
     queryTopConcurrencesByTableId: queryTopConcurrencesByTableIdReducer,
     dataLineages: dataLineagesReducer,
     dataTableWarningById: dataTableWarningByIdReducer,

--- a/querybook/webapp/redux/dataSources/types.ts
+++ b/querybook/webapp/redux/dataSources/types.ts
@@ -20,6 +20,7 @@ import {
     IDataTableOwnership,
     ITableStats,
     ITopQueryConcurrences,
+    ITopQueryEngine,
 } from 'const/metastore';
 import { IStoreState } from '../store/types';
 
@@ -130,6 +131,14 @@ export interface IReceiveTopQueryUsersAction extends Action {
     };
 }
 
+export interface IReceiveTopQueryEnginesAction extends Action {
+    type: '@@dataSources/RECEIVE_TOP_QUERY_ENGINES';
+    payload: {
+        tableId: number;
+        engines: ITopQueryEngine[];
+    };
+}
+
 export interface IReceiveTopQueryJoinsAction extends Action {
     type: '@@dataSources/RECEIVE_TOP_QUERY_CONCURRENCES';
     payload: {
@@ -198,6 +207,7 @@ export type DataSourcesAction =
     | IAddDataTableOwnership
     | IRemoveDataTableOwnership
     | IReceiveTopQueryUsersAction
+    | IReceiveTopQueryEnginesAction
     | IReceiveTopQueryJoinsAction;
 
 export type ThunkResult<R> = ThunkAction<
@@ -230,6 +240,7 @@ export interface IDataSourcesState {
 
     queryExampleIdsById: Record<number, IPaginatedQuerySamples>;
     queryTopUsersByTableId: Record<number, ITopQueryUser[]>;
+    queryTopEnginesByTableId: Record<number, ITopQueryEngine[]>;
     queryTopConcurrencesByTableId: Record<number, ITopQueryConcurrences[]>;
 
     dataLineages: ILineageCollection;

--- a/querybook/webapp/resource/table.ts
+++ b/querybook/webapp/resource/table.ts
@@ -15,6 +15,7 @@ import type {
     ITableSampleParams,
     ITableStats,
     ITopQueryConcurrences,
+    ITopQueryEngine,
     ITopQueryUser,
     IUpdateTableParams,
 } from 'const/metastore';
@@ -93,6 +94,18 @@ export const TableQueryExampleResource = {
         ds.fetch<ITopQueryUser[]>(
             {
                 url: `/table/${tableId}/query_examples/users/`,
+            },
+            {
+                table_id: tableId,
+                environment_id: environmentId,
+                limit,
+            }
+        ),
+
+    getTopEngines: (tableId: number, environmentId: number, limit: number) =>
+        ds.fetch<ITopQueryEngine[]>(
+            {
+                url: `/table/${tableId}/query_examples/engines/`,
             },
             {
                 table_id: tableId,


### PR DESCRIPTION
closes #222 

Add option to filter by query engines in table page
![Screen Shot 2021-08-23 at 5 25 58 PM](https://user-images.githubusercontent.com/23270317/130537201-2cdfb05e-95af-497a-9496-2a2ab39ac316.png)
![Screen Shot 2021-08-23 at 12 58 08 PM](https://user-images.githubusercontent.com/23270317/130537229-66ee5848-8ecf-4c37-ae3a-975f8e282686.png)


Top query engines list is also available in table overview page
![Screen Shot 2021-08-23 at 5 26 07 PM](https://user-images.githubusercontent.com/23270317/130537211-b1e4ab46-858e-4e56-a43c-8b41a22368a6.png)
