### PR TITLE
fix: hide error overlay from react fast refresh

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -240,7 +240,10 @@ module.exports = (env, options) => {
                 filename: '[file].map[query]',
                 exclude: [/vendor/],
             }),
-            !PROD && new ReactRefreshWebpackPlugin(),
+            !PROD &&
+                new ReactRefreshWebpackPlugin({
+                    overlay: false,
+                }),
         ].filter(Boolean),
     };
 };


### PR DESCRIPTION
Turns out the errors shown in Overlay are not very useful but a bit confusing for dev experience. Now it is turned off and we can use console instead to inspect errors