### PR TITLE
major: migration to es7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,10 +118,11 @@ services:
             timeout: 30s
             retries: 3
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:6.6.1
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.15.1
         environment:
             cluster.name: docker-cluster
             bootstrap.memory_lock: 'true'
+            discovery.type: single-node
             ES_JAVA_OPTS: -Xms750m -Xmx750m
         ulimits:
             memlock:

--- a/docs_website/docs/changelog/breaking_change.md
+++ b/docs_website/docs/changelog/breaking_change.md
@@ -7,6 +7,42 @@ slug: /changelog
 
 Here are the list of breaking changes that you should be aware of when updating Querybook:
 
+## v3.0.0
+
+### ElasticSearch
+
+Depending on deployment of Querybook, re-initialization of indices in ElasticSearch 7 cluster might be needed.
+
+This may happen for example when your `web` component is not started with `querybook/scripts/bundled_docker_run_web` script with `--initdb` option.
+
+In such a cases, one has the following options how to initialize them manually:
+
+1. In Docker based deployments, attach to `web` or `worker` component and run
+    ```shell
+    python ./querybook/server/scripts/init_es.py
+    ```
+
+2. Locally, set following keys to proper values in `querybook/config/querybook_config.yaml`
+    ```shell
+    FLASK_SECRET_KEY: ...
+    DATABASE_CONN: ...
+    REDIS_URL: ...
+    ELASTICSEARCH_HOST: ...
+    ```
+    and run
+    ```shell
+    PYTHONPATH=querybook/server python ./querybook/server/scripts/init_es.py
+    ```
+
+#### Make and Docker-compose
+In case some inconsistency occurs in ES indices source data in development deployment using `make`,
+or deployment using `docker-compose`, one can clear cached ES data by stopping and removing `querybook_elasticsearch_1` container
+and then removing Docker volume `querybook_esdata1`. Next `make` or `docker-compose` will create fresh volume again.
+
+#### Kubernetes
+Kubernetes base deployments that uses ElasticSearch templates as they are should work without any impact,
+as the volumes are always recreated with deployment of a new (updated) pod.
+
 ## v2.9.0
 
 Now announcements have two extra fields - `active_from` and `active_till`. These fields are not required and a user can still create an announcement without these two fields and if an announcement has two one these fields and the date in these fields are not in the range, this announcement will be filtered.

--- a/docs_website/docs/setup_guide/prod_setup.md
+++ b/docs_website/docs/setup_guide/prod_setup.md
@@ -11,7 +11,7 @@ Once further scalability is desired you can start each service individually in d
 These items should be prepared before setting up Querybook:
 
 -   (**Required**) A MySQL/PostgresSQL[^1] database with version >=5.7. It is recommended to have more than 5GB of space.
--   (**Required**) An Elasticsearch server with version 6.6.1.
+-   (**Required**) An Elasticsearch server with version 7.
 -   (**Required**) A 2GB Redis instance, Querybook should not use more than 1GB of memory.
 -   If OAuth will be used for authentication, remember to get the OAuth client information (secrets, token url, etc).
 -   For notifications, you would need

--- a/helm/templates/elasticsearch/elasticsearch-deployment.yaml
+++ b/helm/templates/elasticsearch/elasticsearch-deployment.yaml
@@ -47,13 +47,7 @@ spec:
                 - SYS_RESOURCE
       containers:
         - name: {{ .Values.elasticsearch.name }}
-          env:
-            - name: ES_JAVA_OPTS
-              value: -Xms512m -Xmx512m
-            - name: bootstrap.memory_lock
-              value: 'false'
-            - name: cluster.name
-              value: docker-cluster
+          env: {{ toYaml .Values.elasticsearch.extraEnvs | nindent 12 }}
           image: "{{ .Values.elasticsearch.image.repository }}:{{ .Values.elasticsearch.image.tag }}"
           imagePullPolicy: {{ .Values.elasticsearch.image.pullPolicy }}
           ports:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -117,7 +117,16 @@ elasticsearch:
   image:
     repository: docker.elastic.co/elasticsearch/elasticsearch
     pullPolicy: IfNotPresent
-    tag: "6.6.1"
+    tag: "7.15.1"
+  extraEnvs:
+    - name: ES_JAVA_OPTS
+      value: -Xms512m -Xmx512m
+    - name: bootstrap.memory_lock
+      value: 'false'
+    - name: cluster.name
+      value: docker-cluster
+    - name: discovery.type
+      value: single-node
   service:
     serviceType: ClusterIP
     servicePort: 9200

