### PR TITLE
minor: Set up filters as true by default.

### DIFF
--- a/docs_website/docs/integrations/customize_html.md
+++ b/docs_website/docs/integrations/customize_html.md
@@ -74,3 +74,50 @@ window.CUSTOM_KEY_MAP = {
 ```
 
 When adding a new key binding, follow the format of Codemirror as documented [here](https://codemirror.net/doc/manual.html#keymaps). Use `cmd` in place of `ctrl` whenever possible as it would work for both mac and windows. Note that you can only override existing values which means adding a new key would be considered a noop.
+
+### Customize data table filters
+
+You can set default parameters for table filters. You can add all examples from this part to file `querybook/plugins/webpage_plugin/custom_script.ts`.
+
+Which parameters you can customize:
+
+1. `Featured` flag. You can set up this filter selected by default using next code:
+
+```typescript
+window.DATA_TABLE_SEARCH_CONFIG = {
+    getInitialState: (initialState) => ({
+        ...initialState,
+        searchFilters: {
+            golden: true
+        }
+    })
+}
+```
+
+2. If you want to use searching for some schema by default, you can set this parameter using next code:
+
+```typescript
+window.DATA_TABLE_SEARCH_CONFIG = {
+    getInitialState: (initialState) => ({
+        ...initialState,
+        searchFilters: {
+            schema: "main"
+        }
+    })
+}
+```
+
+3. By default search field works for `table_name` field but you set any other valid field (table_name, description or column). 
+   So, you can set the field with value `true`. This is the example of setting `description` as default search field.
+
+```typescript
+window.DATA_TABLE_SEARCH_CONFIG = {
+    getInitialState: (initialState) => ({
+        ...initialState,
+        searchFields: {
+           description: true
+        }
+    })
+}
+```
+ 

--- a/docs_website/docs/integrations/customize_html.md
+++ b/docs_website/docs/integrations/customize_html.md
@@ -88,10 +88,10 @@ window.DATA_TABLE_SEARCH_CONFIG = {
     getInitialState: (initialState) => ({
         ...initialState,
         searchFilters: {
-            golden: true
-        }
-    })
-}
+            golden: true,
+        },
+    }),
+};
 ```
 
 2. If you want to use searching for some schema by default, you can set this parameter using next code:
@@ -101,13 +101,13 @@ window.DATA_TABLE_SEARCH_CONFIG = {
     getInitialState: (initialState) => ({
         ...initialState,
         searchFilters: {
-            schema: "main"
-        }
-    })
-}
+            schema: 'main',
+        },
+    }),
+};
 ```
 
-3. By default search field works for `table_name` field but you set any other valid field (table_name, description or column). 
+3. By default search field works for `table_name` field but you set any other valid field (table_name, description or column).
    So, you can set the field with value `true`. This is the example of setting `description` as default search field.
 
 ```typescript
