### PR TITLE
fix: specify snowflake-connector-python version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -56,6 +56,9 @@ pydruid==0.5.7
 # BigQuery
 google-cloud-bigquery==1.28.0
 # Snowflake
+
+# snake-connector-python version needs to specified since it is a transitive dependency of snowflake-sqlalchemy
+# https://github.com/pinterest/querybook/pull/669
 snowflake-connector-python==2.6.1
 snowflake-sqlalchemy==1.2.4
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -56,6 +56,7 @@ pydruid==0.5.7
 # BigQuery
 google-cloud-bigquery==1.28.0
 # Snowflake
+snowflake-connector-python==2.6.1
 snowflake-sqlalchemy==1.2.4
 
 # Query Store

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -56,7 +56,6 @@ pydruid==0.5.7
 # BigQuery
 google-cloud-bigquery==1.28.0
 # Snowflake
-
 # snake-connector-python version needs to specified since it is a transitive dependency of snowflake-sqlalchemy
 # https://github.com/pinterest/querybook/pull/669
 snowflake-connector-python==2.6.1


### PR DESCRIPTION
After conversation with @czgu in slack, I found out that snowflake-connector-python should be specified in order to prevent an error.
Previously, snowflake-connector-python was version 2.4.5 in Querybook, and it created this error:
`(certifi 2021.5.30 (/usr/local/lib/python3.7/site-packages), Requirement.parse('certifi<2021.0.0'), {'snowflake-connector-python'})`
By specifying version to 2.6.1, everything worked fine in my production environment. This version was selected after reviewing the version that was used by Apache Superset. 
Currently we only use snowflake-sqlalchemy for our requirements, but since snowflake-connector-python is included as a dependency, we should also specify the version to prevent any issues. 

Related Issue: https://github.com/snowflakedb/snowflake-connector-python/issues/732