--- a/k8s/elasticsearch-deployment.yaml
+++ b/k8s/elasticsearch-deployment.yaml
@@ -39,7 +39,9 @@ spec:
                         value: 'false'
                       - name: cluster.name
                         value: docker-cluster
-                  image: docker.elastic.co/elasticsearch/elasticsearch:6.6.1
+                      - name: discovery.type
+                        value: single-node
+                  image: docker.elastic.co/elasticsearch/elasticsearch:7.15.1
                   #   livenessProbe:
                   #       httpGet:
                   #           path: /_cluster/health

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "2.8.3",
+    "version": "3.0.0",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/config/elasticsearch.yaml
+++ b/querybook/config/elasticsearch.yaml
@@ -13,26 +13,25 @@ datadocs:
                         filter:
                             - lowercase
         mappings:
-            datadocs:
-                properties:
-                    id:
-                        type: long
-                    environment_id:
-                        type: long
-                    owner_uid:
-                        type: long
-                    title:
-                        type: text
-                        analyzer: snowball
-                    cells:
-                        type: text
-                        analyzer: user_content_analyzer
-                    created_at:
-                        type: long
-                    public:
-                        type: boolean
-                    readable_user_ids:
-                        type: integer
+            properties:
+                id:
+                    type: long
+                environment_id:
+                    type: long
+                owner_uid:
+                    type: long
+                title:
+                    type: text
+                    analyzer: snowball
+                cells:
+                    type: text
+                    analyzer: user_content_analyzer
+                created_at:
+                    type: long
+                public:
+                    type: boolean
+                readable_user_ids:
+                    type: integer
 tables:
     index_name: search_tables_v1
     type_name: tables # Keep this same in mappings
@@ -72,57 +71,55 @@ tables:
                         type: simple_pattern
                         pattern: '[A-Za-z0-9]+'
         mappings:
-            tables:
-                properties:
-                    id:
-                        type: long
-                    metastore_id:
-                        type: long
-                    schema:
-                        type: keyword
-                        normalizer: case_insensitive
-                    name:
-                        type: keyword
-                        normalizer: case_insensitive
-                    full_name:
-                        type: text
-                        analyzer: table_name_lowercase
-                    full_name_ngram:
-                        type: text
-                        analyzer: edge_ngram_lowercase
-                    completion_name:
-                        type: completion
-                        analyzer: keyword
-                        contexts:
-                            name: metastore_id
-                            type: category
-                    description:
-                        type: text
-                        analyzer: user_content_analyzer
-                    created_at:
-                        type: long
-                    columns:
-                        type: keyword
-                        normalizer: case_insensitive
-                    golden:
-                        type: boolean
-                    importance_score:
-                        type: long
-                    tags:
-                        type: keyword
+            properties:
+                id:
+                    type: long
+                metastore_id:
+                    type: long
+                schema:
+                    type: keyword
+                    normalizer: case_insensitive
+                name:
+                    type: keyword
+                    normalizer: case_insensitive
+                full_name:
+                    type: text
+                    analyzer: table_name_lowercase
+                full_name_ngram:
+                    type: text
+                    analyzer: edge_ngram_lowercase
+                completion_name:
+                    type: completion
+                    analyzer: keyword
+                    contexts:
+                        name: metastore_id
+                        type: category
+                description:
+                    type: text
+                    analyzer: user_content_analyzer
+                created_at:
+                    type: long
+                columns:
+                    type: keyword
+                    normalizer: case_insensitive
+                golden:
+                    type: boolean
+                importance_score:
+                    type: long
+                tags:
+                    type: keyword
 users:
     index_name: search_users_v1
     type_name: users
     mappings:
         mappings:
-            users:
-                properties:
-                    id:
-                        type: long
-                    username:
-                        type: keyword
-                    fullname:
-                        type: text
-                        analyzer: whitespace
-                    suggest:
-                        type: completion
+            properties:
+                id:
+                    type: long
+                username:
+                    type: keyword
+                fullname:
+                    type: text
+                    analyzer: whitespace
+                suggest:
+                    type: completion

--- a/querybook/server/datasources/search.py
+++ b/querybook/server/datasources/search.py
@@ -269,10 +269,10 @@ def _parse_results(results, get_count):
     return ret
 
 
