### PR TITLE
fix: parsing issue for connection strings of Presto,Trino

### DIFF
--- a/querybook/server/lib/query_executor/connection_string/trino.py
+++ b/querybook/server/lib/query_executor/connection_string/trino.py
@@ -16,7 +16,7 @@ class TrinoConnectionConf(NamedTuple):
 
 def get_trino_connection_conf(connection_string: str) -> TrinoConnectionConf:
     match = re.search(
-        r"^(?:jdbc:)?trino:\/\/([\w.-]+(?:\:\d+)?(?:,[\w.-]+(?:\:\d+)?)*)(\/\w+)?(\/\w+)?(\?[\w.-]+=[\w.-]+(?:&[\w.-]+=[\w.-]+)*)?$",  # noqa: E501
+        r"^(?:jdbc:)?trino:\/\/([\w.-]+(?:\:\d+)?(?:,[\w.-]+(?:\:\d+)?)*)(\/\w+)?(\/\w+)?(\?[\w]+=[^&]+(?:&[\w]+=[^&]+)*)?$",  # noqa: E501
         connection_string,
     )
 
@@ -26,7 +26,7 @@ def get_trino_connection_conf(connection_string: str) -> TrinoConnectionConf:
     raw_conf = (match.group(4) or "?")[1:]
 
     parsed_hosts = [split_hostport(hostport) for hostport in raw_hosts.split(",")]
-    configurations = get_parsed_variables(raw_conf)
+    configurations = get_parsed_variables(raw_conf, separator="&")
 
     hostname, port = random_choice(parsed_hosts, default=(None, None))
     protocol = "https" if configurations.get("SSL", False) else "http"

--- a/querybook/server/lib/query_executor/executor_template/templates.py
+++ b/querybook/server/lib/query_executor/executor_template/templates.py
@@ -25,7 +25,7 @@ jdbc:hive2://&lt;host1&gt;:&lt;port1&gt;,&lt;host2&gt;:&lt;port2&gt;/dbName;sess
 presto_executor_template = StructFormField(
     connection_string=FormField(
         required=True,
-        regex="^(?:jdbc:)?presto:\\/\\/([\\w.-]+(?:\\:\\d+)?(?:,[\\w.-]+(?:\\:\\d+)?)*)(\\/\\w+)?(\\/\\w+)?(\\?[\\w.-]+=[\\w.-]+(?:&[\\w.-]+=[\\w.-]+)*)?$",  # noqa: E501
+        regex="^(?:jdbc:)?presto:\\/\\/([\\w.-]+(?:\\:\\d+)?(?:,[\\w.-]+(?:\\:\\d+)?)*)(\\/\\w+)?(\\/\\w+)?(\\?[\\w]+=[^&]+(?:&[\\w]+=[^&]+)*)?$",  # noqa: E501
         helper="""
 <p>Format jdbc:presto://&lt;host:port&gt;/&lt;catalog&gt;/&lt;schema&gt;?presto_conf_list</p>
 <p>Catalog and schema are optional. We only support SSL as the conf option.</p>
@@ -46,7 +46,7 @@ presto_executor_template = StructFormField(
 trino_executor_template = StructFormField(
     connection_string=FormField(
         required=True,
-        regex="^(?:jdbc:)?trino:\\/\\/([\\w.-]+(?:\\:\\d+)?(?:,[\\w.-]+(?:\\:\\d+)?)*)(\\/\\w+)?(\\/\\w+)?(\\?[\\w.-]+=[\\w.-]+(?:&[\\w.-]+=[\\w.-]+)*)?$",  # noqa: E501
+        regex="^(?:jdbc:)?trino:\\/\\/([\\w.-]+(?:\\:\\d+)?(?:,[\\w.-]+(?:\\:\\d+)?)*)(\\/\\w+)?(\\/\\w+)?(\\?[\\w]+=[^&]+(?:&[\\w]+=[^&]+)*)?$",  # noqa: E501
         helper="""
 <p>Format jdbc:trino://&lt;host:port&gt;/&lt;catalog&gt;/&lt;schema&gt;?trino_conf_list</p>
 <p>Catalog and schema are optional. We only support SSL as the conf option.</p>

--- a/querybook/tests/test_lib/test_query_executor/test_connection_string/test_presto.py
+++ b/querybook/tests/test_lib/test_query_executor/test_connection_string/test_presto.py
@@ -1,0 +1,41 @@
+from unittest import TestCase
+from lib.query_executor.connection_string.presto import (
+    get_presto_connection_conf,
+    PrestoConnectionConf,
+)
+
+
+class GetPrestoConnectionConfTestCase(TestCase):
+    def test_minimal(self):
+        conf = get_presto_connection_conf("presto://foobar.com")
+        self.assertEqual(conf.host, "foobar.com")
+        self.assertEqual(conf.protocol, "http")
+
+    def test_parts(self):
+        conf = get_presto_connection_conf("presto://foobar.com:443/spam")
+        self.assertEqual(conf.catalog, "spam")
+        conf = get_presto_connection_conf("presto://foobar.com:443/spam/egg")
+        self.assertEqual(conf.schema, "egg")
+
+    def test_full(self):
+        self.assertEqual(
+            get_presto_connection_conf(
+                "presto://www.foobar.com:443/spam/egg?hello=world&SSL=true&foo=#bar"
+            ),
+            PrestoConnectionConf(
+                host="www.foobar.com",
+                port=443,
+                catalog="spam",
+                schema="egg",
+                protocol="https",
+                properties={"hello": "world", "foo": "#bar"},
+            ),
+        )
+
+    def test_multi_hosts(self):
+        conf = get_presto_connection_conf(
+            "presto://www.foobar.com:443,www.baz.com:80/spam/egg?SSL=true&foo=bar"
+        )
+        self.assertIn(
+            (conf.host, conf.port), [("www.foobar.com", 443), ("www.baz.com", 80)]
+        )

--- a/querybook/webapp/components/AppAdmin/AppAdmin.scss
+++ b/querybook/webapp/components/AppAdmin/AppAdmin.scss
@@ -152,10 +152,6 @@
         }
     }
 
