### PR TITLE
refactor: use shallowEquals for useselector

### DIFF
--- a/querybook/webapp/components/Board/BoardDataTableItem.tsx
+++ b/querybook/webapp/components/Board/BoardDataTableItem.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { ContentState } from 'draft-js';
 import { Link } from 'react-router-dom';
 
-import { Dispatch, IStoreState } from 'redux/store/types';
+import { useShallowSelector } from 'hooks/redux/useShallowSelector';
 import { getWithinEnvUrl } from 'lib/utils/query-string';
 
 import { BoardItemAddButton } from 'components/BoardItemAddButton/BoardItemAddButton';
+import { Dispatch, IStoreState } from 'redux/store/types';
+import { fetchDataTableIfNeeded } from 'redux/dataSources/action';
 import { Icon } from 'ui/Icon/Icon';
 import { RichTextEditor } from 'ui/RichTextEditor/RichTextEditor';
 import { Title } from 'ui/Title/Title';
-import { fetchDataTableIfNeeded } from 'redux/dataSources/action';
 
 interface IProps {
     tableId: number;
@@ -19,7 +20,7 @@ interface IProps {
 export const BoardDataTableItem: React.FunctionComponent<IProps> = ({
     tableId,
 }) => {
-    const { table, schema } = useSelector((state: IStoreState) => {
+    const { table, schema } = useShallowSelector((state: IStoreState) => {
         const tableFromState = state.dataSources.dataTablesById[tableId];
         const schemaFromState = tableFromState
             ? state.dataSources.dataSchemasById[tableFromState.schema]

--- a/querybook/webapp/components/CodeMirrorTooltip/CodeMirrorTooltip.tsx
+++ b/querybook/webapp/components/CodeMirrorTooltip/CodeMirrorTooltip.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { IFunctionDescription } from 'const/metastore';
 import { useEvent } from 'hooks/useEvent';
+import { useShallowSelector } from 'hooks/redux/useShallowSelector';
 import { IStoreState } from 'redux/store/types';
 import * as dataSourcesActions from 'redux/dataSources/action';
 
@@ -27,23 +28,25 @@ export const CodeMirrorTooltip: React.FunctionComponent<ICodeMirrorTooltipProps>
     error,
     openTableModal,
 }) => {
-    const { table, schema, columns } = useSelector((state: IStoreState) => {
-        const tableFromState = state.dataSources.dataTablesById[tableId];
-        const schemaFromState = tableFromState
-            ? state.dataSources.dataSchemasById[tableFromState.schema]
-            : null;
-        const columnsFromState = tableFromState
-            ? (tableFromState.column || []).map(
-                  (id) => state.dataSources.dataColumnsById[id]
-              )
-            : [];
+    const { table, schema, columns } = useShallowSelector(
+        (state: IStoreState) => {
+            const tableFromState = state.dataSources.dataTablesById[tableId];
+            const schemaFromState = tableFromState
+                ? state.dataSources.dataSchemasById[tableFromState.schema]
+                : null;
+            const columnsFromState = tableFromState
+                ? (tableFromState.column || []).map(
+                      (id) => state.dataSources.dataColumnsById[id]
+                  )
+                : [];
 
-        return {
-            table: tableFromState,
-            schema: schemaFromState,
-            columns: columnsFromState,
-        };
-    });
+            return {
+                table: tableFromState,
+                schema: schemaFromState,
+                columns: columnsFromState,
+            };
+        }
+    );
 
     const dispatch = useDispatch();
 

--- a/querybook/webapp/components/DataDocNavigator/DataDocNavigator.tsx
+++ b/querybook/webapp/components/DataDocNavigator/DataDocNavigator.tsx
@@ -29,12 +29,13 @@ import { DataDocDraggableType, BoardDraggableType } from './navigatorConst';
 import { IDragItem } from 'ui/DraggableList/types';
 
 export const DataDocNavigator: React.FC = () => {
-    const loadedFilterModes = useSelector(
-        (state: IStoreState) =>
-            state.dataDoc.loadedEnvironmentFilterMode[
-                state.environment.currentEnvironmentId
-            ] ?? {}
-    );
+    const loadedFilterModes =
+        useSelector(
+            (state: IStoreState) =>
+                state.dataDoc.loadedEnvironmentFilterMode[
+                    state.environment.currentEnvironmentId
+                ]
+        ) ?? {};
 
     const dispatch: Dispatch = useDispatch();
     const loadDataDocs = useCallback(

--- a/querybook/webapp/components/DataTableNavigator/DataTableNavigator.tsx
+++ b/querybook/webapp/components/DataTableNavigator/DataTableNavigator.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { useSelector, useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
+import { useShallowSelector } from 'hooks/redux/useShallowSelector';
 import * as dataTableSearchActions from 'redux/dataTableSearch/action';
 import { IStoreState, Dispatch } from 'redux/store/types';
 import {
@@ -33,7 +34,7 @@ interface IDataTableNavigatorProps {
 
 const useDataTableNavigatorReduxState = () => {
     const queryMetastores = useSelector(queryMetastoresSelector);
-    const dataTableSearchState = useSelector((state: IStoreState) => ({
+    const dataTableSearchState = useShallowSelector((state: IStoreState) => ({
         dataTables: state.dataTableSearch.results,
         numDataTables: state.dataTableSearch.count,
         searchString: state.dataTableSearch.searchString,

--- a/querybook/webapp/components/Landing/Landing.tsx
+++ b/querybook/webapp/components/Landing/Landing.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { sample } from 'lodash';
 
+import { useShallowSelector } from 'hooks/redux/useShallowSelector';
 import { useBrowserTitle } from 'hooks/useBrowserTitle';
 import { titleize } from 'lib/utils';
 import { navigateWithinEnv } from 'lib/utils/query-string';
@@ -29,7 +30,7 @@ const DefaultLanding: React.FC = ({ children }) => {
         recentDataDocs,
         favoriteDataDocs,
         environment,
-    } = useSelector((state: IStoreState) => {
+    } = useShallowSelector((state: IStoreState) => {
         const recentDataDocsFromState = recentDataDocsSelector(state);
         const favoriteDataDocsFromState = favoriteDataDocsSelector(state).slice(
             0,

--- a/querybook/webapp/components/Search/SearchOverview.tsx
+++ b/querybook/webapp/components/Search/SearchOverview.tsx
@@ -1,23 +1,25 @@
 import React from 'react';
 import moment from 'moment';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { IDataDocPreview, ITablePreview } from 'const/search';
-import { IStoreState } from 'redux/store/types';
-import { RESULT_PER_PAGE, SearchOrder, SearchType } from 'redux/search/types';
 
+import { useShallowSelector } from 'hooks/redux/useShallowSelector';
 import { getCurrentEnv } from 'lib/utils/query-string';
 import {
     makeReactSelectStyle,
     miniReactSelectStyles,
 } from 'lib/utils/react-select';
 import * as searchActions from 'redux/search/action';
+import { IStoreState } from 'redux/store/types';
+import { RESULT_PER_PAGE, SearchOrder, SearchType } from 'redux/search/types';
 import * as dataTableSearchActions from 'redux/dataTableSearch/action';
 import { queryMetastoresSelector } from 'redux/dataSources/selector';
 import { currentEnvironmentSelector } from 'redux/environment/selector';
 
 import { UserSelect } from 'components/UserSelect/UserSelect';
 import { UserAvatar } from 'components/UserBadge/UserAvatar';
+import { TableTagGroupSelect } from 'components/DataTableTags/TableTagGroupSelect';
 import { DataDocItem, DataTableItem } from './SearchResultItem';
 
 import { Button } from 'ui/Button/Button';
@@ -34,11 +36,8 @@ import { Select } from 'ui/Select/Select';
 import { Tabs } from 'ui/Tabs/Tabs';
 import { PrettyNumber } from 'ui/PrettyNumber/PrettyNumber';
 
-import './SearchOverview.scss';
-import { TableTagGroupSelect } from 'components/DataTableTags/TableTagGroupSelect';
 import { SearchDatePicker } from './SearchDatePicker';
-
-const secondsPerDay = 60 * 60 * 24;
+import './SearchOverview.scss';
 
 const userReactSelectStyle = makeReactSelectStyle(true, miniReactSelectStyles);
 export const SearchOverview: React.FunctionComponent = () => {
@@ -57,7 +56,7 @@ export const SearchOverview: React.FunctionComponent = () => {
         searchRequest,
         queryMetastores,
         metastoreId,
-    } = useSelector((state: IStoreState) => ({
+    } = useShallowSelector((state: IStoreState) => ({
         ...state.search,
         environment: currentEnvironmentSelector(state),
         queryMetastores: queryMetastoresSelector(state),

--- a/querybook/webapp/hooks/redux/useShallowSelector.ts
+++ b/querybook/webapp/hooks/redux/useShallowSelector.ts
@@ -1,0 +1,25 @@
+import { useSelector, shallowEqual } from 'react-redux';
+import { IStoreState } from 'redux/store/types';
+
+/**
+ * Use this instead of useSelect ONLY IF the select would produce
+ * a new object or array and not via Reselect.
+ *
+ * The shallow comparsion would prevent a React state update
+ * via shallow comparsion instead of ===.
+ *
+ * Examples to use useShallowSelect
+ * - useShallowSelect((state) => ({ a: state.a, b: state.b }))
+ * - useShallowSelect((state) => [...state.a, ...state.b])
+ *
+ * Examples to NOT use useShallowSelect
+ * - useSelect((state) => state.a)
+ * - useSelect(reselectSelector)
+ *
+ * @param selector The same selector you would put in useSelect
+ */
+export function useShallowSelector<
+    F extends (state: IStoreState, ...args: any[]) => any
+>(selector: F): ReturnType<F> {
+    return useSelector(selector, shallowEqual);
+}

--- a/querybook/webapp/hooks/redux/useUserQueryEditorConfig.ts
+++ b/querybook/webapp/hooks/redux/useUserQueryEditorConfig.ts
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
 import { IStoreState } from 'redux/store/types';
 
 import { UserSettingsFontSizeToCSSFontSize } from 'const/font';
@@ -7,6 +6,7 @@ import { ISearchAndReplaceContextType } from 'context/searchAndReplace';
 import CodeMirror, { CodeMirrorKeyMap } from 'lib/codemirror';
 import { AutoCompleteType } from 'lib/sql-helper/sql-autocompleter';
 import { getCodeEditorTheme } from 'lib/utils';
+import { useShallowSelector } from './useShallowSelector';
 
 export function useUserQueryEditorConfig(
     searchContext: ISearchAndReplaceContextType
@@ -17,7 +17,7 @@ export function useUserQueryEditorConfig(
     options: CodeMirror.EditorConfiguration;
     autoCompleteType: AutoCompleteType;
 } {
-    const editorSettings = useSelector((state: IStoreState) => ({
+    const editorSettings = useShallowSelector((state: IStoreState) => ({
         theme: getCodeEditorTheme(state.user.computedSettings['theme']),
         fontSize:
             UserSettingsFontSizeToCSSFontSize[


### PR DESCRIPTION
The shallowEquals useSelector prevents unnecessary re-rendering of React components if the useSelector creates a new object