### PR TITLE
fix: lineage not showing due to table view height

### DIFF
--- a/querybook/webapp/components/DataTableView/DataTableView.scss
+++ b/querybook/webapp/components/DataTableView/DataTableView.scss
@@ -1,4 +1,6 @@
 .DataTableView {
+    height: 100%;
+
     .DataTableView-tabs {
         z-index: 10;
         position: sticky;
@@ -16,9 +18,5 @@
     .DataTableView-content {
         padding: 16px 24px;
         flex: 1;
-
-        .Container {
-            height: 100%;
-        }
     }
 }

--- a/querybook/webapp/components/DataTableView/DataTableView.tsx
+++ b/querybook/webapp/components/DataTableView/DataTableView.tsx
@@ -319,7 +319,7 @@ class DataTableViewComponent extends React.PureComponent<
             );
 
         return (
-            <Container className="DataTableView with-background">
+            <Container className="DataTableView with-background" flex="column">
                 <DataTableHeader
                     table={table}
                     tableName={tableName}


### PR DESCRIPTION
Before this fix, lineage graph would not show up because the DataTableView component does not take the full height of the page
After:
![image](https://user-images.githubusercontent.com/8283407/136453063-ed903e0a-aaba-4d28-b0d9-771a1f274eee.png)