@@ -115,9 +115,8 @@ window.DATA_TABLE_SEARCH_CONFIG = {
     getInitialState: (initialState) => ({
         ...initialState,
         searchFields: {
-           description: true
-        }
-    })
-}
+            description: true,
+        },
+    }),
+};
 ```
- 

--- a/querybook/webapp/redux/dataTableSearch/reducer.ts
+++ b/querybook/webapp/redux/dataTableSearch/reducer.ts
@@ -20,12 +20,8 @@ const initialState: IDataTableSearchState = {
 };
 
 function getInitialState() {
-    if (
-        window.DATA_TABLE_SEARCH_CONFIG?.getInitialState
-    ) {
-        return window.DATA_TABLE_SEARCH_CONFIG.getInitialState(
-            initialState
-        );
+    if (window.DATA_TABLE_SEARCH_CONFIG?.getInitialState) {
+        return window.DATA_TABLE_SEARCH_CONFIG.getInitialState(initialState);
     }
 
     return initialState;

--- a/querybook/webapp/redux/dataTableSearch/reducer.ts
+++ b/querybook/webapp/redux/dataTableSearch/reducer.ts
@@ -19,12 +19,11 @@ const initialState: IDataTableSearchState = {
     ...initialResultState,
 };
 
-function calculateInitialState() {
+function getInitialState() {
     if (
-        window.DATA_TABLE_SEARCH_CONFIG &&
-        window.DATA_TABLE_SEARCH_CONFIG.calculateInitialState
+        window.DATA_TABLE_SEARCH_CONFIG?.getInitialState
     ) {
-        return window.DATA_TABLE_SEARCH_CONFIG.calculateInitialState(
+        return window.DATA_TABLE_SEARCH_CONFIG.getInitialState(
             initialState
         );
     }
@@ -33,7 +32,7 @@ function calculateInitialState() {
 }
 
 export default function dataTableSearch(
-    state = calculateInitialState(),
+    state = getInitialState(),
     action: DataTableSearchAction
 ) {
     return produce(state, (draft) => {
@@ -46,7 +45,7 @@ export default function dataTableSearch(
             }
             case '@@dataTableSearch/DATA_TABLE_SEARCH_RESET': {
                 return {
-                    ...calculateInitialState(),
+                    ...getInitialState(),
                 };
             }
             case '@@dataTableSearch/DATA_TABLE_SEARCH_STARTED': {

--- a/querybook/webapp/redux/dataTableSearch/reducer.ts
+++ b/querybook/webapp/redux/dataTableSearch/reducer.ts
@@ -19,8 +19,21 @@ const initialState: IDataTableSearchState = {
     ...initialResultState,
 };
 
+function calculateInitialState() {
+    if (
+        window.DATA_TABLE_SEARCH_CONFIG &&
+        window.DATA_TABLE_SEARCH_CONFIG.calculateInitialState
+    ) {
+        return window.DATA_TABLE_SEARCH_CONFIG.calculateInitialState(
+            initialState
+        );
+    }
+
+    return initialState;
+}
+
 export default function dataTableSearch(
-    state = initialState,
+    state = calculateInitialState(),
     action: DataTableSearchAction
 ) {
     return produce(state, (draft) => {
@@ -33,7 +46,7 @@ export default function dataTableSearch(
             }
             case '@@dataTableSearch/DATA_TABLE_SEARCH_RESET': {
                 return {
-                    ...initialState,
+                    ...calculateInitialState(),
                 };
             }
             case '@@dataTableSearch/DATA_TABLE_SEARCH_STARTED': {

--- a/querybook/webapp/types.d.ts
+++ b/querybook/webapp/types.d.ts
@@ -24,7 +24,9 @@ declare global {
             renderer: () => React.ReactElement;
         };
         DATA_TABLE_SEARCH_CONFIG?: {
-            getInitialState: (initialState: IDataTableSearchState) => IDataTableSearchState;
+            getInitialState: (
+                initialState: IDataTableSearchState
+            ) => IDataTableSearchState;
         };
         CUSTOM_COLUMN_STATS_ANALYZERS?: IColumnStatsAnalyzer[];
         CUSTOM_COLUMN_DETECTORS?: IColumnDetector[];

--- a/querybook/webapp/types.d.ts
+++ b/querybook/webapp/types.d.ts
@@ -5,6 +5,8 @@ import type {
     IColumnTransformer,
 } from 'lib/query-result/types';
 
+import { IDataTableSearchState } from 'redux/dataTableSearch/types';
+
 declare global {
     /* eslint-disable @typescript-eslint/naming-convention */
     interface Window {
@@ -22,7 +24,7 @@ declare global {
             renderer: () => React.ReactElement;
         };
         DATA_TABLE_SEARCH_CONFIG?: {
-            calculateInitialState: <T>(initialState: T) => typeof initialState;
+            getInitialState: (initialState: IDataTableSearchState) => IDataTableSearchState;
         };
         CUSTOM_COLUMN_STATS_ANALYZERS?: IColumnStatsAnalyzer[];
         CUSTOM_COLUMN_DETECTORS?: IColumnDetector[];

--- a/querybook/webapp/types.d.ts
+++ b/querybook/webapp/types.d.ts
@@ -21,6 +21,9 @@ declare global {
             mode?: 'replace';
             renderer: () => React.ReactElement;
         };
+        DATA_TABLE_SEARCH_CONFIG?: {
+            calculateInitialState: <T>(initialState: T) => typeof initialState;
+        };
         CUSTOM_COLUMN_STATS_ANALYZERS?: IColumnStatsAnalyzer[];
         CUSTOM_COLUMN_DETECTORS?: IColumnDetector[];
         CUSTOM_COLUMN_TRANSFORMERS?: IColumnTransformer[];


### PR DESCRIPTION
Email: oleksandr_vasylenko2@epam.com
There is a commit for adding a possibility to set up a default value for DataTable page.


After this commit we can set up this code in custom_script.tsx

```window.DATA_TABLE_SEARCH_CONFIG = {
    calculateInitialState: (initialState) => ({
        ...initialState,
        searchFilters: {
            golden: true
        }
    })
}

to set up the filter `Featured` as true by default. 

Thank you!
