### PR TITLE
Feat: LDAP bind user and filter

### DIFF
--- a/docs_website/docs/configurations/infra_config.md
+++ b/docs_website/docs/configurations/infra_config.md
@@ -101,8 +101,25 @@ the next few configurations are only relevant if you are using OAuth based authe
 
 for LDAP authentication:
 
--   `LDAP_CONN`(**required**)
--   `LDAP_USER_DN` (**required**) DN with {} for username/etc (ex. `uid={},dc=example,dc=com`)
+- `LDAP_CONN`(**required**)
+- `LDAP_USE_TLS` (optional, defaults to `False`)
+- `LDAP_USE_BIND_USER` (optional, defaults to `False`)
+  - If `False`: Direct LDAP login
+    - Additional configuration:
+      - `LDAP_USER_DN` (**required**) DN with {} for username/etc (ex. `uid={},dc=example,dc=com`)
+    - Login flow:
+      - Direct login using formatted `LDAP_USER_DN` + password
+  - If `True`: Advanced LDAP login using _bind user_
+    - Additional configuration:
+      - `LDAP_BIND_USER` (**required**) Name of a _bind user_
+      - `LDAP_BIND_PASSWORD` (**required**) Password of a _bind user_
+      - `LDAP_SEARCH` (**required**) LDAP search base (ex. `ou=people,dc=example,dc=com`)
+      - `LDAP_FILTER` (optional) LDAP filter condition (ex. `(departmentNumber=01000)`)
+    - Login flow:
+      1) Initialized connection for the _bind user_.
+      2) Searching the _login user_ using the _bind user_ in LDAP dictionary based on `LDAP_SEARCH` and `LDAP_FILTER`.
+      3) The _login user_ credentials are tested in direct login.
+      4) If the previous steps were OK, the user is passed on.
 
 If you want to force the user to login again after a certain time, you can the following variable:
 

--- a/querybook/server/app/auth/ldap_auth.py
+++ b/querybook/server/app/auth/ldap_auth.py
@@ -1,72 +1,318 @@
-import re
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 import ldap
 import flask_login
+import re
+from ldap.ldapobject import SimpleLDAPObject
 
 from flask_login import current_user
 from env import QuerybookSettings
 from app.db import with_session, DBSession
 from .utils import AuthenticationError, AuthUser, QuerybookLoginManager
+from lib.logger import get_logger
 from logic.user import (
     get_user_by_name,
     create_user,
 )
+from models.user import User
+
+LOG = get_logger(__file__)
 
 login_manager = QuerybookLoginManager()
 
 
-def get_transformed_username(username):
-    dn = None
-    if username.startswith("uid="):
-        dn = username
-
-        match = re.match(r"^uid=([^,]+)", username)
-        username = match.group(1)
-    else:
-        dn = QuerybookSettings.LDAP_USER_DN.format(username)
-    return username, dn
+class LDAPAuthErrors:
+    BAD_CREDENTIALS = "Bad credentials"
+    UNAUTHORIZED = "Unauthorized"
 
 
-@with_session
-def authenticate(username, password, session=None):
-    if not username or not password:
-        raise AuthenticationError()
+@dataclass
+class LDAPUserInfo:
+    LDAP_ATTRS = ["cn", "givenName", "mail", "sn"]
 
-    conn = ldap.initialize(QuerybookSettings.LDAP_CONN)
-    conn.set_option(ldap.OPT_REFERRALS, 0)
+    cn: Optional[str] = None
+    dn: Optional[str] = None
+    email: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
 
+    @property
+    def full_name(self) -> str:
+        full_name = " ".join(filter(bool, [self.first_name, self.last_name]))
+        return full_name if full_name else self.cn
+
+
+def _sanitize_ldap_search_results(
+    search_results: List[Tuple],
+) -> Optional[Tuple[str, Dict]]:
+    # Remove any search referrals from results
+    cleared_results = [
+        (dn, attrs)
+        for dn, attrs in search_results
+        if dn is not None and isinstance(attrs, dict)
+    ]
+    n_found = len(cleared_results)
+    if n_found != 1:
+        if n_found > 1:
+            LOG.warning(f"LDAP search returned {n_found} results")
+        return None
+    return cleared_results[0]
+
+
+def _get_ldap_filter() -> str:
+    search_filter = (
+        QuerybookSettings.LDAP_FILTER
+        if QuerybookSettings.LDAP_USE_BIND_USER and QuerybookSettings.LDAP_FILTER
+        else "(objectClass=*)"
+    )
+
+    if QuerybookSettings.LDAP_FILTER and not QuerybookSettings.LDAP_USE_BIND_USER:
+        LOG.warning(
+            "LDAP_FILTER is going to be ignored when LDAP_USE_BIND_USER is not True"
+        )
+
+    if search_filter and not re.match("\\(.*\\)", search_filter):
+        search_filter = f"({search_filter})"
+
+    return search_filter
+
+
+def _parse_value(value: Union[bytes, str, List[Union[bytes, str]]]) -> str:
+    if isinstance(value, List):
+        value = value[0]
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return value
+
+
+def _parse_user_info(ldap_user_info: Tuple[str, Dict]) -> LDAPUserInfo:
     try:
