### PR TITLE
feat: Add latest_partition template function

### DIFF
--- a/docs_website/docs/user_guide/faq.md
+++ b/docs_website/docs/user_guide/faq.md
@@ -26,10 +26,11 @@ You can copy/cut the cell by hovering over the ⋮ menu on the right and paste t
 
 ### Q: How do I use templating? What capabilities does it have?
 
-You can add templating for DataDoc query cells. Querybook’s templating uses Jinja2 syntax and supports all of its functionalities. You can also define any custom templated variable that can be shared across different cells by clicking the `<>` button on the bottom right, they can infer other variables and be recursively rendered. Some variables are provided automatically. Such as:
+You can add templating for DataDoc query cells. Querybook’s templating uses Jinja2 syntax and supports all of its functionalities. You can also define any custom templated variable that can be shared across different cells by clicking the `<>` button on the bottom right, they can infer other variables and be recursively rendered. Some variables/functions are provided automatically. Such as:
 
 -   `{{today}}` which maps to todays date in yyyy-mm-dd
 -   `{{yesterday}}` which maps to yesterday’s date
+-   `{{latest_partition('<schema_name>.<table_name>', '<partition_key')}}` which is a function to get the latest partition of a table
 
 ### Q:How do I schedule a DataDoc?
 

--- a/docs_website/docs/user_guide/faq.md
+++ b/docs_website/docs/user_guide/faq.md
@@ -30,7 +30,7 @@ You can add templating for DataDoc query cells. Querybook’s templating uses Ji
 
 -   `{{today}}` which maps to todays date in yyyy-mm-dd
 -   `{{yesterday}}` which maps to yesterday’s date
--   `{{latest_partition('<schema_name>.<table_name>', '<partition_key')}}` which is a function to get the latest partition of a table
+-   `{{latest_partition('<schema_name>.<table_name>', '<partition_key>')}}` which is a function to get the latest partition of a table
 
 ### Q:How do I schedule a DataDoc?
 

--- a/querybook/server/datasources/query_execution.py
+++ b/querybook/server/datasources/query_execution.py
@@ -15,8 +15,7 @@ from clients.s3_client import FileDoesNotExist
 from lib.export.all_exporters import ALL_EXPORTERS, get_exporter
 from lib.result_store import GenericReader
 from lib.query_analysis.templating import (
-    render_templated_query,
-    get_templated_variables_in_string,
+    TemplatedQueryRenderer,
     QueryTemplatingError,
 )
 from lib.form import validate_form
@@ -373,17 +372,19 @@ def export_statement_execution_result(
     )
 
 
-@register("/query_execution/templated_query/", methods=["POST"])
-def get_templated_query(query: str, variables: Dict[str, str]):
+@register("/query_execution/templated_query/", methods=["GET"])
+def get_templated_query(query: str, variables: Dict[str, str], engine_id: int = None):
     try:
-        return render_templated_query(query, variables)
+        return TemplatedQueryRenderer(engine_id).render_templated_query(
+            query, variables
+        )
     except QueryTemplatingError as e:
         raise RequestException(e)
 
 
-@register("/query_execution/templated_query_params/", methods=["POST"])
+@register("/query_execution/templated_query_params/", methods=["GET"])
 def get_templated_query_params(query: str):
-    return list(get_templated_variables_in_string(query))
+    return list(TemplatedQueryRenderer().get_templated_variables_in_string(query))
 
 
 @register("/query_execution/<int:execution_id>/viewer/", methods=["POST"])

--- a/querybook/server/datasources/query_execution.py
+++ b/querybook/server/datasources/query_execution.py
@@ -15,8 +15,9 @@ from clients.s3_client import FileDoesNotExist
 from lib.export.all_exporters import ALL_EXPORTERS, get_exporter
 from lib.result_store import GenericReader
 from lib.query_analysis.templating import (
-    TemplatedQueryRenderer,
     QueryTemplatingError,
+    get_templated_variables_in_string,
+    render_templated_query,
 )
 from lib.form import validate_form
 from const.query_execution import QueryExecutionStatus
