### PR TITLE
fix: Change docker image and update README

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -5,4 +5,3 @@ The setup is modified from docker-compose and runs in production mode.
 Here are a few things to note **before** you use this:
 
 -   **Do not use this for production!** Please host elasticsearch/sqldb/redis independently and pass their connection details via secrets.
--   The docker file for Querybook cannot be pulled because GitHub does not allow public docker pull. Please provide your own github authentication or change it to your custom docker build. Querybook's Docker Image will be moved to DockerHub once the source code is public.

--- a/k8s/scheduler-deployment.yaml
+++ b/k8s/scheduler-deployment.yaml
@@ -17,7 +17,7 @@ spec:
                       - ./querybook/scripts/runservice
                       - prod_scheduler
                       - --pidfile=/opt/celerybeat.pid
-                  image: docker.pkg.github.com/pinterest/querybook/querybook:latest
+                  image: querybook/querybook:latest
                   env:
                       - name: FLASK_SECRET_KEY
                         value: SOME_RANDOM_SECRET_KEY

--- a/k8s/web-deployment.yaml
+++ b/k8s/web-deployment.yaml
@@ -27,7 +27,7 @@ spec:
                         value: redis://redis:6379/0
                       - name: ELASTICSEARCH_HOST
                         value: elasticsearch:9200
-                  image: docker.pkg.github.com/pinterest/querybook/querybook:latest
+                  image: querybook:latest
                   name: web
                   ports:
                       - containerPort: 10001

--- a/k8s/worker-deployment.yaml
+++ b/k8s/worker-deployment.yaml
@@ -16,7 +16,7 @@ spec:
                 - args:
                       - ./querybook/scripts/runservice
                       - prod_worker
-                  image: docker.pkg.github.com/pinterest/querybook/querybook:latest
+                  image: querybook/querybook:latest
                   name: worker
                   resources:
                       requests:


### PR DESCRIPTION
Sorry, I should have fixed this earlier.
Since Querybook has its image on Docker Hub now, I am replacing the image to use Docker Hub and update README.