-        conn.simple_bind_s(username, password)
+        user_info = ldap_user_info[1]
+        return LDAPUserInfo(
+            cn=_parse_value(user_info["cn"]),
+            dn=ldap_user_info[0],
+            email=_parse_value(user_info["mail"]),
+            first_name=_parse_value(user_info["givenName"]),
+            last_name=_parse_value(user_info["sn"]),
+        )
+
+    except (IndexError, NameError):
+        LOG.error(f"Failed to parse UserInfo from: {ldap_user_info}")
+        raise AuthenticationError("Failed to parse user information")
+
+
+def ldap_authenticate(ldap_conn: SimpleLDAPObject, user_dn: str, password: str):
+    """Validates/binds the provided dn/password with the LDAP sever."""
+    try:
+        LOG.debug(f"LDAP bind TRY with username: '{user_dn}'")
+        ldap_conn.simple_bind_s(who=user_dn, cred=password)
+        LOG.debug(f"LDAP bind SUCCESS with username: '{user_dn}'")
+        return True
     except ldap.INVALID_CREDENTIALS:
-        raise AuthenticationError("User does not exist or wrong password")
-    return True
+        return False
 
 
 @with_session
-def login_user(username, session=None):
+def login_user(username: str, email: str, full_name: str, session=None):
     user = get_user_by_name(username, session=session)
     if not user:
-        user = create_user(username=username, fullname=username, session=session)
+        user = create_user(
+            username=username, fullname=full_name, email=email, session=session
+        )
     return user
 
 
