### PR TITLE
minor: load_partitions for hive metastore loaders

### DIFF
--- a/querybook/migrations/versions/aceefd7708b6_change_params_for_hive_metastore_loaders.py
+++ b/querybook/migrations/versions/aceefd7708b6_change_params_for_hive_metastore_loaders.py
@@ -1,0 +1,48 @@
+"""Change params for Hive metastore loaders
+
+Revision ID: aceefd7708b6
+Revises: ea497b49195e
+Create Date: 2021-11-12 15:17:50.332447
+
+"""
+from alembic import op
+from sqlalchemy.orm import Session
+from typing import List
+
+from models.admin import QueryMetastore
+
+# revision identifiers, used by Alembic.
+revision = 'aceefd7708b6'
+down_revision = 'ea497b49195e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+
+    hms_loaders: List[QueryMetastore] = session.query(QueryMetastore).filter(QueryMetastore.loader == 'HMSMetastoreLoader').all()
+    for hms_loader in hms_loaders:
+        hms_loader.metastore_params = {'hms_connection': hms_loader.metastore_params, 'load_partitions': True}
+
+    hms_thrift_loaders: List[QueryMetastore] = session.query(QueryMetastore).filter(QueryMetastore.loader == 'HMSThriftMetastoreLoader').all()
+    for hms_thrift_loader in hms_thrift_loaders:
+        hms_thrift_loader.metastore_params = {'load_partitions': True, **hms_thrift_loader.metastore_params}
+
+    session.commit()
+
+
+def downgrade():
+    session = Session(bind=op.get_bind())
+
+    hms_loaders: List[QueryMetastore] = session.query(QueryMetastore).filter(QueryMetastore.loader == 'HMSMetastoreLoader').all()
+    for hms_loader in hms_loaders:
+        hms_loader.metastore_params = hms_loader.metastore_params['hms_connection']
+
+    hms_thrift_loaders: List[QueryMetastore] = session.query(QueryMetastore).filter(QueryMetastore.loader == 'HMSThriftMetastoreLoader').all()
+    for hms_thrift_loader in hms_thrift_loaders:
+        params = hms_thrift_loader.metastore_params.copy()
+        params.pop('load_partitions', None)  # load_partitions might not be present, if the button wasn't touched during metastore creation
+        hms_thrift_loader.metastore_params = params
+
+    session.commit()

--- a/querybook/server/lib/metastore/loaders/form_fileds.py
+++ b/querybook/server/lib/metastore/loaders/form_fileds.py
@@ -1,0 +1,10 @@
+from lib.form import FormField, FormFieldType
+
+
+load_partitions = FormField(
+    required=False,
+    field_type=FormFieldType.Boolean,
+    helper="""In case your data catalog is large, loading all partitions for all tables can be quite time consuming.
+    Skipping partition information can reduce your metastore refresh latency
+    """,
+)

--- a/querybook/server/lib/metastore/loaders/form_fileds.py
+++ b/querybook/server/lib/metastore/loaders/form_fileds.py
@@ -1,7 +1,7 @@
 from lib.form import FormField, FormFieldType
 
 
