### PR TITLE
ci: set patch, minor, major when publishing to docker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
     push:
         branches:
             - master
+    pull_request:
 jobs:
     update:
         runs-on: ubuntu-latest
@@ -14,11 +15,17 @@ jobs:
             - uses: actions/checkout@v2
             - name: Get version from package.json
               run: |
-                  echo STATE_RELEASE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]') >> $GITHUB_ENV
+                  PATCH_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]')
+                  MINOR_VERSION=${PATCH_VERSION%.*}
+                  MAJOR_VERSION=${MINOR_VERSION%.*}
+
+                  echo PATCH_VERSION=$PATCH_VERSION >> $GITHUB_ENV
+                  echo MINOR_VERSION=$MINOR_VERSION >> $GITHUB_ENV
+                  echo MAJOR_VERSION=$MAJOR_VERSION >> $GITHUB_ENV
             - name: Publish to Registry
               uses: elgohr/Publish-Docker-Github-Action@master
               with:
                   name: querybook/querybook
                   username: ${{ secrets.DOCKER_USERNAME }}
                   password: ${{ secrets.DOCKER_PASSWORD }}
-                  tags: 'latest,${{ env.STATE_RELEASE_VERSION }}'
+                  tags: 'latest,${{ env.PATCH_VERSION }},${{ env.MINOR_VERSION }},${{ env.MAJOR_VERSION }}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
     push:
         branches:
             - master
-    pull_request:
 jobs:
     update:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Right now only full semver is used, so people can use querybook/querybook:2.8.3. But we want to support both
querybook/querybook:2.8 and querybook/querybook:2 as well