-def login_user_endpoint(username, password):
+def search_user_by_uid(
+    ldap_conn: SimpleLDAPObject,
+    uid: str = None,
+    attrs: Optional[List[str]] = None,
+    apply_filter: bool = False,
+) -> Optional[Tuple[str, Dict]]:
+    search_filter = (
+        f"(&(uid={uid})"
+        + (_get_ldap_filter() if apply_filter else "(objectClass=*)")
+        + ")"
+    )
+    try:
+        raw_search_result = ldap_conn.search_s(
+            base=QuerybookSettings.LDAP_SEARCH,
+            scope=ldap.SCOPE_SUBTREE,
+            filterstr=search_filter,
+            attrlist=attrs,
+        )
+    except ldap.NO_SUCH_OBJECT:
+        return None
+    return _sanitize_ldap_search_results(raw_search_result)
+
+
+def search_user_by_dn(
+    ldap_conn: SimpleLDAPObject,
+    user_dn: str = None,
+    attrs: Optional[List[str]] = None,
+    apply_filter: bool = False,
+) -> Optional[Tuple[str, Dict]]:
+    try:
+        raw_search_result = ldap_conn.search_s(
+            base=user_dn,
+            scope=ldap.SCOPE_SUBTREE,
+            filterstr=_get_ldap_filter() if apply_filter else "(objectClass=*)",
+            attrlist=attrs,
+        )
+    except ldap.NO_SUCH_OBJECT:
+        return None
+    return _sanitize_ldap_search_results(raw_search_result)
+
+
+def get_transformed_username(
+    ldap_conn: SimpleLDAPObject, username: str
+) -> Tuple[str, str]:
+    # Case when there is a username in form of DN
+    if re.match(r"^\w+=.+", username):
+        dn = username
+        if QuerybookSettings.LDAP_USE_BIND_USER:
+            search_result = search_user_by_dn(ldap_conn, user_dn=dn, attrs=["uid"])
+            if not search_result:
+                # In case when provided DN wasn't found in LDAP
+                raise AuthenticationError(LDAPAuthErrors.BAD_CREDENTIALS)
+            username = _parse_value(search_result[1]["uid"])
+        else:
+            match = re.match(
+                QuerybookSettings.LDAP_USER_DN.replace("{}", "(.+?)"), username
+            )
+            if not match:
+                raise ValueError(
+                    f"Username in form of LDAP DN has to follow '{QuerybookSettings.LDAP_USER_DN}' pattern"
+                )
+            username = match.group(1)
+    # Username in form of UID
+    else:
+        if QuerybookSettings.LDAP_USE_BIND_USER:
+            search_result = search_user_by_uid(ldap_conn, uid=username)
+            if not search_result:
+                # In case when provided UID wasn't found in LDAP
+                raise AuthenticationError(LDAPAuthErrors.BAD_CREDENTIALS)
+            dn = search_result[0]
+        else:
+            dn = QuerybookSettings.LDAP_USER_DN.format(username)
+
+    return username, dn
+
+
+@contextmanager
+def ldap_connection() -> Iterator[SimpleLDAPObject]:
+    try:
+        conn = ldap.initialize(QuerybookSettings.LDAP_CONN, trace_level=0)
+        conn.set_option(ldap.OPT_REFERRALS, 0)
+    except ldap.LDAPError as ldap_error:
+        raise ConnectionError("Failed to create LDAP connection") from ldap_error
+
+    if QuerybookSettings.LDAP_USE_TLS:
+        try:
+            conn.start_tls_s()
+        except ldap.CONNECT_ERROR as connect_error:
+            raise ConnectionError(
+                "Failed to create LDAP TLS connection"
+            ) from connect_error
+
+    try:
+        yield conn
+    finally:
+        conn.unbind_s()
+
+
+def authenticate_user_by_bind_connection(
+    user_dn: str,
+    password: str,
+    bind_conn: SimpleLDAPObject,
+    user_conn: SimpleLDAPObject,
+) -> LDAPUserInfo:
+    # Try to connect with user credentials now
+    if not ldap_authenticate(user_conn, user_dn=user_dn, password=password):
+        raise AuthenticationError(LDAPAuthErrors.BAD_CREDENTIALS)
+
+    # Get information about the session user using the bind user.
+    # The filter is applied, so no results means the user isn't allowed.
+    user_info_search = search_user_by_dn(
+        bind_conn, user_dn=user_dn, attrs=LDAPUserInfo.LDAP_ATTRS, apply_filter=True
+    )
+    if not user_info_search:
+        raise AuthenticationError(LDAPAuthErrors.UNAUTHORIZED)
+
+    return _parse_user_info(user_info_search)
+
+
+def authenticate_user_by_direct_connection(
+    user_dn: str, password: str, user_conn: SimpleLDAPObject
+) -> LDAPUserInfo:
+    # Try to do direct authentication with the session user
+    if not ldap_authenticate(user_conn, user_dn=user_dn, password=password):
+        raise AuthenticationError(LDAPAuthErrors.BAD_CREDENTIALS)
+
+    # In case of direct login, ldap_search may not be allowed for all users,
+    # therefore it's not possible to obtain user details, but user should be allowed.
+    user_info_search = search_user_by_dn(
+        user_conn, user_dn=user_dn, attrs=LDAPUserInfo.LDAP_ATTRS
+    )
+    return (
+        _parse_user_info(user_info_search)
+        if user_info_search
+        else LDAPUserInfo(dn=user_dn)
+    )
+
+
+def login_user_endpoint(username, password) -> Optional[User]:
     if current_user.is_authenticated:
         return
 
-    username, dn = get_transformed_username(username)
+    if not username or not password:
+        raise AuthenticationError("Missing username or password")
 
-    if authenticate(dn, password):
-        with DBSession() as session:
-            user = login_user(username, session=session)
-            flask_login.login_user(AuthUser(user))
-            return user
+    if QuerybookSettings.LDAP_USE_BIND_USER:
+        with ldap_connection() as bind_conn:
+            # Try to make connection with the bind user first
+            if not ldap_authenticate(
+                bind_conn,
+                user_dn=QuerybookSettings.LDAP_BIND_USER,
+                password=QuerybookSettings.LDAP_BIND_PASSWORD,
+            ):
+                raise ConnectionError(
+                    "Failed to establish LDAP connection for bind user"
+                )
+
+            processed_username, user_dn = get_transformed_username(bind_conn, username)
+
+            with ldap_connection() as user_conn:
+                ldap_user_info = authenticate_user_by_bind_connection(
+                    user_dn=user_dn,
+                    password=password,
+                    bind_conn=bind_conn,
+                    user_conn=user_conn,
+                )
+    else:
+        with ldap_connection() as user_conn:
+            processed_username, user_dn = get_transformed_username(user_conn, username)
+
+            ldap_user_info = authenticate_user_by_direct_connection(
+                user_dn=user_dn, password=password, user_conn=user_conn
+            )
+
+    with DBSession() as session:
+        db_user = login_user(
+            username=processed_username,
+            email=ldap_user_info.email,
+            full_name=ldap_user_info.full_name,
+            session=session,
+        )
+        flask_login.login_user(AuthUser(db_user))
+        return db_user
 
 
-def init_app(app):
+def init_app(app) -> None:
     login_manager.init_app(app)
 
 