@@ -375,16 +376,14 @@ def export_statement_execution_result(
 @register("/query_execution/templated_query/", methods=["POST"])
 def get_templated_query(query: str, variables: Dict[str, str], engine_id: int = None):
     try:
-        return TemplatedQueryRenderer(engine_id).render_templated_query(
-            query, variables
-        )
+        return render_templated_query(query, variables, engine_id=engine_id)
     except QueryTemplatingError as e:
         raise RequestException(e)
 
 
 @register("/query_execution/templated_query_params/", methods=["POST"])
 def get_templated_query_params(query: str):
-    return list(TemplatedQueryRenderer().get_templated_variables_in_string(query))
+    return list(get_templated_variables_in_string(query))
 
 
 @register("/query_execution/<int:execution_id>/viewer/", methods=["POST"])

--- a/querybook/server/datasources/query_execution.py
+++ b/querybook/server/datasources/query_execution.py
@@ -376,7 +376,7 @@ def export_statement_execution_result(
 @register("/query_execution/templated_query/", methods=["POST"])
 def get_templated_query(query: str, variables: Dict[str, str], engine_id: int = None):
     try:
-        return render_templated_query(query, variables, engine_id=engine_id)
+        return render_templated_query(query, variables, engine_id)
     except QueryTemplatingError as e:
         raise RequestException(e)
 

--- a/querybook/server/datasources/query_execution.py
+++ b/querybook/server/datasources/query_execution.py
@@ -374,7 +374,7 @@ def export_statement_execution_result(
 
 
 @register("/query_execution/templated_query/", methods=["POST"])
-def get_templated_query(query: str, variables: Dict[str, str], engine_id: int = None):
+def get_templated_query(query: str, variables: Dict[str, str], engine_id: int):
     try:
         return render_templated_query(query, variables, engine_id)
     except QueryTemplatingError as e:

--- a/querybook/server/datasources/query_execution.py
+++ b/querybook/server/datasources/query_execution.py
@@ -372,7 +372,7 @@ def export_statement_execution_result(
     )
 
 
-@register("/query_execution/templated_query/", methods=["GET"])
+@register("/query_execution/templated_query/", methods=["POST"])
 def get_templated_query(query: str, variables: Dict[str, str], engine_id: int = None):
     try:
         return TemplatedQueryRenderer(engine_id).render_templated_query(
@@ -382,7 +382,7 @@ def get_templated_query(query: str, variables: Dict[str, str], engine_id: int = 
         raise RequestException(e)
 
 
-@register("/query_execution/templated_query_params/", methods=["GET"])
+@register("/query_execution/templated_query_params/", methods=["POST"])
 def get_templated_query_params(query: str):
     return list(TemplatedQueryRenderer().get_templated_variables_in_string(query))
 

--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -140,9 +140,8 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
         self._create_tables_batched(schema_tables)
 
     def get_latest_partition(self, schema_name, table_name):
-        table, _ = self.get_table_and_columns(schema_name, table_name)
-        partitions = table.partitions or []
-        latest_partition = partitions[-1] if len(partitions) else None
+        partitions = self.get_partitions(schema_name, table_name)
+        latest_partition = partitions[-1] if partitions and len(partitions) else None
         return latest_partition
 
     def _create_tables_batched(self, schema_tables):
@@ -248,6 +247,15 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
 
         batch_size = max(int(math.ceil(num_tables / num_threads)), min_batch_size)
         return batch_size
+
+    def get_partitions(self, schema_name: str, table_name: str) -> List[str]:
+        """Override this method to return a list of the given table's partitions
+        Returns None by default.
+
+        Returns:
+            List[str] -- [partition keys]
+        """
+        return None
 
     @abstractmethod
     def get_all_schema_names(self) -> List[str]:

--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -139,6 +139,12 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
                 ]
         self._create_tables_batched(schema_tables)
 
+    def get_latest_partition(self, schema_name, table_name):
+        table, _ = self.get_table_and_columns(schema_name, table_name)
+        partitions = table.partitions or []
+        latest_partition = partitions[-1] if len(partitions) else None
+        return latest_partition
+
     def _create_tables_batched(self, schema_tables):
         """Create greenlets for create table batches
 

--- a/querybook/server/lib/metastore/loaders/glue_data_catalog_loader.py
+++ b/querybook/server/lib/metastore/loaders/glue_data_catalog_loader.py
@@ -52,9 +52,7 @@ class GlueDataCatalogLoader(BaseMetastoreLoader):
         glue_table = self.glue_client.get_table(schema_name, table_name).get("Table")
 
         if self.load_partitions:
-            partitions = self.glue_client.get_hms_style_partitions(
-                schema_name, table_name
-            )
+            partitions = self.get_partitions(schema_name, table_name)
         else:
             partitions = []
 
@@ -86,6 +84,9 @@ class GlueDataCatalogLoader(BaseMetastoreLoader):
         )
 
         return table, columns
+
+    def get_partitions(self, schema_name: str, table_name: str) -> List[str]:
+        return self.glue_client.get_hms_style_partitions(schema_name, table_name)
 
     @staticmethod
     def _get_glue_data_catalog_client(catalog_id, region):

--- a/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
+++ b/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
@@ -45,9 +45,7 @@ class HMSMetastoreLoader(BaseMetastoreLoader):
 
         parameters = description.parameters
         sd = description.sd
-        partitions = get_hive_metastore_table_partitions(
-            self.hmc, schema_name, table_name
-        )
+        partitions = self.get_partitions(schema_name, table_name)
 
         last_modified_time = parameters.get("last_modified_time")
         last_modified_time = (
@@ -79,6 +77,9 @@ class HMSMetastoreLoader(BaseMetastoreLoader):
             )
         )
         return table, columns
+
+    def get_partitions(self, schema_name: str, table_name: str) -> List[str]:
+        return get_hive_metastore_table_partitions(self.hmc, schema_name, table_name)
 
     def _get_hmc(self, metastore_dict):
         return HiveMetastoreClient(hmss_ro_addrs=metastore_dict["metastore_params"])

--- a/querybook/server/lib/query_analysis/templating.py
+++ b/querybook/server/lib/query_analysis/templating.py
@@ -39,235 +39,231 @@ class LatestPartitionException(QueryTemplatingError):
 comment_re = re.compile(r"((?:--.*)|(?:\/\*(?:.|\n)*?\*\/))", re.MULTILINE)
 
 
-class TemplatedQueryRenderer(object):
-    def __init__(self, engine_id: int = None):
-        self.env = SandboxedEnvironment()
-        self.engine_id = engine_id
-        self.env.globals.update(latest_partition=self.create_get_latest_partition())
+def _escape_sql_comments(query: str):
+    return re.sub(
+        comment_re, lambda match: "{{ " + json.dumps(match.group()) + " }}", query
+    )
 
-    @staticmethod
-    def _escape_sql_comments(query: str):
-        return re.sub(
-            comment_re, lambda match: "{{ " + json.dumps(match.group()) + " }}", query
-        )
 
-    @staticmethod
-    def _detect_cycle_helper(node: str, dag: _DAG, seen: Set[str]) -> bool:
-        if node in seen:
+def _detect_cycle_helper(node: str, dag: _DAG, seen: Set[str]) -> bool:
+    if node in seen:
+        return True
+
+    seen.add(node)
+
+    children = dag.get(node, [])
+    for child in children:
+        if _detect_cycle_helper(child, dag, seen):
             return True
+    seen.remove(node)
+    return False
 
-        seen.add(node)
 
-        children = dag.get(node, [])
-        for child in children:
-            if TemplatedQueryRenderer._detect_cycle_helper(child, dag, seen):
-                return True
-        seen.remove(node)
-        return False
+def _detect_cycle(dag: _DAG) -> bool:
+    seen = set()
+    return any(_detect_cycle_helper(node, dag, seen) for node in dag.keys())
 
-    @staticmethod
-    def _detect_cycle(dag: _DAG) -> bool:
-        seen = set()
-        return any(
-            TemplatedQueryRenderer._detect_cycle_helper(node, dag, seen)
-            for node in dag.keys()
+
+def get_default_variables():
+    return {
+        "today": datetime.today().strftime("%Y-%m-%d"),
+        "yesterday": (datetime.today() - timedelta(1)).strftime("%Y-%m-%d"),
+    }
+
+
+def create_get_latest_partition(engine_id) -> Callable[[str, str], str]:
+    metastore_loader = None
+    with DBSession() as session:
+        engine = admin_logic.get_query_engine_by_id(engine_id, session=session)
+        metastore_id = engine.metastore_id if engine else None
+        metastore_loader = (
+            metastore.get_metastore_loader(metastore_id, session=session)
+            if metastore_id is not None
+            else None
         )
 
-    @staticmethod
-    def get_default_variables():
-        return {
-            "today": datetime.today().strftime("%Y-%m-%d"),
-            "yesterday": (datetime.today() - timedelta(1)).strftime("%Y-%m-%d"),
-        }
+    def get_latest_partition(full_table_name: str, partition: str) -> str:
+        """Returns latest partition function of a given table and partition key
+            Args:
+            full_table_name {str} - full table name in the format <schema_name>.<table_name>
+            partition {str} - partition key
 
-    def create_get_latest_partition(self) -> Callable[[str, str], str]:
-        metastore_loader = None
-        with DBSession() as session:
-            engine = admin_logic.get_query_engine_by_id(self.engine_id, session=session)
-            metastore_id = engine.metastore_id if engine else None
-            metastore_loader = (
-                metastore.get_metastore_loader(metastore_id, session=session)
-                if metastore_id is not None
-                else None
-            )
+        Raises:
+            LatestPartitionException: If unable to get latest partition with engine_id, partition, and full_table_name
 
-        def get_latest_partition(full_table_name: str, partition: str) -> str:
-            """Returns latest partition function of a given table and partition key
-                Args:
-                full_table_name {str} - full table name in the format <schema_name>.<table_name>
-                partition {str} - partition key
-
-            Raises:
-                LatestPartitionException: If unable to get latest partition with engine_id, partition, and full_table_name
-
-            Returns:
-                str - value of latest partition
-            """
-            full_table_name_parts = full_table_name.split(".")
-            if not len(full_table_name_parts) == 2:
-                raise LatestPartitionException(
-                    f"Full table name '{full_table_name}' is invalid. Must be in the format <schema_name>.<table_name>"
-                )
-            [schema_name, table_name] = full_table_name_parts
-
-            # metastore_loader only needs to be available for `get_latest_partition` function call,
-            # so this check is made here
-            if metastore_loader is None:
-                raise LatestPartitionException(
-                    f"Unable to load metastore for engine id {self.engine_id}"
-                )
-
-            latest_partition = metastore_loader.get_latest_partition(
-                schema_name, table_name
-            )
-            if latest_partition:  # latest_partitions is like dt=2015-01-01/column1=val1
-                for partition_col in latest_partition.split("/"):
-                    partition_key, partition_val = partition_col.split("=")
-                    if partition_key == partition:
-                        return partition_val
+        Returns:
+            str - value of latest partition
+        """
+        full_table_name_parts = full_table_name.split(".")
+        if not len(full_table_name_parts) == 2:
             raise LatestPartitionException(
-                f"Partitition '{partition}' not found on table '{full_table_name}'"
+                f"Full table name '{full_table_name}' is invalid. Must be in the format <schema_name>.<table_name>"
+            )
+        [schema_name, table_name] = full_table_name_parts
+
+        # metastore_loader only needs to be available for `get_latest_partition` function call,
+        # so this check is made here
+        if metastore_loader is None:
+            raise LatestPartitionException(
+                f"Unable to load metastore for engine id {engine_id}"
             )
 
-        return get_latest_partition
-
-    def get_templated_variables_in_string(self, s: str) -> Set[str]:
-        """Find possible templated variables within a string
-
-        Arguments:
-            s {str}
-        Returns:
-            Set[str] - set of variable names
-        """
-        ast = self.env.parse(s)
-        variables = meta.find_undeclared_variables(ast)
-
-        # temporarily applying https://github.com/pallets/jinja/pull/994/files
-        # since the current version is binded by flask
-        filtered_variables = set()
-        for variable in variables:
-            if variable not in self.env.globals:
-                filtered_variables.add(variable)
-
-        return filtered_variables
-
-    @staticmethod
-    def verify_all_variables_are_defined(variables_required, variables_provided):
-        for variable_name in variables_required:
-            if variable_name not in variables_provided:
-                raise UndefinedVariableException(
-                    "Invalid variable name {}".format(variable_name)
-                )
-
-    def render_query_with_variables(self, s, variables):
-        template = self.env.from_string(s)
-
-        return template.render(**variables)
-
-    def _flatten_variable(
-        var_name: str,
-        variable_defs: Dict[str, str],
-        variables_dag: Dict[str, Set[str]],
-        flattened_variables: Dict[str, str],
-    ):
-        """ Helper function for flatten_recursive_variables.
-            Recursively resolve each variable definition
-        """
-        var_deps = variables_dag[var_name]
-        for dep_var_name in var_deps:
-            # Resolve anything that is not defined
-            if dep_var_name not in flattened_variables:
-                TemplatedQueryRenderer._flatten_variable(
-                    dep_var_name, variable_defs, variables_dag, flattened_variables,
-                )
-
-        # Now all dependencies are solved
-        env = SandboxedEnvironment(autoescape=False)
-        template = env.from_string(variable_defs[var_name])
-        flattened_variables[var_name] = template.render(
-            **{
-                dep_var_name: flattened_variables[dep_var_name]
-                for dep_var_name in var_deps
-            }
+        latest_partition = metastore_loader.get_latest_partition(
+            schema_name, table_name
+        )
+        if latest_partition:  # latest_partitions is like dt=2015-01-01/column1=val1
+            for partition_col in latest_partition.split("/"):
+                partition_key, partition_val = partition_col.split("=")
+                if partition_key == partition:
+                    return partition_val
+        raise LatestPartitionException(
+            f"Partitition '{partition}' not found on table '{full_table_name}'"
         )
 
-    def flatten_recursive_variables(
-        self, raw_variables: Dict[str, str]
-    ) -> Dict[str, str]:
-        """Given a list of variables, recursively replace variables that refers other variables
+    return get_latest_partition
 
-        Arguments:
-            raw_variables {Dict[str, str]} -- The variable name/value pair
-        Raises:
-            UndefinedVariableException: If the variable refers to a variable that does not exist
-            QueryHasCycleException: If the partials contains a cycle
 
-        Returns:
-            Dict[str, str] -- the variables replaced with other variables
-        """
-        flattened_variables = {}
-        variables_dag = {}
+def get_templated_variables_in_string(s: str, env=None) -> Set[str]:
+    """Find possible templated variables within a string
 
-        for key, value in raw_variables.items():
-            if not value:
-                value = ""
+    Arguments:
+        s {str}
+    Returns:
+        Set[str] - set of variable names
+    """
+    env = env or SandboxedEnvironment()
+    ast = env.parse(s)
+    variables = meta.find_undeclared_variables(ast)
 
-            variables_in_value = self.get_templated_variables_in_string(value)
+    # temporarily applying https://github.com/pallets/jinja/pull/994/files
+    # since the current version is binded by flask
+    filtered_variables = set()
+    for variable in variables:
+        if variable not in env.globals:
+            filtered_variables.add(variable)
 
-            if len(variables_in_value) == 0:
-                flattened_variables[key] = value
-            else:
-                for var_in_value in variables_in_value:
-                    # Double check if the recursive referred variable is valid
-                    if var_in_value not in raw_variables:
-                        raise UndefinedVariableException(
-                            "Invalid variable name: {}.".format(var_in_value)
-                        )
-                variables_dag[key] = variables_in_value
+    return filtered_variables
 
-        if TemplatedQueryRenderer._detect_cycle(variables_dag):
-            raise QueryHasCycleException(
-                "Infinite recursion in variable definition detected."
+
+def verify_all_variables_are_defined(variables_required, variables_provided):
+    for variable_name in variables_required:
+        if variable_name not in variables_provided:
+            raise UndefinedVariableException(
+                "Invalid variable name {}".format(variable_name)
             )
 
-        # Resolve everything within the dag
-        for var_name in variables_dag:
-            TemplatedQueryRenderer._flatten_variable(
-                var_name, raw_variables, variables_dag, flattened_variables
-            )
-        return flattened_variables
 
-    def get_templated_query_variables(self, variables_provided):
-        return self.flatten_recursive_variables(
-            {**TemplatedQueryRenderer.get_default_variables(), **variables_provided,}
+def render_query_with_variables(s, variables, env):
+    template = env.from_string(s)
+
+    return template.render(**variables)
+
+
+def _flatten_variable(
+    var_name: str,
+    variable_defs: Dict[str, str],
+    variables_dag: Dict[str, Set[str]],
+    flattened_variables: Dict[str, str],
+):
+    """ Helper function for flatten_recursive_variables.
+        Recursively resolve each variable definition
+    """
+    var_deps = variables_dag[var_name]
+    for dep_var_name in var_deps:
+        # Resolve anything that is not defined
+        if dep_var_name not in flattened_variables:
+            _flatten_variable(
+                dep_var_name, variable_defs, variables_dag, flattened_variables,
+            )
+
+    # Now all dependencies are solved
+    env = SandboxedEnvironment(autoescape=False)
+    template = env.from_string(variable_defs[var_name])
+    flattened_variables[var_name] = template.render(
+        **{dep_var_name: flattened_variables[dep_var_name] for dep_var_name in var_deps}
+    )
+
+
+def flatten_recursive_variables(
+    raw_variables: Dict[str, str], env=None
+) -> Dict[str, str]:
+    """Given a list of variables, recursively replace variables that refers other variables
+
+    Arguments:
+        raw_variables {Dict[str, str]} -- The variable name/value pair
+    Raises:
+        UndefinedVariableException: If the variable refers to a variable that does not exist
+        QueryHasCycleException: If the partials contains a cycle
+
+    Returns:
+        Dict[str, str] -- the variables replaced with other variables
+    """
+    flattened_variables = {}
+    variables_dag = {}
+
+    for key, value in raw_variables.items():
+        if not value:
+            value = ""
+
+        variables_in_value = get_templated_variables_in_string(value, env)
+
+        if len(variables_in_value) == 0:
+            flattened_variables[key] = value
+        else:
+            for var_in_value in variables_in_value:
+                # Double check if the recursive referred variable is valid
+                if var_in_value not in raw_variables:
+                    raise UndefinedVariableException(
+                        "Invalid variable name: {}.".format(var_in_value)
+                    )
+            variables_dag[key] = variables_in_value
+
+    if _detect_cycle(variables_dag):
+        raise QueryHasCycleException(
+            "Infinite recursion in variable definition detected."
         )
 
-    def render_templated_query(self, query: str, variables: Dict[str, str]) -> str:
-        """Renders the templated query, with global variables such as today/yesterday and functions such as `latest_partition`.
-        All the default html escape is ignore since it is not applicable.
-        It also checks if a variable is a partial (in which it can refer other variables).
+    # Resolve everything within the dag
+    for var_name in variables_dag:
+        _flatten_variable(var_name, raw_variables, variables_dag, flattened_variables)
+    return flattened_variables
 
 
-        Arguments:
-            query {str} -- The query string that would get rendered
-            raw_variables {Dict[str, str]} -- The variable name, variable value string pair
+def get_templated_query_variables(variables_provided, env=None):
+    return flatten_recursive_variables(
+        {**get_default_variables(), **variables_provided,}, env
+    )
 
-        Raises:
-            UndefinedVariableException: If the variable refers to a variable that does not exist
-            QueryHasCycleException: If the partials contains a cycle
 
-        Returns:
-            str -- The rendered string
-        """
-        try:
-            escaped_query = TemplatedQueryRenderer._escape_sql_comments(query)
-            variables_in_query = self.get_templated_variables_in_string(escaped_query)
+def render_templated_query(
+    query: str, variables: Dict[str, str], engine_id: int = None
+) -> str:
+    """Renders the templated query, with global variables such as today/yesterday
+    and functions such as `latest_partition`.
+    All the default html escape is ignore since it is not applicable.
+    It also checks if a variable is a partial (in which it can refer other variables).
 
-            all_variables = self.get_templated_query_variables(variables)
-            TemplatedQueryRenderer.verify_all_variables_are_defined(
-                variables_in_query, all_variables
-            )
 
-            return self.render_query_with_variables(escaped_query, all_variables)
-        except TemplateSyntaxError as e:
-            raise QueryJinjaSyntaxException(f"Line {e.lineno}: {e.message}")
+    Arguments:
+        query {str} -- The query string that would get rendered
+        raw_variables {Dict[str, str]} -- The variable name, variable value string pair
+
+    Raises:
+        UndefinedVariableException: If the variable refers to a variable that does not exist
+        QueryHasCycleException: If the partials contains a cycle
+
+    Returns:
+        str -- The rendered string
+    """
+    env = SandboxedEnvironment()
+    env.globals.update(latest_partition=create_get_latest_partition(engine_id))
+    try:
+        escaped_query = _escape_sql_comments(query)
+        variables_in_query = get_templated_variables_in_string(escaped_query, env)
+
+        all_variables = get_templated_query_variables(variables, env)
+        verify_all_variables_are_defined(variables_in_query, all_variables)
+
+        return render_query_with_variables(escaped_query, all_variables, env)
+    except TemplateSyntaxError as e:
+        raise QueryJinjaSyntaxException(f"Line {e.lineno}: {e.message}")

--- a/querybook/server/lib/query_analysis/templating.py
+++ b/querybook/server/lib/query_analysis/templating.py
@@ -240,7 +240,7 @@ class TemplatedQueryRenderer(object):
         )
 
     def render_templated_query(self, query: str, variables: Dict[str, str]) -> str:
-        """Renders the templated query, with global variables such as today, yesterday.
+        """Renders the templated query, with global variables such as today/yesterday and functions such as `latest_partition`.
         All the default html escape is ignore since it is not applicable.
         It also checks if a variable is a partial (in which it can refer other variables).
 

--- a/querybook/server/lib/query_analysis/templating.py
+++ b/querybook/server/lib/query_analysis/templating.py
@@ -7,6 +7,10 @@ from jinja2.exceptions import TemplateSyntaxError
 from jinja2.sandbox import SandboxedEnvironment
 from jinja2 import meta
 
+from app.db import with_session
+from lib import metastore
+from logic import admin as admin_logic
+
 _DAG = Dict[str, Set[str]]
 
 
@@ -26,179 +30,241 @@ class QueryJinjaSyntaxException(QueryTemplatingError):
     pass
 
 
+class LatestPartitionFunctionException(QueryTemplatingError):
+    pass
+
+
 # The first part is regex for single line comment, ie -- some comment
 # the second part is for multi line comment, ie /* test */
 comment_re = re.compile(r"((?:--.*)|(?:\/\*(?:.|\n)*?\*\/))", re.MULTILINE)
 
 
-def _escape_sql_comments(query: str):
-    return re.sub(
-        comment_re, lambda match: "{{ " + json.dumps(match.group()) + " }}", query
-    )
+class TemplatedQueryRenderer(object):
+    def __init__(self, engine_id: int = None):
+        self.env = SandboxedEnvironment()
+        self.engine_id = engine_id
+        self.env.globals.update(latest_partition=self.get_latest_partition)
 
-
-def _detect_cycle_helper(node: str, dag: _DAG, seen: Set[str]) -> bool:
-    if node in seen:
-        return True
-
-    seen.add(node)
-
-    children = dag.get(node, [])
-    for child in children:
-        if _detect_cycle_helper(child, dag, seen):
-            return True
-    seen.remove(node)
-    return False
-
-
-def _detect_cycle(dag: _DAG) -> bool:
-    seen = set()
-    return any(_detect_cycle_helper(node, dag, seen) for node in dag.keys())
-
-
-def get_default_variables():
-    return {
-        "today": datetime.today().strftime("%Y-%m-%d"),
-        "yesterday": (datetime.today() - timedelta(1)).strftime("%Y-%m-%d"),
-    }
-
-
-def get_templated_variables_in_string(s: str) -> Set[str]:
-    """Find possible templated variables within a string
-
-    Arguments:
-        s {str}
-    Returns:
-        Set[str] - set of variable names
-    """
-
-    env = SandboxedEnvironment()
-    ast = env.parse(s)
-    variables = meta.find_undeclared_variables(ast)
-
-    # temporarily applying https://github.com/pallets/jinja/pull/994/files
-    # since the current version is binded by flask
-    filtered_variables = set()
-    for variable in variables:
-        if variable not in env.globals:
-            filtered_variables.add(variable)
-
-    return filtered_variables
-
-
-def verify_all_variables_are_defined(variables_required, variables_provided):
-    for variable_name in variables_required:
-        if variable_name not in variables_provided:
-            raise UndefinedVariableException(
-                "Invalid variable name {}".format(variable_name)
-            )
-
-
-def render_query_with_variables(s, variables):
-    env = SandboxedEnvironment(autoescape=False)
-    template = env.from_string(s)
-
-    return template.render(**variables)
-
-
-def _flatten_variable(
-    var_name: str,
-    variable_defs: Dict[str, str],
-    variables_dag: Dict[str, Set[str]],
-    flattened_variables: Dict[str, str],
-):
-    """ Helper function for flatten_recursive_variables.
-        Recurisvely resolve each variable definition
-    """
-    var_deps = variables_dag[var_name]
-    for dep_var_name in var_deps:
-        # Resolve anything that is not defined
-        if dep_var_name not in flattened_variables:
-            _flatten_variable(
-                dep_var_name, variable_defs, variables_dag, flattened_variables,
-            )
-
-    # Now all dependencies are solved
-    env = SandboxedEnvironment(autoescape=False)
-    template = env.from_string(variable_defs[var_name])
-    flattened_variables[var_name] = template.render(
-        **{dep_var_name: flattened_variables[dep_var_name] for dep_var_name in var_deps}
-    )
-
-
-def flatten_recursive_variables(raw_variables: Dict[str, str]) -> Dict[str, str]:
-    """Given a list of variables, recursively replace variables that refers other variables
-
-    Arguments:
-        raw_variables {Dict[str, str]} -- The variable name/value pair
-    Raises:
-        UndefinedVariableException: If the variable refers to a variable that does not exist
-        QueryHasCycleException: If the partials contains a cycle
-
-    Returns:
-        Dict[str, str] -- the variables replaced with other variables
-    """
-    flattened_variables = {}
-    variables_dag = {}
-
-    for key, value in raw_variables.items():
-        if not value:
-            value = ""
-
-        variables_in_value = get_templated_variables_in_string(value)
-
-        if len(variables_in_value) == 0:
-            flattened_variables[key] = value
-        else:
-            for var_in_value in variables_in_value:
-                # Double check if the recursive referred variable is valid
-                if var_in_value not in raw_variables:
-                    raise UndefinedVariableException(
-                        "Invalid variable name: {}.".format(var_in_value)
-                    )
-            variables_dag[key] = variables_in_value
-
-    if _detect_cycle(variables_dag):
-        raise QueryHasCycleException(
-            "Infinite recursion in variable definition detected."
+    @staticmethod
+    def _escape_sql_comments(query: str):
+        return re.sub(
+            comment_re, lambda match: "{{ " + json.dumps(match.group()) + " }}", query
         )
 
-    # Resolve everything within the dag
-    for var_name in variables_dag:
-        _flatten_variable(var_name, raw_variables, variables_dag, flattened_variables)
-    return flattened_variables
+    @staticmethod
+    def _detect_cycle_helper(node: str, dag: _DAG, seen: Set[str]) -> bool:
+        if node in seen:
+            return True
+
+        seen.add(node)
+
+        children = dag.get(node, [])
+        for child in children:
+            if TemplatedQueryRenderer._detect_cycle_helper(child, dag, seen):
+                return True
+        seen.remove(node)
+        return False
+
+    @staticmethod
+    def _detect_cycle(dag: _DAG) -> bool:
+        seen = set()
+        return any(
+            TemplatedQueryRenderer._detect_cycle_helper(node, dag, seen)
+            for node in dag.keys()
+        )
+
+    @staticmethod
+    def get_default_variables():
+        return {
+            "today": datetime.today().strftime("%Y-%m-%d"),
+            "yesterday": (datetime.today() - timedelta(1)).strftime("%Y-%m-%d"),
+        }
+
+    @with_session
+    def get_latest_partition(
+        self, full_table_name: str, partition: str, session=None
+    ) -> str:
+        """Returns latest partition value of a given table and partition key
+        Args:
+            full_table_name {str} - full table name in the format <schema_name>.<table_name>
+            partition {str} - partition key
+
+        Raises:
+            LatestPartitionFunctionException: If unable to get latest partition with engine_id, partition, and full_table_name
+
+        Returns:
+            str - value of latest partition
+        """
+        engine = admin_logic.get_query_engine_by_id(self.engine_id, session=session)
+        metastore_id = engine.metastore_id if engine else None
+        metastore_loader = (
+            metastore.get_metastore_loader(metastore_id, session=session)
+            if metastore_id is not None
+            else None
+        )
+        if metastore_loader is None:
+            raise LatestPartitionFunctionException(
+                "Unable to load metastore for engine id {}".format(self.engine_id)
+            )
+        full_table_name_parts = full_table_name.split(".")
+        if not len(full_table_name_parts) == 2:
+            raise LatestPartitionFunctionException(
+                "Full table name '{}' is invalid. Must be in the format <schema_name>.<table_name>".format(
+                    full_table_name
+                )
+            )
+        [schema_name, table_name] = full_table_name_parts
+        latest_partition = metastore_loader.get_latest_partition(
+            schema_name, table_name
+        )
+        if latest_partition:  # latest_partitions is like dt=2015-01-01/column1=val1
+            for partition_col in latest_partition.split("/"):
+                partition_key, partition_val = partition_col.split("=")
+                if partition_key == partition:
+                    return partition_val
+        raise LatestPartitionFunctionException(
+            "Partitition '{}' not found on table '{}'".format(
+                partition, full_table_name
+            )
+        )
+
+    def get_templated_variables_in_string(self, s: str) -> Set[str]:
+        """Find possible templated variables within a string
+
+        Arguments:
+            s {str}
+        Returns:
+            Set[str] - set of variable names
+        """
+        ast = self.env.parse(s)
+        variables = meta.find_undeclared_variables(ast)
+
+        # temporarily applying https://github.com/pallets/jinja/pull/994/files
+        # since the current version is binded by flask
+        filtered_variables = set()
+        for variable in variables:
+            if variable not in self.env.globals:
+                filtered_variables.add(variable)
+
+        return filtered_variables
+
+    @staticmethod
+    def verify_all_variables_are_defined(variables_required, variables_provided):
+        for variable_name in variables_required:
+            if variable_name not in variables_provided:
+                raise UndefinedVariableException(
+                    "Invalid variable name {}".format(variable_name)
+                )
+
+    def render_query_with_variables(self, s, variables):
+        template = self.env.from_string(s)
+
+        return template.render(**variables)
+
+    def _flatten_variable(
+        var_name: str,
+        variable_defs: Dict[str, str],
+        variables_dag: Dict[str, Set[str]],
+        flattened_variables: Dict[str, str],
+    ):
+        """ Helper function for flatten_recursive_variables.
+            Recurisvely resolve each variable definition
+        """
+        var_deps = variables_dag[var_name]
+        for dep_var_name in var_deps:
+            # Resolve anything that is not defined
+            if dep_var_name not in flattened_variables:
+                TemplatedQueryRenderer._flatten_variable(
+                    dep_var_name, variable_defs, variables_dag, flattened_variables,
+                )
+
+        # Now all dependencies are solved
+        env = SandboxedEnvironment(autoescape=False)
+        template = env.from_string(variable_defs[var_name])
+        flattened_variables[var_name] = template.render(
+            **{
+                dep_var_name: flattened_variables[dep_var_name]
+                for dep_var_name in var_deps
+            }
+        )
+
+    def flatten_recursive_variables(
+        self, raw_variables: Dict[str, str]
+    ) -> Dict[str, str]:
+        """Given a list of variables, recursively replace variables that refers other variables
+
+        Arguments:
+            raw_variables {Dict[str, str]} -- The variable name/value pair
+        Raises:
+            UndefinedVariableException: If the variable refers to a variable that does not exist
+            QueryHasCycleException: If the partials contains a cycle
+
+        Returns:
+            Dict[str, str] -- the variables replaced with other variables
+        """
+        flattened_variables = {}
+        variables_dag = {}
+
+        for key, value in raw_variables.items():
+            if not value:
+                value = ""
+
+            variables_in_value = self.get_templated_variables_in_string(value)
+
+            if len(variables_in_value) == 0:
+                flattened_variables[key] = value
+            else:
+                for var_in_value in variables_in_value:
+                    # Double check if the recursive referred variable is valid
+                    if var_in_value not in raw_variables:
+                        raise UndefinedVariableException(
+                            "Invalid variable name: {}.".format(var_in_value)
+                        )
+                variables_dag[key] = variables_in_value
+
+        if TemplatedQueryRenderer._detect_cycle(variables_dag):
+            raise QueryHasCycleException(
+                "Infinite recursion in variable definition detected."
+            )
+
+        # Resolve everything within the dag
+        for var_name in variables_dag:
+            TemplatedQueryRenderer._flatten_variable(
+                var_name, raw_variables, variables_dag, flattened_variables
+            )
+        return flattened_variables
+
+    def get_templated_query_variables(self, variables_provided):
+        return self.flatten_recursive_variables(
+            {**TemplatedQueryRenderer.get_default_variables(), **variables_provided,}
+        )
+
+    def render_templated_query(self, query: str, variables: Dict[str, str]) -> str:
+        """Renders the templated query, with global variables such as today, yesterday.
+        All the default html escape is ignore since it is not applicable.
+        It also checks if a variable is a partial (in which it can refer other variables).
 
 
-def get_templated_query_variables(variables_provided):
-    return flatten_recursive_variables(
-        {**get_default_variables(), **variables_provided,}
-    )
+        Arguments:
+            query {str} -- The query string that would get rendered
+            raw_variables {Dict[str, str]} -- The variable name, variable value string pair
 
+        Raises:
+            UndefinedVariableException: If the variable refers to a variable that does not exist
+            QueryHasCycleException: If the partials contains a cycle
 
-def render_templated_query(query: str, variables: Dict[str, str]) -> str:
-    """Renders the templated query, with global variables such as today, yesterday.
-       All the default html escape is ignore since it is not applicable.
-       It also checks if a variable is a partial (in which it can refer other variables).
+        Returns:
+            str -- The rendered string
+        """
+        try:
+            escaped_query = TemplatedQueryRenderer._escape_sql_comments(query)
+            variables_in_query = self.get_templated_variables_in_string(escaped_query)
 
+            all_variables = self.get_templated_query_variables(variables)
+            TemplatedQueryRenderer.verify_all_variables_are_defined(
+                variables_in_query, all_variables
+            )
 
-    Arguments:
-        query {str} -- The query string that would get rendered
-        raw_variables {Dict[str, str]} -- The variable name, variable value string pair
-
-    Raises:
-        UndefinedVariableException: If the variable refers to a variable that does not exist
-        QueryHasCycleException: If the partials contains a cycle
-
-    Returns:
-        str -- The rendered string
-    """
-    try:
-        escaped_query = _escape_sql_comments(query)
-        variables_in_query = get_templated_variables_in_string(escaped_query)
-
-        all_variables = get_templated_query_variables(variables)
-        verify_all_variables_are_defined(variables_in_query, all_variables)
-
-        return render_query_with_variables(escaped_query, all_variables)
-    except TemplateSyntaxError as e:
-        raise QueryJinjaSyntaxException(f"Line {e.lineno}: {e.message}")
+            return self.render_query_with_variables(escaped_query, all_variables)
+        except TemplateSyntaxError as e:
+            raise QueryJinjaSyntaxException(f"Line {e.lineno}: {e.message}")

--- a/querybook/server/tasks/run_datadoc.py
+++ b/querybook/server/tasks/run_datadoc.py
@@ -7,7 +7,7 @@ from const.query_execution import QueryExecutionStatus
 from const.schedule import NotifyOn, TaskRunStatus
 
 from lib.logger import get_logger
-from lib.query_analysis.templating import TemplatedQueryRenderer
+from lib.query_analysis.templating import render_templated_query
 from lib.scheduled_datadoc.export import export_datadoc
 from lib.scheduled_datadoc.legacy import convert_if_legacy_datadoc_schedule
 from lib.scheduled_datadoc.notification import notifiy_on_datadoc_complete
@@ -58,8 +58,8 @@ def run_datadoc_with_config(
         # Preping chain jobs each unit is a [make_qe_task, run_query_task] combo
         for index, query_cell in enumerate(query_cells):
             engine_id = query_cell.meta["engine"]
-            query = TemplatedQueryRenderer(engine_id).render_templated_query(
-                query_cell.context, data_doc.meta
+            query = render_templated_query(
+                query_cell.context, data_doc.meta, engine_id=engine_id
             )
 
             start_query_execution_kwargs = {

--- a/querybook/server/tasks/run_datadoc.py
+++ b/querybook/server/tasks/run_datadoc.py
@@ -58,15 +58,13 @@ def run_datadoc_with_config(
         # Preping chain jobs each unit is a [make_qe_task, run_query_task] combo
         for index, query_cell in enumerate(query_cells):
             engine_id = query_cell.meta["engine"]
-            query = render_templated_query(
-                query_cell.context, data_doc.meta, engine_id=engine_id
-            )
+            query = render_templated_query(query_cell.context, data_doc.meta, engine_id)
 
             start_query_execution_kwargs = {
                 "cell_id": query_cell.id,
                 "query_execution_params": {
                     "query": query,
-                    "engine_id": query_cell.meta["engine"],
+                    "engine_id": engine_id,
                     "uid": runner_id,
                 },
             }

--- a/querybook/server/tasks/run_datadoc.py
+++ b/querybook/server/tasks/run_datadoc.py
@@ -7,7 +7,7 @@ from const.query_execution import QueryExecutionStatus
 from const.schedule import NotifyOn, TaskRunStatus
 
 from lib.logger import get_logger
-from lib.query_analysis.templating import render_templated_query
+from lib.query_analysis.templating import TemplatedQueryRenderer
 from lib.scheduled_datadoc.export import export_datadoc
 from lib.scheduled_datadoc.legacy import convert_if_legacy_datadoc_schedule
 from lib.scheduled_datadoc.notification import notifiy_on_datadoc_complete
@@ -57,7 +57,10 @@ def run_datadoc_with_config(
 
         # Preping chain jobs each unit is a [make_qe_task, run_query_task] combo
         for index, query_cell in enumerate(query_cells):
-            query = render_templated_query(query_cell.context, data_doc.meta)
+            engine_id = query_cell.meta["engine"]
+            query = TemplatedQueryRenderer(engine_id).render_templated_query(
+                query_cell.context, data_doc.meta
+            )
 
             start_query_execution_kwargs = {
                 "cell_id": query_cell.id,

--- a/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
+++ b/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
@@ -296,7 +296,11 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
 
         try {
             const rawQuery = getSelectedQuery(query, selectedRange);
-            return await renderTemplatedQuery(rawQuery, templatedVariables);
+            return await renderTemplatedQuery(
+                rawQuery,
+                templatedVariables,
+                this.engineId
+            );
         } catch (e) {
             toast.error(
                 <div>
@@ -627,6 +631,7 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
                 <TemplatedQueryView
                     query={query}
                     templatedVariables={templatedVariables}
+                    engineId={this.engineId}
                     onRunQueryClick={this.handleRunFromRenderedTemplateModal}
                 />
             </Modal>

--- a/querybook/webapp/components/QuerySnippetInsertionModal/QuerySnippetView.tsx
+++ b/querybook/webapp/components/QuerySnippetInsertionModal/QuerySnippetView.tsx
@@ -62,14 +62,15 @@ export class QuerySnippetView extends React.PureComponent<
 
     @bind
     public async handleQuerySnippetInsert() {
-        const context = this.props.querySnippet.context;
+        const { context, engine_id: engineId } = this.props.querySnippet;
         const { templatedVariables } = this.state;
 
         let renderedQuery = context;
         if (templatedVariables.length) {
             renderedQuery = await renderTemplatedQuery(
                 context,
-                this.state.templatedQueryForm
+                this.state.templatedQueryForm,
+                engineId
             );
         }
 

--- a/querybook/webapp/components/TemplateDataDocButton/DataDocTemplateVarForm.tsx
+++ b/querybook/webapp/components/TemplateDataDocButton/DataDocTemplateVarForm.tsx
@@ -128,6 +128,11 @@ export const DataDocTemplateVarForm: React.FunctionComponent<IDataDocTemplateVar
                                                         "{{yesterday}} which maps to yesterday's date"
                                                     }
                                                 </li>
+                                                <li>
+                                                    {
+                                                        "{{latest_partition('<schema_name>.<table_name>', '<partition_key>')}} which is a function to get the latest partition of a table"
+                                                    }
+                                                </li>
                                             </ul>
                                         </p>
                                         <p>

--- a/querybook/webapp/components/TemplateQueryView/TemplatedQueryView.tsx
+++ b/querybook/webapp/components/TemplateQueryView/TemplatedQueryView.tsx
@@ -13,12 +13,14 @@ import './TemplatedQueryView.scss';
 export interface ITemplatedQueryViewProps {
     query: string;
     templatedVariables: Record<string, string>;
+    engineId: number;
     onRunQueryClick?: () => void;
 }
 
 export const TemplatedQueryView: React.FC<ITemplatedQueryViewProps> = ({
     query,
     templatedVariables,
+    engineId,
     onRunQueryClick,
 }) => {
     const { data: renderedQuery, isLoading, error } = useResource(
@@ -26,7 +28,8 @@ export const TemplatedQueryView: React.FC<ITemplatedQueryViewProps> = ({
             () =>
                 TemplatedQueryResource.renderTemplatedQuery(
                     query,
-                    templatedVariables
+                    templatedVariables,
+                    engineId
                 ),
             [query, templatedVariables]
         )

--- a/querybook/webapp/lib/templated-query/index.ts
+++ b/querybook/webapp/lib/templated-query/index.ts
@@ -11,11 +11,13 @@ export async function getTemplatedQueryVariables(query: string) {
 
 export async function renderTemplatedQuery(
     query: string,
-    variables: Record<string, string>
+    variables: Record<string, string>,
+    engineId: number
 ) {
     const { data } = await TemplatedQueryResource.renderTemplatedQuery(
         query,
-        variables
+        variables,
+        engineId
     );
     return data;
 }

--- a/querybook/webapp/resource/queryExecution.ts
+++ b/querybook/webapp/resource/queryExecution.ts
@@ -136,15 +136,20 @@ export const QueryExecutionNotificationResource = {
 
 export const TemplatedQueryResource = {
     getVariables: (query: string) =>
-        ds.save<string[]>('/query_execution/templated_query_params/', {
+        ds.fetch<string[]>('/query_execution/templated_query_params/', {
             query,
         }),
-    renderTemplatedQuery: (query: string, variables: Record<string, string>) =>
-        ds.save<string>(
+    renderTemplatedQuery: (
+        query: string,
+        variables: Record<string, string>,
+        engineId: number
+    ) =>
+        ds.fetch<string>(
             '/query_execution/templated_query/',
             {
                 query,
                 variables,
+                engine_id: engineId,
             },
             false
         ),

--- a/querybook/webapp/resource/queryExecution.ts
+++ b/querybook/webapp/resource/queryExecution.ts
@@ -136,7 +136,7 @@ export const QueryExecutionNotificationResource = {
 
 export const TemplatedQueryResource = {
     getVariables: (query: string) =>
-        ds.fetch<string[]>('/query_execution/templated_query_params/', {
+        ds.save<string[]>('/query_execution/templated_query_params/', {
             query,
         }),
     renderTemplatedQuery: (
@@ -144,7 +144,7 @@ export const TemplatedQueryResource = {
         variables: Record<string, string>,
         engineId: number
     ) =>
-        ds.fetch<string>(
+        ds.save<string>(
             '/query_execution/templated_query/',
             {
                 query,


### PR DESCRIPTION
closes #635 

Add templated function to get the latest partition of a table.
Users can use this function by adding `{{ latest_partition('schema_name.table_name', 'partition_key') }}` to their queries.

Error messages:
1. Cannot get metastore_loader (or engine_id is not provided)
<img width="376" alt="Screen Shot 2021-09-09 at 12 17 15 PM" src="https://user-images.githubusercontent.com/23270317/132749388-bf5b2636-8729-4eb0-b102-e1a817123bd0.png">

2. Partition key provided is invalid
<img width="355" alt="Screen Shot 2021-09-09 at 12 15 31 PM" src="https://user-images.githubusercontent.com/23270317/132749419-c22f6db7-d5ce-455c-b932-501fd52d87de.png">

3. Full table name is improperly formatted
<img width="364" alt="Screen Shot 2021-09-09 at 12 15 57 PM" src="https://user-images.githubusercontent.com/23270317/132749447-afcb6723-9084-4705-a0cf-3de6b852267f.png">