-def _get_matching_objects(query, index_name, doc_type, get_count=False):
+def _get_matching_objects(query, index_name, get_count=False):
     result = None
     try:
-        result = get_hosted_es().search(index_name, doc_type, body=query)
+        result = get_hosted_es().search(index=index_name, body=query)
     except Exception as e:
         LOG.warning("Got ElasticSearch exception: \n " + str(e))
 
@@ -306,10 +306,7 @@ def search_datadoc(
         sort_order=sort_order,
     )
     results, count = _get_matching_objects(
-        query,
-        ES_CONFIG["datadocs"]["index_name"],
-        ES_CONFIG["datadocs"]["type_name"],
-        True,
+        query, ES_CONFIG["datadocs"]["index_name"], True
     )
     return {"count": count, "results": results}
 
@@ -340,10 +337,7 @@ def search_tables(
         sort_order=sort_order,
     )
     results, count = _get_matching_objects(
-        query,
-        ES_CONFIG["tables"]["index_name"],
-        ES_CONFIG["tables"]["type_name"],
-        True,
+        query, ES_CONFIG["tables"]["index_name"], True
     )
     return {"count": count, "results": results}
 
@@ -366,11 +360,10 @@ def suggest_tables(metastore_id, prefix, limit=10):
     }
 
     index_name = ES_CONFIG["tables"]["index_name"]
-    type_name = ES_CONFIG["tables"]["type_name"]
 
     result = None
     try:
-        result = get_hosted_es().search(index_name, type_name, body=query)
+        result = get_hosted_es().search(index=index_name, body=query)
     except Exception as e:
         LOG.info(e)
     finally:
@@ -404,12 +397,11 @@ def suggest_user(name, limit=10, offset=None):
     }
 
     index_name = ES_CONFIG["users"]["index_name"]
-    type_name = ES_CONFIG["users"]["type_name"]
 
     result = None
     try:
         # print '\n--ES latest hosted_index %s\n' % hosted_index
-        result = get_hosted_es().search(index_name, type_name, body=query)
+        result = get_hosted_es().search(index=index_name, body=query)
     except Exception as e:
         LOG.info(e)
     finally:

--- a/querybook/server/logic/elasticsearch.py
+++ b/querybook/server/logic/elasticsearch.py
@@ -130,23 +130,21 @@ def datadocs_to_es(datadoc, session=None):
 
 @with_exception
 def _bulk_insert_datadocs():
-    type_name = ES_CONFIG["datadocs"]["type_name"]
     index_name = ES_CONFIG["datadocs"]["index_name"]
 
     for datadoc in get_datadocs_iter():
-        _insert(index_name, type_name, datadoc["id"], datadoc)
+        _insert(index_name, datadoc["id"], datadoc)
 
 
 @with_exception
 @with_session
 def update_data_doc_by_id(doc_id, session=None):
-    type_name = ES_CONFIG["datadocs"]["type_name"]
     index_name = ES_CONFIG["datadocs"]["index_name"]
 
     doc = get_data_doc_by_id(doc_id, session=session)
     if doc is None or doc.archived:
         try:
-            _delete(index_name, type_name, id=doc_id)
+            _delete(index_name, id=doc_id)
         except Exception:
             LOG.error("failed to delete {}. Will pass.".format(doc_id))
     else:
@@ -157,7 +155,7 @@ def update_data_doc_by_id(doc_id, session=None):
                 "doc": formatted_object,
                 "doc_as_upsert": True,
             }  # ES requires this format for updates
-            _update(index_name, type_name, doc_id, updated_body)
+            _update(index_name, doc_id, updated_body)
         except Exception:
             LOG.error("failed to upsert {}. Will pass.".format(doc_id))
 
@@ -252,17 +250,15 @@ def table_to_es(table, session=None):
 
 
 def _bulk_insert_tables():
-    type_name = ES_CONFIG["tables"]["type_name"]
     index_name = ES_CONFIG["tables"]["index_name"]
 
     for table in get_tables_iter():
-        _insert(index_name, type_name, table["id"], table)
+        _insert(index_name, table["id"], table)
 
 
 @with_exception
 @with_session
 def update_table_by_id(table_id, session=None):
-    type_name = ES_CONFIG["tables"]["type_name"]
     index_name = ES_CONFIG["tables"]["index_name"]
 
     table = get_table_by_id(table_id, session=session)