-load_partitions = FormField(
+load_partitions_field = FormField(
     required=False,
     field_type=FormFieldType.Boolean,
     helper="""In case your data catalog is large, loading all partitions for all tables can be quite time consuming.

--- a/querybook/server/lib/metastore/loaders/glue_data_catalog_loader.py
+++ b/querybook/server/lib/metastore/loaders/glue_data_catalog_loader.py
@@ -2,12 +2,13 @@ from datetime import datetime
 from typing import Dict, List, Tuple
 
 from clients.glue_client import GlueDataCatalogClient
-from lib.form import StructFormField, FormField, FormFieldType
+from lib.form import StructFormField, FormField
 from lib.metastore.base_metastore_loader import (
     BaseMetastoreLoader,
     DataTable,
     DataColumn,
 )
+from lib.metastore.loaders.form_fileds import load_partitions
 
 
 class GlueDataCatalogLoader(BaseMetastoreLoader):
@@ -31,13 +32,7 @@ class GlueDataCatalogLoader(BaseMetastoreLoader):
                 regex=r"^\d{12}$",
             ),
             region=FormField(required=True, description="Enter the AWS Region"),
-            load_partitions=FormField(
-                required=False,
-                field_type=FormFieldType.Boolean,
-                helper="""In case your data catalog is large, loading all partitions for all tables can be quite time consuming.
-                Skipping partition information can reduce your metastore refresh latency
-                """,
-            ),
+            load_partitions=load_partitions,
         )
 
     def get_all_schema_names(self) -> List[str]:

--- a/querybook/server/lib/metastore/loaders/glue_data_catalog_loader.py
+++ b/querybook/server/lib/metastore/loaders/glue_data_catalog_loader.py
@@ -8,7 +8,7 @@ from lib.metastore.base_metastore_loader import (
     DataTable,
     DataColumn,
 )
-from lib.metastore.loaders.form_fileds import load_partitions
+from lib.metastore.loaders.form_fileds import load_partitions_field
 
 
 class GlueDataCatalogLoader(BaseMetastoreLoader):
@@ -32,7 +32,7 @@ class GlueDataCatalogLoader(BaseMetastoreLoader):
                 regex=r"^\d{12}$",
             ),
             region=FormField(required=True, description="Enter the AWS Region"),
-            load_partitions=load_partitions,
+            load_partitions=load_partitions_field,
         )
 
     def get_all_schema_names(self) -> List[str]:

--- a/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
+++ b/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
@@ -8,7 +8,7 @@ from lib.metastore.base_metastore_loader import (
     DataTable,
     DataColumn,
 )
-from lib.metastore.loaders.form_fileds import load_partitions
+from lib.metastore.loaders.form_fileds import load_partitions_field
 from lib.utils import json as ujson
 
 
@@ -35,7 +35,7 @@ class HMSMetastoreLoader(BaseMetastoreLoader):
                 ),
                 min=1,
             ),
-            load_partitions=load_partitions,
+            load_partitions=load_partitions_field,
         )
 
     def get_all_schema_names(self) -> List[str]:

--- a/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
+++ b/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
@@ -1,5 +1,5 @@
 from typing import Dict, List, Tuple
-from lib.form import ExpandableFormField, FormField
+from lib.form import ExpandableFormField, FormField, FormFieldType, StructFormField
 from hmsclient.genthrift.hive_metastore.ttypes import NoSuchObjectException
 
 from clients.hms_client import HiveMetastoreClient
@@ -8,12 +8,17 @@ from lib.metastore.base_metastore_loader import (
     DataTable,
     DataColumn,
 )
+from lib.metastore.loaders.form_fileds import load_partitions
 from lib.utils import json as ujson
 
 
 class HMSMetastoreLoader(BaseMetastoreLoader):
     def __init__(self, metastore_dict: Dict):
         self.hmc = self._get_hmc(metastore_dict)
+        # load_partitions may not be present in the JSON, if the button wasn't touched during metastore creation
+        self.load_partitions = metastore_dict["metastore_params"].get(
+            "load_partitions", False
+        )
         super(HMSMetastoreLoader, self).__init__(metastore_dict)
 
     def __del__(self):
@@ -21,11 +26,16 @@ class HMSMetastoreLoader(BaseMetastoreLoader):
 
     @classmethod
     def get_metastore_params_template(cls):
-        return ExpandableFormField(
-            of=FormField(
-                required=True, description="Put url to hive metastore server here"
+        return StructFormField(
+            hms_connection=ExpandableFormField(
+                of=FormField(
+                    required=True,
+                    description="Put url to hive metastore server here",
+                    field_type=FormFieldType.String,
+                ),
+                min=1,
             ),
-            min=1,
+            load_partitions=load_partitions,
         )
 
     def get_all_schema_names(self) -> List[str]:
@@ -45,7 +55,9 @@ class HMSMetastoreLoader(BaseMetastoreLoader):
 
         parameters = description.parameters
         sd = description.sd
-        partitions = self.get_partitions(schema_name, table_name)
+        partitions = (
+            self.get_partitions(schema_name, table_name) if self.load_partitions else []
+        )
 
         last_modified_time = parameters.get("last_modified_time")
         last_modified_time = (
@@ -86,7 +98,9 @@ class HMSMetastoreLoader(BaseMetastoreLoader):
         )
 
     def _get_hmc(self, metastore_dict):
-        return HiveMetastoreClient(hmss_ro_addrs=metastore_dict["metastore_params"])
+        return HiveMetastoreClient(
+            hmss_ro_addrs=metastore_dict["metastore_params"]["hms_connection"]
+        )
 
 
 def get_hive_metastore_table_description(hmc, db_name, table_name):

--- a/querybook/server/lib/metastore/loaders/thrifthive_metastore_loader.py
+++ b/querybook/server/lib/metastore/loaders/thrifthive_metastore_loader.py
@@ -5,6 +5,7 @@ from lib.query_executor.clients.hive import HiveClient
 
 from clients.hms_client import HiveMetastoreClient
 from lib.metastore.loaders.hive_metastore_loader import HMSMetastoreLoader
+from lib.metastore.loaders.form_fileds import load_partitions
 from lib.metastore.base_metastore_loader import DataTable, DataColumn
 
 
@@ -40,6 +41,7 @@ class HMSThriftMetastoreLoader(HMSMetastoreLoader):
                 ),
                 min=1,
             ),
+            load_partitions=load_partitions,
         )
 
     def get_table_and_columns(

--- a/querybook/server/lib/metastore/loaders/thrifthive_metastore_loader.py
+++ b/querybook/server/lib/metastore/loaders/thrifthive_metastore_loader.py
@@ -5,7 +5,7 @@ from lib.query_executor.clients.hive import HiveClient
 
 from clients.hms_client import HiveMetastoreClient
 from lib.metastore.loaders.hive_metastore_loader import HMSMetastoreLoader
-from lib.metastore.loaders.form_fileds import load_partitions
+from lib.metastore.loaders.form_fileds import load_partitions_field
 from lib.metastore.base_metastore_loader import DataTable, DataColumn
 
 
@@ -41,7 +41,7 @@ class HMSThriftMetastoreLoader(HMSMetastoreLoader):
                 ),
                 min=1,
             ),
-            load_partitions=load_partitions,
+            load_partitions=load_partitions_field,
         )
 
     def get_table_and_columns(


### PR DESCRIPTION
Solving #690

## Description
This pull request adds `Load_partitions` boolean switch to the Metastore creation form for `HMSMetastoreLoader` and `HMSThriftMetastoreLoader`.

## Solution
I've noticed that this switch is already available in `GlueDataCatalogLoader`, so I've decided to extract the form field to a new module and reuse it from there in all three loaders.

## Backwards compatibility
- If I just tried to change the form and opened a Metastore page that uses `HMSMetastoreLoader`, the front-end returned following error: `[Immer] Immer only supports setting array indices and the 'length' property` caused by an array of URLs still present in the DB for the loader in `metastore_params` field.
  - Therefore, I've included transformation for `HMSMetastoreLoader` loader that changes `metastore_params` into proper dictionary in data migrations.

- If there is an existing metastore that uses `HMSMetastoreLoader` or `HMSThriftMetastoreLoader`, it has a behavior of loading all partitions right now. After applying changes from this pull requests, `Load_partitions` would be turned off by default.
  - Therefore, I've included logic that adds `"load_partitions": True` in `metastore_params` for these two loaders in data migrations.

Another solution would be to create completely new loader classes (`HMSMetastoreLoaderV2`, `HMSThriftMetastoreLoaderV2`) that would not infer with the current DB data. But this approach could lead to big number of very similar loaders after some time, so I wasn't sure about it.