### PR TITLE
feat: add redshift query engine

### DIFF
--- a/docs_website/docs/configurations/infra_installation.md
+++ b/docs_website/docs/configurations/infra_installation.md
@@ -51,6 +51,7 @@ If you install the required packages, these integrations will be automatically s
     -   Druid (via `-r engine/druid.txt`)
     -   Hive (via `-r engine/hive.txt`)
     -   Presto (via `-r engine/presto.txt`)
+    -   Redshift (via `-r engine/redshift.txt`)
     -   Snowflake (via `-r engine/snowflake.txt`)
     -   Trino (via `-r engine/trino.txt`)
     -   And [any sqlalchemy supported engines](../setup_guide/connect_to_query_engines.md)

--- a/docs_website/docs/setup_guide/connect_to_query_engines.md
+++ b/docs_website/docs/setup_guide/connect_to_query_engines.md
@@ -73,35 +73,35 @@ make
 
 **Note**: If the query engine is not included below, but it does have a Sqlalchemy integration, you can still use it in Querybook. Follow the [step by step guide](#step-by-step-guide) with 1 additional step before step 4. Visit `<project_root>/querybook/server/lib/query_executor/sqlalchemy.py` and add the query engine to the list variable `SQLALCHEMY_SUPPORTED_DIALECTS`, and continue to step 4. If it works, please contribute to Querybook by submitting a PR of your changes.
 
-| Query Engine         | Tier | Package                                                                                                                                       |
-| -------------------- | ---- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Apache Drill         | 3    | [sqlalchemy-drill](https://pypi.org/project/sqlalchemy-drill/)                                                                                |
-| Apache Hive          | 1    | [pyhive](https://pypi.org/project/PyHive/) OR `-r engines/hive.txt`                                                                           |
-| Apache Kylin         | 3    | [kylinpy](https://pypi.org/project/kylinpy/)                                                                                                  |
-| Apache Solr          | 3    | [sqlalchemy-solr](https://pypi.org/project/sqlalchemy-solr/)                                                                                  |
-| Amazon Athena        | 3    | [pyathena](https://pypi.org/project/pyathena/)                                                                                                |
-| Amazon Redshift      | 2    | [sqlalchemy-redshift](https://pypi.org/project/sqlalchemy-redshift/)<br/>[redshift_connector](https://pypi.org/project/redshift-connector/)   |
-| BigQuery             | 2    | [google-cloud-bigquery](https://pypi.org/project/google-cloud-bigquery/)<br/> OR `-r engines/bigquery.txt`                                    |
-| ClickHouse           | 3    | [clickhouse-sqlalchemy](https://pypi.org/project/clickhouse-sqlalchemy/)<br/>[clickhouse-driver](https://pypi.org/project/clickhouse-driver/) |
-| CockroachDB          | 3    | [sqlalchemy-cockroachdb](https://pypi.org/project/sqlalchemy-cockroachdb/)<br/>[psycopg2](https://pypi.org/project/psycopg2/)                 |
-| CrateDB              | 3    | [crate](https://pypi.org/project/crate/)                                                                                                      |
-| Dremio               | 3    | [sqlalchemy-dremio](https://pypi.org/project/sqlalchemy-dremio/)                                                                              |
-| Druid                | 2    | [pydruid](https://pypi.org/project/pydruid/) OR `-r engines/druid.txt`                                                                        |
-| ElasticSearch        | 3    | [elasticsearch-dbapi](https://pypi.org/project/elasticsearch-dbapi/0.2.1/)                                                                    |
-| EXASolution          | 3    | [sqlalchemy-exasol](https://pypi.org/project/sqlalchemy-exasol/)                                                                              |
-| Firebird             | 3    | [sqlalchemy-firebird](https://pypi.org/project/sqlalchemy-firebird/)                                                                          |
-| Google Spreasheets   | 3    | [gsheetsdb](https://pypi.org/project/gsheetsdb/)                                                                                              |
-| IBM DB2              | 3    | [ibm-db-sa](https://pypi.org/project/ibm-db-sa/)                                                                                              |
-| Microsoft Access     | 3    | [sqlalchemy-access](https://pypi.org/project/sqlalchemy-access/)                                                                              |
-| Microsoft SQL Server | 3    | Included by default                                                                                                                           |
-| MySQL                | 1    | Included by default                                                                                                                           |
-| MonetDB              | 3    | [sqlalchemy_monetdb](https://pypi.org/project/sqlalchemy_monetdb/)                                                                            |
-| Oracle               | 3    | Included by default                                                                                                                           |
-| PostgreSQL           | 2    | Included by default                                                                                                                           |
-| Presto               | 1    | [pyhive](https://pypi.org/project/PyHive/) OR `-r engines/presto.txt`                                                                         |
-| SAP Hana             | 3    | [sqlalchemy-hana](https://pypi.org/project/sqlalchemy-hana/0.2.2/)                                                                            |
-| Snowflake            | 2    | [snowflake-sqlalchemy](https://pypi.org/project/snowflake-sqlalchemy/) OR `-r engines/snowflake.txt`                                          |
-| SQLite               | 2    | Included by default                                                                                                                           |
-| Teradata Vantage     | 3    | [teradatasqlalchemy](https://pypi.org/project/teradatasqlalchemy/)                                                                            |
-| Trino                | 2    | [trino](https://github.com/trinodb/trino-python-client) OR `-r engines/trino.txt`                                                             |
-| Vertica              | 3    | [sqlalchemy-vertica-python](https://pypi.org/project/sqlalchemy-vertica-python/)                                                              |
+| Query Engine         | Tier | Package                                                                                                                                                                  |
+| -------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Apache Drill         | 3    | [sqlalchemy-drill](https://pypi.org/project/sqlalchemy-drill/)                                                                                                           |
+| Apache Hive          | 1    | [pyhive](https://pypi.org/project/PyHive/) OR `-r engines/hive.txt`                                                                                                      |
+| Apache Kylin         | 3    | [kylinpy](https://pypi.org/project/kylinpy/)                                                                                                                             |
+| Apache Solr          | 3    | [sqlalchemy-solr](https://pypi.org/project/sqlalchemy-solr/)                                                                                                             |
+| Amazon Athena        | 3    | [pyathena](https://pypi.org/project/pyathena/)                                                                                                                           |
+| Amazon Redshift      | 2    | [sqlalchemy-redshift](https://pypi.org/project/sqlalchemy-redshift/)<br/>[redshift_connector](https://pypi.org/project/redshift-connector/) OR `-r engines/redshift.txt` |
+| BigQuery             | 2    | [google-cloud-bigquery](https://pypi.org/project/google-cloud-bigquery/)<br/> OR `-r engines/bigquery.txt`                                                               |
+| ClickHouse           | 3    | [clickhouse-sqlalchemy](https://pypi.org/project/clickhouse-sqlalchemy/)<br/>[clickhouse-driver](https://pypi.org/project/clickhouse-driver/)                            |
+| CockroachDB          | 3    | [sqlalchemy-cockroachdb](https://pypi.org/project/sqlalchemy-cockroachdb/)<br/>[psycopg2](https://pypi.org/project/psycopg2/)                                            |
+| CrateDB              | 3    | [crate](https://pypi.org/project/crate/)                                                                                                                                 |
+| Dremio               | 3    | [sqlalchemy-dremio](https://pypi.org/project/sqlalchemy-dremio/)                                                                                                         |
+| Druid                | 2    | [pydruid](https://pypi.org/project/pydruid/) OR `-r engines/druid.txt`                                                                                                   |
+| ElasticSearch        | 3    | [elasticsearch-dbapi](https://pypi.org/project/elasticsearch-dbapi/0.2.1/)                                                                                               |
+| EXASolution          | 3    | [sqlalchemy-exasol](https://pypi.org/project/sqlalchemy-exasol/)                                                                                                         |
+| Firebird             | 3    | [sqlalchemy-firebird](https://pypi.org/project/sqlalchemy-firebird/)                                                                                                     |
+| Google Spreasheets   | 3    | [gsheetsdb](https://pypi.org/project/gsheetsdb/)                                                                                                                         |
+| IBM DB2              | 3    | [ibm-db-sa](https://pypi.org/project/ibm-db-sa/)                                                                                                                         |
+| Microsoft Access     | 3    | [sqlalchemy-access](https://pypi.org/project/sqlalchemy-access/)                                                                                                         |
+| Microsoft SQL Server | 3    | Included by default                                                                                                                                                      |
+| MySQL                | 1    | Included by default                                                                                                                                                      |
+| MonetDB              | 3    | [sqlalchemy_monetdb](https://pypi.org/project/sqlalchemy_monetdb/)                                                                                                       |
+| Oracle               | 3    | Included by default                                                                                                                                                      |
+| PostgreSQL           | 2    | Included by default                                                                                                                                                      |
+| Presto               | 1    | [pyhive](https://pypi.org/project/PyHive/) OR `-r engines/presto.txt`                                                                                                    |
+| SAP Hana             | 3    | [sqlalchemy-hana](https://pypi.org/project/sqlalchemy-hana/0.2.2/)                                                                                                       |
+| Snowflake            | 2    | [snowflake-sqlalchemy](https://pypi.org/project/snowflake-sqlalchemy/) OR `-r engines/snowflake.txt`                                                                     |
+| SQLite               | 2    | Included by default                                                                                                                                                      |
+| Teradata Vantage     | 3    | [teradatasqlalchemy](https://pypi.org/project/teradatasqlalchemy/)                                                                                                       |
+| Trino                | 2    | [trino](https://github.com/trinodb/trino-python-client) OR `-r engines/trino.txt`                                                                                        |
+| Vertica              | 3    | [sqlalchemy-vertica-python](https://pypi.org/project/sqlalchemy-vertica-python/)                                                                                         |

--- a/querybook/server/lib/query_executor/all_executors.py
+++ b/querybook/server/lib/query_executor/all_executors.py
@@ -17,6 +17,7 @@ PROVIDED_EXECUTORS = import_modules(
         ("lib.query_executor.executors.bigquery", "BigQueryQueryExecutor"),
         ("lib.query_executor.executors.snowflake", "SnowflakeQueryExecutor"),
         ("lib.query_executor.executors.trino", "TrinoQueryExecutor"),
+        ("lib.query_executor.executors.redshift", "RedshiftQueryExecutor"),
     ]
 )
 ALL_PLUGIN_EXECUTORS = import_module_with_default(

--- a/querybook/server/lib/query_executor/executors/redshift.py
+++ b/querybook/server/lib/query_executor/executors/redshift.py
@@ -1,0 +1,28 @@
+from redshift_connector import error as rs_errors
+from sqlalchemy.exc import SQLAlchemyError
+from const.query_execution import QueryExecutionErrorType
+
+from lib.query_executor.executors.sqlalchemy import SqlAlchemyQueryExecutor
+
+
+class RedshiftQueryExecutor(SqlAlchemyQueryExecutor):
+    @classmethod
+    def EXECUTOR_NAME(cls):
+        return "sqlalchemy-redshift"
+
+    @classmethod
+    def EXECUTOR_LANGUAGE(cls):
+        return "redshift"
+
+    def _parse_exception(self, e):
+        if isinstance(e, SQLAlchemyError):
+            orig_error = getattr(e, "orig", None)
+
+            if isinstance(orig_error, rs_errors.Error):
+                error_type = QueryExecutionErrorType.ENGINE.value
+                error_msg = getattr(e, "args", None)
+                error_extracted = None
+
+                if error_msg is not None:
+                    return error_type, str(error_msg), error_extracted
+        return super(RedshiftQueryExecutor, self)._parse_exception(e)

--- a/querybook/server/lib/query_executor/executors/sqlalchemy.py
+++ b/querybook/server/lib/query_executor/executors/sqlalchemy.py
@@ -67,7 +67,6 @@ SQLALCHEMY_SUPPORTED_DIALECTS = [
     "kylin",
     "monetdb",
     "presto",
-    "redshift",
     "solr",
     "teradata",
     "trino",

--- a/requirements/engine/redshift.txt
+++ b/requirements/engine/redshift.txt
@@ -1,0 +1,2 @@
+sqlalchemy-redshift==0.8.9
+redshift_connector==2.0.902

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -7,6 +7,7 @@
 -r engine/druid.txt
 -r engine/hive.txt
 -r engine/presto.txt
+-r engine/redshift.txt
 -r engine/snowflake.txt
 -r engine/trino.txt
 


### PR DESCRIPTION
Adds redshift query engine python packages. @czgu -- is the testing provided below and in #693 sufficient for providing this query engine as "tier 1"? if not, I'm more than happy to perform additional testing, just let me know what else you'd like to see :).

Testing

- confirmed querybook `make` executes successfully after adding `-r extra.txt` in `requirements/local.txt`


Testing Screenshots


- Language Specific Autocomplete supported for Amazon Redshift datatypes

![Screen Shot 2021-11-15 at 12 51 07 PM](https://user-images.githubusercontent.com/7676438/146262854-9ae9b988-b53a-4317-a011-d732ae25bb73.png)
![Screen Shot 2021-11-15 at 12 49 54 PM](https://user-images.githubusercontent.com/7676438/146262907-b1474d3c-2972-49d3-95f4-d3d2397b8986.png)
![Screen Shot 2021-12-15 at 1 11 45 PM](https://user-images.githubusercontent.com/7676438/146265865-4f85f5f9-244c-415b-8604-4d719cb41e2f.png)

- Query execution 
![Screen Shot 2021-11-15 at 11 49 21 AM](https://user-images.githubusercontent.com/7676438/146262980-72a9fd2b-5114-4b2d-a898-327f2221a5d3.png)

- Query Engine execution provides status in UI

![Screen Shot 2021-12-15 at 1 09 07 PM](https://user-images.githubusercontent.com/7676438/146265434-33f90f29-0755-4e23-ab4e-5cdec5d9a3f5.png)

- Query Engine generates logs

![Screen Shot 2021-12-15 at 1 09 44 PM](https://user-images.githubusercontent.com/7676438/146265463-ea3e3830-5502-45eb-8f5a-ed3a03cc4d37.png)


- Authentication via IAM is supported

![localhost_10001_admin_query_engine_4_ (1)](https://user-images.githubusercontent.com/7676438/146264595-b8afa02a-506a-472e-862d-04762878115e.png)

- Federated Authentication via Identity Provider is supported

![localhost_10001_admin_query_engine_2_ (1) (1)](https://user-images.githubusercontent.com/7676438/146264229-edcaa673-d4a8-45e0-ba00-8e79951c22da.png)