@@ -276,17 +272,16 @@ def update_table_by_id(table_id, session=None):
                 "doc": formatted_object,
                 "doc_as_upsert": True,
             }  # ES requires this format for updates
-            _update(index_name, type_name, table_id, updated_body)
+            _update(index_name, table_id, updated_body)
         except Exception:
             # Otherwise insert as new
             LOG.error("failed to upsert {}. Will pass.".format(table_id))
 
 
 def delete_es_table_by_id(table_id,):
-    type_name = ES_CONFIG["tables"]["type_name"]
     index_name = ES_CONFIG["tables"]["index_name"]
     try:
-        _delete(index_name, type_name, id=table_id)
+        _delete(index_name, id=table_id)
     except Exception:
         LOG.error("failed to delete {}. Will pass.".format(table_id))
 
@@ -343,23 +338,21 @@ def get_users_iter(batch_size=5000, session=None):
 
 
 def _bulk_insert_users():
-    type_name = ES_CONFIG["users"]["type_name"]
     index_name = ES_CONFIG["users"]["index_name"]
 
     for user in get_users_iter():
-        _insert(index_name, type_name, user["id"], user)
+        _insert(index_name, user["id"], user)
 
 
 @with_exception
 @with_session
 def update_user_by_id(uid, session=None):
-    type_name = ES_CONFIG["users"]["type_name"]
     index_name = ES_CONFIG["users"]["index_name"]
 
     user = User.get(id=uid, session=session)
     if user is None or user.deleted:
         try:
-            _delete(index_name, type_name, id=uid)
+            _delete(index_name, id=uid)
         except Exception:
             LOG.error("failed to delete {}. Will pass.".format(uid))
     else:
@@ -370,7 +363,7 @@ def update_user_by_id(uid, session=None):
                 "doc": formatted_object,
                 "doc_as_upsert": True,
             }  # ES requires this format for updates
-            _update(index_name, type_name, uid, updated_body)
+            _update(index_name, uid, updated_body)
         except Exception:
             LOG.error("failed to upsert {}. Will pass.".format(uid))
 
@@ -380,16 +373,16 @@ def update_user_by_id(uid, session=None):
 """
 
 
-def _insert(index_name, doc_type, id, content):
-    get_hosted_es().index(index=index_name, doc_type=doc_type, id=id, body=content)
+def _insert(index_name, id, content):
+    get_hosted_es().index(index=index_name, id=id, body=content)
 
 
-def _delete(index_name, doc_type, id):
-    get_hosted_es().delete(index=index_name, doc_type=doc_type, id=id)
+def _delete(index_name, id):
+    get_hosted_es().delete(index=index_name, id=id)
 
 
-def _update(index_name, doc_type, id, content):
-    get_hosted_es().update(index=index_name, doc_type=doc_type, id=id, body=content)
+def _update(index_name, id, content):
+    get_hosted_es().update(index=index_name, id=id, body=content)
 
 
 def create_indices(*config_names):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ pyyaml==5.4.1
 sqlalchemy==1.3.17
 pymysql==0.9.3
 requests==2.22.0
-elasticsearch==7.15.1
+elasticsearch==7.13.4
 
 # Query meta
 sqlparse==0.2.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ pyyaml==5.4.1
 sqlalchemy==1.3.17
 pymysql==0.9.3
 requests==2.22.0
-elasticsearch==6.3.1
+elasticsearch==7.15.1
 
 # Query meta
 sqlparse==0.2.3


### PR DESCRIPTION
Solving #683 

This pull requests contains:
- Changes in ElasticSearch document mappings and calls to ES client
- Changes in `docker-compose`, `k8s`, `helm` ElasticSearch deployments
  - As every deployment uses only one ES server (it doesn't actually create ES cluster there)`discovery.type=single-node` was used. This is necessary in ES7, otherwise it leads to verification of production setup ([bootstrap checks](https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html)) and `the default discovery settings are unsuitable for production use; at least one of [discovery.seed_hosts, discovery.seed_providers, cluster.initial_master_nodes] must be configured` error. But these options are good only with proper cluster.
  - For `helm` deployment, I've taken the setting of ES environmental variables from `elasticsearch-deployment.yaml` template to `values.yaml` completely, so it's more on the eyes.
- Increased version of _base requirement_ `elasticsearch` library

The most recent version of ElasticSearch 7 (7.15.2) was chosen as the default version, but according to my local tests any ES7 minor/patch version should work.