### PR TITLE
configurable proxy_user for query executors

### DIFF
--- a/querybook/config/querybook_default_config.yaml
+++ b/querybook/config/querybook_default_config.yaml
@@ -44,6 +44,10 @@ OAUTH_AUTHORIZATION_URL: ~
 OAUTH_TOKEN_URL: ~
 OAUTH_USER_PROFILE: ~
 
+# User identifier which will be passed to query engines.
+# Possible values are 'username' and 'email'. Defaults to 'username'.
+QUERY_USER_IDENTIFIER: username
+
 # LDAP
 LDAP_CONN: ~
 LDAP_USER_DN: uid={},dc=example,dc=com

--- a/querybook/server/env.py
+++ b/querybook/server/env.py
@@ -71,6 +71,9 @@ class QuerybookSettings(object):
     OAUTH_TOKEN_URL = get_env_config("OAUTH_TOKEN_URL")
     OAUTH_USER_PROFILE = get_env_config("OAUTH_USER_PROFILE")
 
+    # User identifier which will be passed to query engines.
+    QUERY_USER_IDENTIFIER = get_env_config("QUERY_USER_IDENTIFIER")
+
     LDAP_CONN = get_env_config("LDAP_CONN")
     LDAP_USER_DN = get_env_config("LDAP_USER_DN")
 

--- a/querybook/server/lib/query_executor/executor_factory.py
+++ b/querybook/server/lib/query_executor/executor_factory.py
@@ -1,5 +1,6 @@
 from app.db import with_session
 from const.query_execution import QueryExecutionStatus
+from env import QuerybookSettings
 from lib.logger import get_logger
 from lib.query_analysis import get_statement_ranges
 from lib.query_analysis.lineage import process_query
@@ -33,6 +34,7 @@ def _get_executor_params_and_engine(query_execution_id, celery_task, session=Non
     if engine.deleted_at is not None:
         raise ArchivedQueryEngine("This query engine is disabled.")
 
+    proxy_user = user.email if QuerybookSettings.QUERY_USER_IDENTIFIER == "email" else user.username
     return (
         {
             "query_execution_id": query_execution_id,
@@ -41,7 +43,7 @@ def _get_executor_params_and_engine(query_execution_id, celery_task, session=Non
             "statement_ranges": statement_ranges,
             "client_setting": {
                 **engine.get_engine_params(),
-                "proxy_user": user.username,
+                "proxy_user": proxy_user,
             },
         },
         engine,


### PR DESCRIPTION
In our data stack, we use the user's email_id as the user identifier for our data access policies. Querybook by default sets `user.username` as the proxy_user which isn't desirable for everyone. 

This PR makes the proxy_user configurable with possible values of `username` and `email`. It defaults to `username` to avoid breaking current setups.  