-def login(request):
+def login(_) -> None:
     # The webapp will handle the UI for logging in
     pass

--- a/querybook/server/env.py
+++ b/querybook/server/env.py
@@ -73,7 +73,30 @@ class QuerybookSettings(object):
     AZURE_TENANT_ID = get_env_config("AZURE_TENANT_ID")
 
     LDAP_CONN = get_env_config("LDAP_CONN")
+    LDAP_USE_TLS = str(get_env_config("LDAP_USE_TLS")).lower() == "true"
+    LDAP_USE_BIND_USER = str(get_env_config("LDAP_USE_BIND_USER")).lower() == "true"
+    # For direct authentication
     LDAP_USER_DN = get_env_config("LDAP_USER_DN")
+    # For searches using bind user
+    LDAP_BIND_USER = get_env_config("LDAP_BIND_USER")
+    LDAP_BIND_PASSWORD = get_env_config("LDAP_BIND_PASSWORD")
+    LDAP_SEARCH = get_env_config("LDAP_SEARCH")
+    LDAP_FILTER = get_env_config("LDAP_FILTER")
+    # Configuration validation
+    if LDAP_CONN is not None:
+        if LDAP_USE_BIND_USER:
+            if (
+                LDAP_BIND_USER is None
+                or LDAP_BIND_PASSWORD is None
+                or LDAP_SEARCH is None
+            ):
+                raise ValueError(
+                    "LDAP_BIND_USER, LDAP_BIND_PASSWORD and LDAP_SEARCH has to be set when using LDAP bind user connection"
+                )
+        elif LDAP_USER_DN is None:
+            raise ValueError(
+                "LDAP_USER_DN has to be set when using direct LDAP connection"
+            )
 
     # Result Store
     RESULT_STORE_TYPE = get_env_config("RESULT_STORE_TYPE")