-    .GenericCRUD-invalid-msg {
-        margin-left: 8px;
-    }
-
     .Tabs {
         li {
             min-width: 120px;

--- a/querybook/webapp/lib/formik/extract-error.ts
+++ b/querybook/webapp/lib/formik/extract-error.ts
@@ -1,0 +1,25 @@
+import { isArray, isObject, isString } from 'lodash';
+
+export function extractFormikError(rootErrors: Record<string, any>): string[] {
+    const errorDescriptions = [];
+
+    const helper = (errors: any, path: string = '') => {
+        if (isString(errors)) {
+            errorDescriptions.push(`${path}: ${errors}`);
+            return;
+        }
+        if (isObject(errors) || isArray(errors)) {
+            // It can be an array, object, or string
+            for (const [parentName, childErrors] of Object.entries(errors)) {
+                helper(
+                    childErrors,
+                    path ? path + '.' + parentName : parentName
+                );
+            }
+        }
+    };
+
+    helper(rootErrors);
+
+    return errorDescriptions;
+}

--- a/querybook/webapp/ui/Form/FormError.tsx
+++ b/querybook/webapp/ui/Form/FormError.tsx
@@ -1,0 +1,25 @@
+import { uniq } from 'lodash';
+import React, { useMemo } from 'react';
+import { extractFormikError } from 'lib/formik/extract-error';
+import { Message } from 'ui/Message/Message';
+
+export const FormError: React.FC<{
+    errors: Record<string, any>;
+}> = ({ errors }) => {
+    const errorStrings = useMemo(() => uniq(extractFormikError(errors)), [
+        errors,
+    ]);
+    if (errorStrings.length === 0) {
+        return null;
+    }
+    return (
+        <Message type="error">
+            {errorStrings.map((error, idx) => (
+                <div key={idx}>
+                    <span>{error}</span>
+                    <br />
+                </div>
+            ))}
+        </Message>
+    );
+};

--- a/querybook/webapp/ui/GenericCRUD/GenericCRUD.scss
+++ b/querybook/webapp/ui/GenericCRUD/GenericCRUD.scss
@@ -1,7 +1,2 @@
 .GenericCRUD {
-    .GenericCRUD-invalid-msg {
-        font-weight: var(--bold-font);
-        color: var(--color-false);
-        font-size: var(--text-size);
-    }
 }

--- a/querybook/webapp/ui/GenericCRUD/GenericCRUD.tsx
+++ b/querybook/webapp/ui/GenericCRUD/GenericCRUD.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Formik, FormikConfig } from 'formik';
+import { isEmpty } from 'lodash';
 
 import { AsyncButton } from 'ui/AsyncButton/AsyncButton';
-import './GenericCRUD.scss';
 import { Button } from 'ui/Button/Button';
 import { getChangedObject } from 'lib/utils';
 import toast from 'react-hot-toast';
+import './GenericCRUD.scss';
+import { FormError } from 'ui/Form/FormError';
 
 export interface IGenericCRUDProps<T> extends Partial<FormikConfig<T>> {
     item: T;
@@ -82,6 +84,7 @@ export function GenericCRUD<T extends Record<any, any>>({
                     setFieldValue,
                     handleSubmit,
                     isSubmitting,
+                    errors,
                 }) => {
                     const deleteButton = deleteItem && (
                         <AsyncButton
@@ -104,9 +107,14 @@ export function GenericCRUD<T extends Record<any, any>>({
                         />
                     );
 
+                    const errorSection = !isEmpty(errors) ? (
+                        <FormError errors={errors} />
+                    ) : null;
+
                     return (
                         <div>
                             {renderItem(values, setFieldValue)}
+                            {errorSection}
                             <div className="pv8 right-align">
                                 <div>{deleteButton}</div>
                                 <div>{saveButton}</div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -240,7 +240,10 @@ module.exports = (env, options) => {
                 filename: '[file].map[query]',
                 exclude: [/vendor/],
             }),
-            !PROD && new ReactRefreshWebpackPlugin(),
+            !PROD &&
+                new ReactRefreshWebpackPlugin({
+                    overlay: false,
+                }),
         ].filter(Boolean),
     };
 };


### PR DESCRIPTION
Fix include:
- Show form error message when executor param is invalid, useful to let users know what needs to be changed.
![image](https://user-images.githubusercontent.com/8283407/146621679-0b69f1a8-bb07-459a-a3ca-c8fc3bcc076a.png)
- Update parsing logic for Presto and Trino so now they can both accept all strings in query parameters
- Added unit tests for presto connection string parsing
- Hide error overlay for frontend