### PR TITLE
docs: update Amazon Redshift query engine docs

### DIFF
--- a/docs_website/docs/setup_guide/connect_to_query_engines.md
+++ b/docs_website/docs/setup_guide/connect_to_query_engines.md
@@ -80,7 +80,7 @@ make
 | Apache Kylin         | 3    | [kylinpy](https://pypi.org/project/kylinpy/)                                                                                                  | No                  |
 | Apache Solr          | 3    | [sqlalchemy-solr](https://pypi.org/project/sqlalchemy-solr/)                                                                                  | No                  |
 | Amazon Athena        | 3    | [pyathena](https://pypi.org/project/pyathena/)                                                                                                | No                  |
-| Amazon Redshift      | 3    | [sqlalchemy-redshift](https://pypi.org/project/sqlalchemy-redshift/)<br/>[redshift_connector](https://pypi.org/project/redshift-connector/)                       | No                  |
+| Amazon Redshift      | 2    | [sqlalchemy-redshift](https://pypi.org/project/sqlalchemy-redshift/)<br/>[redshift_connector](https://pypi.org/project/redshift-connector/)                       | No                  |
 | BigQuery             | 2    | [google-cloud-bigquery](https://pypi.org/project/google-cloud-bigquery/)                                                                      | Yes                 |
 | ClickHouse           | 3    | [clickhouse-sqlalchemy](https://pypi.org/project/clickhouse-sqlalchemy/)<br/>[clickhouse-driver](https://pypi.org/project/clickhouse-driver/) | No                  |
 | CockroachDB          | 3    | [sqlalchemy-cockroachdb](https://pypi.org/project/sqlalchemy-cockroachdb/)<br/>[psycopg2](https://pypi.org/project/psycopg2/)                 | No                  |

--- a/docs_website/docs/setup_guide/connect_to_query_engines.md
+++ b/docs_website/docs/setup_guide/connect_to_query_engines.md
@@ -52,7 +52,7 @@ touch requirements/local.txt
 3. Add the required packages
 
 ```sh
-echo -e "sqlalchemy-redshift\npsycopg2" > requirements/local.txt
+echo -e "sqlalchemy-redshift\nredshift_connector" > requirements/local.txt
 ```
 
 4. Start the container
@@ -80,7 +80,7 @@ make
 | Apache Kylin         | 3    | [kylinpy](https://pypi.org/project/kylinpy/)                                                                                                  | No                  |
 | Apache Solr          | 3    | [sqlalchemy-solr](https://pypi.org/project/sqlalchemy-solr/)                                                                                  | No                  |
 | Amazon Athena        | 3    | [pyathena](https://pypi.org/project/pyathena/)                                                                                                | No                  |
-| Amazon Redshift      | 3    | [sqlalchemy-redshift](https://pypi.org/project/sqlalchemy-redshift/)<br/>[psycopg2](https://pypi.org/project/psycopg2/)                       | No                  |
+| Amazon Redshift      | 3    | [sqlalchemy-redshift](https://pypi.org/project/sqlalchemy-redshift/)<br/>[redshift_connector](https://pypi.org/project/redshift-connector/)                       | No                  |
 | BigQuery             | 2    | [google-cloud-bigquery](https://pypi.org/project/google-cloud-bigquery/)                                                                      | Yes                 |
 | ClickHouse           | 3    | [clickhouse-sqlalchemy](https://pypi.org/project/clickhouse-sqlalchemy/)<br/>[clickhouse-driver](https://pypi.org/project/clickhouse-driver/) | No                  |
 | CockroachDB          | 3    | [sqlalchemy-cockroachdb](https://pypi.org/project/sqlalchemy-cockroachdb/)<br/>[psycopg2](https://pypi.org/project/psycopg2/)                 | No                  |


### PR DESCRIPTION
We should update the `querybook` docs to point Amazon Redshift users toward using [`redshift_connector`](https://github.com/aws/amazon-redshift-python-driver), the Amazon Redshift Python driver, rather than psycopg2 which is designed for use with PostgreSQL.

`sqlalchemy-redshift` now offers a dialect for the Amazon Redshift Python driver,`redshift_connector`. 

`redshift_connector` supports Amazon Redshift specific datatypes (e.g. `SUPER`, `GEOMETRY`, etc.) as well as IAM authentication. 

Attached are screenshots showing an example of using `sqlalchemy-redshift` with `redshift_connector` in querybook to execute some simple statements and generate charts. Given this testing, I've updated the tier for this query engine from `3` to `2`.

Amazon Redshift Engine
![Engine](https://user-images.githubusercontent.com/7676438/141371046-ad384309-b05f-4367-837f-bae25586b7e2.png)

Amazon Redshift Metastore
![Metastore](https://user-images.githubusercontent.com/7676438/141371058-a7ab24d6-98a9-4a93-b3d9-eb7edd5db5d5.png)

Amazon Redshift Example Queries
![Screen Shot 2021-11-11 at 1 59 48 PM](https://user-images.githubusercontent.com/7676438/141375307-368382fd-2f43-4e2f-b308-0952b36d17bd.png)
![Screen Shot 2021-11-11 at 1 59 58 PM](https://user-images.githubusercontent.com/7676438/141375313-460fa1ac-9cde-47ba-a375-6e6d87be9ea0.png)
![Screen Shot 2021-11-11 at 2 00 10 PM](https://user-images.githubusercontent.com/7676438/141375364-f88f6a85-00b0-420b-b375-bd5f71e5cc62.png)
![Screen Shot 2021-11-11 at 2 00 42 PM](https://user-images.githubusercontent.com/7676438/141375380-173c9bea-800d-4cf3-aa69-dc93f4e47742.png)
![Screen Shot 2021-11-11 at 2 11 22 PM](https://user-images.githubusercontent.com/7676438/141376252-10bc90c2-e227-4c78-b5c7-a802a07d7f24.png)