--- a/querybook/tests/test_app/test_auth/test_ldap_auth.py
+++ b/querybook/tests/test_app/test_auth/test_ldap_auth.py
@@ -1,0 +1,534 @@
+from copy import deepcopy
+from typing import Dict, List, Optional, Tuple, Type, cast
+from unittest.mock import MagicMock
+
+import ldap
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from ldap.ldapobject import SimpleLDAPObject
+
+from app.auth import ldap_auth
+from app.auth.utils import AuthenticationError
+from env import QuerybookSettings
+
+LDAP_DIRECTORY_BASE = {
+    "dc=querybook,dc=com": {
+        "objectClass": [b"top", b"dcObject", b"organization"],
+        "o": [b"Querybook"],
+        "dc": [b"socialbakers"],
+    },
+    "ou=people,dc=querybook,dc=com": {
+        "objectClass": [b"top", b"organizationalUnit"],
+        "ou": b"people",
+    },
+}
+
+BIND_USER_DN_UID = "uid=bind,ou=people,dc=querybook,dc=com"
+BIND_USER_DN_CN = "cn=bind user,ou=people,dc=querybook,dc=com"
+USER_DN_UID = "uid=newmaj,ou=people,dc=querybook,dc=com"
+USER_DN_CN = "cn=John Newman,ou=people,dc=querybook,dc=com"
+
+BIND_USER_INFO = {
+    "cn": [b"Bind User"],
+    "uid": [b"bind"],
+    "userPassword": [b"bind123"],
+    "objectClass": [b"organizationalPerson"],
+}
+USER_INFO = {
+    "cn": [b"John Newman"],
+    "givenName": [b"John"],
+    "sn": [b"Newman"],
+    "uid": [b"newmaj"],
+    "mail": [b"jn@querybook.com"],
+    "userPassword": [b"jn123"],
+    "objectClass": [b"organizationalPerson"],
+}
+
+LDAP_DIRECTORY_UID = {
+    **LDAP_DIRECTORY_BASE,
+    BIND_USER_DN_UID: BIND_USER_INFO,
+    USER_DN_UID: USER_INFO,
+}
+
+LDAP_DIRECTORY_CN = {
+    **LDAP_DIRECTORY_BASE,
+    BIND_USER_DN_CN: BIND_USER_INFO,
+    USER_DN_CN: USER_INFO,
+}
+
+
+@pytest.fixture(autouse=True)
+def settings(monkeypatch: MonkeyPatch) -> MonkeyPatch:
+    monkeypatch.setattr(QuerybookSettings, "LDAP_CONN", "ldap://localhost:389")
+    monkeypatch.setattr(
+        QuerybookSettings, "LDAP_SEARCH", "ou=people,dc=querybook,dc=com"
+    )
+    monkeypatch.setattr(
+        QuerybookSettings, "LDAP_USER_DN", "uid={},ou=people,dc=querybook,dc=com"
+    )
+    monkeypatch.setattr(
+        QuerybookSettings, "LDAP_BIND_USER", "uid=bind,ou=people,dc=querybook,dc=com"
+    )
+    monkeypatch.setattr(QuerybookSettings, "LDAP_BIND_PASSWORD", "bind123")
+    monkeypatch
+    yield
+    monkeypatch.undo()
+
+
+from abc import ABC, abstractmethod
+
+
+class MockLdap(ABC):
+    def __init__(self):
+        self.mock_search_s = MagicMock(side_effect=self._search_s)
+        self.mock_simple_bind_s = MagicMock(side_effect=self._simple_bind_s)
+
+    @staticmethod
+    @abstractmethod
+    def _simple_bind_s(who: str, cred: str) -> Tuple:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def _search_s(
+        base: str, scope: int, filterstr: str, attrlist: List[str]
+    ) -> List[Tuple]:
+        pass
+
+    def simple_bind_s(self, **kwargs) -> Tuple:
+        return self.mock_simple_bind_s(**kwargs)
+
+    def search_s(self, **kwargs) -> Tuple:
+        return self.mock_search_s(**kwargs)
+
+
+class MockLdapUID(MockLdap):
+    @staticmethod
+    def _simple_bind_s(who: str, cred: str) -> Tuple:
+        if who == USER_DN_UID and cred == "jn123":
+            return 97, [], 1, []
+        elif who == BIND_USER_DN_UID and cred == "bind123":
+            return 97, [], 2, []
+        raise ldap.INVALID_CREDENTIALS()
+
+    @staticmethod
+    def _search_s(
+        base: str, scope: int, filterstr: str, attrlist: List[str]
+    ) -> List[Tuple]:
+        if (
+            (filterstr == "(&(uid=unknown)(objectClass=*))")
+            or (filterstr == "(&(uid=newmaj)(sn=Unknown))")
+            or (filterstr == "(sn=Unknown)")
+            or (base == "uid=unknown,ou=people,dc=querybook,dc=com")
+            or (base == "uid=newmaj,ou=people,dc=querybook,dc=unknown")
+            or (base == "cn=John Newman,ou=people,dc=querybook,dc=com")
+        ):
+            return []
+        elif scope == 2 and (
+            (
+                base == "ou=people,dc=querybook,dc=com"
+                and filterstr == "(&(uid=newmaj)(objectClass=*))"
+            )
+            or (
+                base == "ou=people,dc=querybook,dc=com"
+                and filterstr == "(&(uid=newmaj)(sn=Newman))"
+            )
+            or (
+                base == "uid=newmaj,ou=people,dc=querybook,dc=com"
+                and filterstr == "(objectClass=*)"
+            )
+            or (
+                base == "uid=newmaj,ou=people,dc=querybook,dc=com"
+                and filterstr == "(sn=Newman)"
+            )
+        ):
+            return [
+                (
+                    USER_DN_UID,
+                    {
+                        k: v
+                        for k, v in USER_INFO.items()
+                        if (k in attrlist if attrlist else True)
+                    },
+                )
+            ]
+        raise RuntimeError("Unsupported mock")
+
+
+class MockLdapCN(MockLdap):
+    @staticmethod
+    def _simple_bind_s(who: str, cred: str) -> Tuple:
+        if who == USER_DN_CN and cred == "jn123":
+            return 97, [], 1, []
+        elif who == BIND_USER_DN_CN and cred == "bind123":
+            return 97, [], 2, []
+        raise ldap.INVALID_CREDENTIALS()
+
+    @staticmethod
+    def _search_s(
+        base: str, scope: int, filterstr: str, attrlist: List[str]
+    ) -> List[Tuple]:
+        if scope == 2 and (
+            (
+                base == "ou=people,dc=querybook,dc=com"
+                and filterstr == "(&(uid=newmaj)(objectClass=*))"
+            )
+            or (
+                base == "cn=John Newman,ou=people,dc=querybook,dc=com"
+                and filterstr == "(objectClass=*)"
+            )
+        ):
+            return [
+                (
+                    USER_DN_CN,
+                    {
+                        k: v
+                        for k, v in USER_INFO.items()
+                        if (k in attrlist if attrlist else True)
+                    },
+                )
+            ]
+        raise RuntimeError("Unsupported mock")
+
+
+@pytest.fixture
+def mock_ldap_uid() -> SimpleLDAPObject:
+    return cast(SimpleLDAPObject, MockLdapUID())
+
+
+@pytest.fixture
+def mock_ldap_cn() -> SimpleLDAPObject:
+    return cast(SimpleLDAPObject, MockLdapCN())
+
+
+@pytest.mark.parametrize(
+    "user_dn, password, result",
+    [
+        ("cn=John Newman,ou=people,dc=querybook,dc=com", "jn123", True),
+        ("cn=John Newman,ou=group,dc=querybook,dc=com", "jn123", False),
+        ("cn=John Badman,ou=people,dc=querybook,dc=com", "123", False),
+        ("cn=John Newman,ou=people,dc=querybook,dc=com", "password", False),
+    ],
+)
+def test_ldap_authenticate_cn(
+    mock_ldap_cn: SimpleLDAPObject, user_dn: str, password: str, result: bool
+):
+    assert (
+        ldap_auth.ldap_authenticate(mock_ldap_cn, user_dn=user_dn, password=password)
+        == result
+    )
+
+
+@pytest.mark.parametrize(
+    "user_dn, password, result",
+    [
+        ("uid=newmaj,ou=people,dc=querybook,dc=com", "jn123", True),
+        ("uid=newmaj,ou=group,dc=querybook,dc=com", "jn123", False),
+        ("uid=newmaa,ou=people,dc=querybook,dc=com", "jn123", False),
+        ("uid=newmaj,ou=people,dc=querybook,dc=com", "password", False),
+    ],
+)
+def test_ldap_authenticate_uid(
+    mock_ldap_uid: SimpleLDAPObject, user_dn: str, password: str, result: bool
+):
+    assert (
+        ldap_auth.ldap_authenticate(mock_ldap_uid, user_dn=user_dn, password=password)
+        == result
+    )
+
+
+@pytest.mark.parametrize(
+    "username, use_bind, user_dn, exp_username, expected_dn, exp_error",
+    [
+        (
+            "newmaj",
+            True,
+            None,
+            "newmaj",
+            "uid=newmaj,ou=people,dc=querybook,dc=com",
+            None,
+        ),
+        (
+            "newmaj",
+            False,
+            "uid={},ou=people,dc=querybook,dc=com",
+            "newmaj",
+            "uid=newmaj,ou=people,dc=querybook,dc=com",
+            None,
+        ),
+        (
+            "uid=newmaj,ou=people,dc=querybook,dc=com",
+            True,
+            None,
+            "newmaj",
+            "uid=newmaj,ou=people,dc=querybook,dc=com",
+            None,
+        ),
+        (
+            "cn=John Newman,ou=people,dc=querybook,dc=com",
+            True,
+            None,
+            None,
+            None,
+            AuthenticationError,
+        ),  # using CN DN on UID based LDAP
+        (
+            "uid=newmaj,ou=people,dc=querybook,dc=com",
+            False,
+            "uid={},ou=people,dc=querybook,dc=com",
+            "newmaj",
+            "uid=newmaj,ou=people,dc=querybook,dc=com",
+            None,
+        ),
+        (
+            "cn=John Newman,ou=people,dc=querybook,dc=com",
+            False,
+            "cn={},ou=people,dc=querybook,dc=com",
+            "John Newman",
+            "cn=John Newman,ou=people,dc=querybook,dc=com",
+            None,
+        ),
+        (
+            "cn=John Newman,ou=people,dc=querybook,dc=com",
+            False,
+            "uid={},ou=people,dc=querybook,dc=com",
+            None,
+            None,
+            ValueError,
+        ),
+    ],
+)
+def test_ldap_get_transformed_username_uid(
+    monkeypatch: MonkeyPatch,
+    mock_ldap_uid: SimpleLDAPObject,
+    username: str,
+    use_bind: bool,
+    user_dn: Optional[str],
+    exp_username: Optional[str],
+    expected_dn: Optional[str],
+    exp_error: Optional[Type[Exception]],
+):
+    monkeypatch.setattr(QuerybookSettings, "LDAP_USE_BIND_USER", use_bind)
+    monkeypatch.setattr(QuerybookSettings, "LDAP_USER_DN", user_dn)
+    try:
+        username, dn = ldap_auth.get_transformed_username(mock_ldap_uid, username)
+    except Exception as exception:
+        if not isinstance(exception, exp_error):
+            raise exception
+    else:
+        assert username == exp_username
+        assert dn == expected_dn
+
+
+@pytest.mark.parametrize(
+    "ldap_filter, use_bind, exp_filter",
+    [
+        ("uid=newmaj", True, "(uid=newmaj)"),
+        ("(uid=newmaj)", True, "(uid=newmaj)"),
+        (None, True, "(objectClass=*)"),
+        ("(uid=newmaj)", False, "(objectClass=*)"),
+    ],
+)
+def test_get_ldap_filter(
+    monkeypatch: MonkeyPatch, ldap_filter: str, use_bind: bool, exp_filter: str
+) -> None:
+    monkeypatch.setattr(QuerybookSettings, "LDAP_FILTER", ldap_filter)
+    monkeypatch.setattr(QuerybookSettings, "LDAP_USE_BIND_USER", use_bind)
+    assert ldap_auth._get_ldap_filter() == exp_filter
+
+
+@pytest.mark.parametrize(
+    "uid, attrs, ldap_filter, exp_res",
+    [
+        (
+            "newmaj",
+            ["mail"],
+            None,
+            (
+                "uid=newmaj,ou=people,dc=querybook,dc=com",
+                {"mail": [b"jn@querybook.com"]},
+            ),
+        ),
+        (
+            "newmaj",
+            ["mail"],
+            "(sn=Newman)",
+            (
+                "uid=newmaj,ou=people,dc=querybook,dc=com",
+                {"mail": [b"jn@querybook.com"]},
+            ),
+        ),
+        ("newmaj", ["mail"], "(sn=Unknown)", None),
+        ("unknown", ["mail"], None, None),
+    ],
+)
+def test_search_by_uid(
+    monkeypatch: MonkeyPatch,
+    mock_ldap_uid: SimpleLDAPObject,
+    uid: str,
+    attrs: List[str],
+    ldap_filter: Optional[str],
+    exp_res: Optional[Tuple[str, Dict]],
+) -> None:
+    if ldap_filter:
+        monkeypatch.setattr(QuerybookSettings, "LDAP_USE_BIND_USER", True)
+        monkeypatch.setattr(QuerybookSettings, "LDAP_FILTER", ldap_filter)
+    assert (
+        ldap_auth.search_user_by_uid(
+            mock_ldap_uid, uid, attrs=attrs, apply_filter=bool(ldap_filter)
+        )
+        == exp_res
+    )
+
+
+@pytest.mark.parametrize(
+    "user_dn, attrs, ldap_filter, exp_res",
+    [
+        (
+            "uid=newmaj,ou=people,dc=querybook,dc=com",
+            ["mail"],
+            None,
+            (
+                "uid=newmaj,ou=people,dc=querybook,dc=com",
+                {"mail": [b"jn@querybook.com"]},
+            ),
+        ),
+        (
+            "uid=newmaj,ou=people,dc=querybook,dc=com",
+            ["mail"],
+            "(sn=Newman)",
+            (
+                "uid=newmaj,ou=people,dc=querybook,dc=com",
+                {"mail": [b"jn@querybook.com"]},
+            ),
+        ),
+        ("uid=newmaj,ou=people,dc=querybook,dc=com", ["mail"], "(sn=Unknown)", None),
+        ("uid=unknown,ou=people,dc=querybook,dc=com", ["mail"], None, None),
+    ],
+)
+def test_search_by_dn(
+    monkeypatch: MonkeyPatch,
+    mock_ldap_uid: SimpleLDAPObject,
+    user_dn: str,
+    attrs: List[str],
+    ldap_filter: Optional[str],
+    exp_res: Optional[Tuple[str, Dict]],
+) -> None:
+    if ldap_filter:
+        monkeypatch.setattr(QuerybookSettings, "LDAP_USE_BIND_USER", True)
+        monkeypatch.setattr(QuerybookSettings, "LDAP_FILTER", ldap_filter)
+    assert (
+        ldap_auth.search_user_by_dn(
+            mock_ldap_uid, user_dn=user_dn, attrs=attrs, apply_filter=bool(ldap_filter)
+        )
+        == exp_res
+    )
+
+
+def test_parse_user_info() -> None:
+    assert ldap_auth._parse_user_info(
+        ("dn", {"mail": "email", "cn": "cn", "givenName": "fn", "sn": "ln"})
+    ) == ldap_auth.LDAPUserInfo(
+        dn="dn", cn="cn", first_name="fn", last_name="ln", email="email"
+    )
+
+
+@pytest.mark.parametrize(
+    "user_dn, password, ldap_filter, error_message",
+    [
+        ("uid=newmaj,ou=people,dc=querybook,dc=com", "jn123", None, None),
+        ("uid=unknown,ou=people,dc=querybook,dc=com", "jn123", None, "Bad credentials"),
+        ("uid=newmaj,ou=people,dc=querybook,dc=com", "xxxxx", None, "Bad credentials"),
+        (
+            "uid=newmaj,ou=people,dc=querybook,dc=unknown",
+            "jn123",
+            None,
+            "Bad credentials",
+        ),
+        (
+            "cn=John Newman,ou=people,dc=querybook,dc=com",
+            "jn123",
+            None,
+            "Bad credentials",
+        ),
+        (
+            "uid=newmaj,ou=people,dc=querybook,dc=com",
+            "jn123",
+            "(sn=Unknown)",
+            "Unauthorized",
+        ),
+    ],
+)
+def test_authenticate_user_by_bind_connection(
+    monkeypatch: MonkeyPatch,
+    user_dn: str,
+    password: str,
+    ldap_filter: Optional[str],
+    error_message: Optional[str],
+    mock_ldap_uid: SimpleLDAPObject,
+) -> None:
+    mock_bind_ldap_uid = deepcopy(mock_ldap_uid)
+    monkeypatch.setattr(QuerybookSettings, "LDAP_USE_BIND_USER", True)
+    monkeypatch.setattr(QuerybookSettings, "LDAP_FILTER", ldap_filter)
+    monkeypatch.setattr(
+        QuerybookSettings, "LDAP_SEARCH", "ou=people,dc=querybook,dc=com"
+    )
+    if error_message:
+        with pytest.raises(AuthenticationError) as error:
+            ldap_auth.authenticate_user_by_bind_connection(
+                user_dn=user_dn,
+                password=password,
+                bind_conn=mock_bind_ldap_uid,
+                user_conn=mock_ldap_uid,
+            )
+        assert error_message in str(error.value)
+    else:
+        ldap_auth.authenticate_user_by_bind_connection(
+            user_dn=user_dn,
+            password=password,
+            bind_conn=mock_bind_ldap_uid,
+            user_conn=mock_ldap_uid,
+        ).email == "jn@querybook.com"
+
+
+@pytest.mark.parametrize(
+    "user_dn, password, error_type, error_message",
+    [
+        ("uid=newmaj,ou=people,dc=querybook,dc=com", "jn123", None, None),
+        (
+            "uid=newmaj,ou=people,dc=querybook,dc=com",
+            "xxxxx",
+            AuthenticationError,
+            "Bad credentials",
+        ),
+        ("xxxxxx", "jn123", AuthenticationError, "Bad credentials"),
+        (
+            "uid=newmaj,ou=people,dc=querybook,dc=xxx",
+            "jn123",
+            AuthenticationError,
+            "Bad credentials",
+        ),
+    ],
+)
+def test_authenticate_user_by_direct_connection(
+    monkeypatch: MonkeyPatch,
+    user_dn: str,
+    password: str,
+    error_type: Type[Exception],
+    error_message: Optional[str],
+    mock_ldap_uid: SimpleLDAPObject,
+) -> None:
+    monkeypatch.setattr(QuerybookSettings, "LDAP_USE_BIND_USER", False)
+    monkeypatch.setattr(
+        QuerybookSettings, "LDAP_USER_DN", "uid={},ou=people,dc=querybook,dc=com"
+    )
+    if error_message:
+        with pytest.raises(error_type) as error:
+            ldap_auth.authenticate_user_by_direct_connection(
+                user_dn=user_dn, password=password, user_conn=mock_ldap_uid
+            )
+        assert error_message in str(error.value)
+    else:
+        ldap_auth.authenticate_user_by_direct_connection(
+            user_dn, password, mock_ldap_uid
+        )

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,6 +2,7 @@ pytest==5.2.2
 coverage==5.4
 moto==2.2.4
 
+-r auth/ldap.txt
 -r engine/hive.txt
 -r metastore/glue.txt
 -r exporter/gspread.txt


### PR DESCRIPTION
Solving #691 

This pull request:
- Extends `ldap_auth.py` module by possibility to specify LDAP bind user that can do LDAP search based on a filtering condition and allow/block specific users to access WebUI.
- Handles situations when user enters LDAP `dn` in different format than `uid=...`.
- Backward compatibility is ensured. Logging in directly with full LDAP DN or with uid and `LDAP_USER_DN` set is still possible.

I was stuck little bit on unit tests, because I based them on `mockldap`  library, but then found out it's not installable under Python 3.7.9 in the GitHub workflow, so I created custom mocked responses instead.