### PR TITLE
fix: remove unused docker compose fields

### DIFF
--- a/containers/docker-compose.dev.yml
+++ b/containers/docker-compose.dev.yml
@@ -3,9 +3,6 @@ version: '2.1'
 services:
     base:
         image: querybook-dev:latest
-        cap_add:
-            - SYS_PTRACE
-        tmpfs: /tmp:exec,mode=777
         tty: true
         stdin_open: true
         network_mode: 'host'

--- a/containers/docker-compose.prod.yml
+++ b/containers/docker-compose.prod.yml
@@ -3,9 +3,6 @@ version: '2.1'
 services:
     base:
         image: querybook:latest
-        cap_add:
-            - SYS_PTRACE
-        tmpfs: /tmp:exec,mode=777
         # tty: true
         # stdin_open: true
         network_mode: 'host'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,6 @@ version: '2.1'
 services:
     web:
         image: querybook-dev:latest
-        cap_add:
-            - SYS_PTRACE
-        tmpfs: /tmp:exec,mode=777
         tty: true
         stdin_open: true
         # network_mode: 'host'
@@ -37,9 +34,6 @@ services:
                 condition: service_healthy
     worker:
         image: querybook-dev:latest
-        cap_add:
-            - SYS_PTRACE
-        tmpfs: /tmp:exec,mode=777
         tty: true
         stdin_open: true
         command: './querybook/scripts/runservice worker -c 5'
@@ -58,9 +52,6 @@ services:
                 condition: service_healthy
     scheduler:
         image: querybook-dev:latest
-        cap_add:
-            - SYS_PTRACE
-        tmpfs: /tmp:exec,mode=777
         tty: true
         stdin_open: true
         command: './querybook/scripts/runservice scheduler --pidfile="/opt/celerybeat.pid"'
@@ -159,9 +150,6 @@ services:
     # Remember to put flower as part of local.txt
     # flower:
     #     image: querybook-dev:latest
-    #     cap_add:
-    #         - SYS_PTRACE
-    #     tmpfs: /tmp:exec,mode=777
     #     tty: true
     #     stdin_open: true
     #     # network_mode: "host"

--- a/docs_website/docs/setup_guide/deployment_guide.md
+++ b/docs_website/docs/setup_guide/deployment_guide.md
@@ -10,6 +10,6 @@ that are recommended when setting up your own production deployment.
 1. Please make sure the web server, the celery beat scheduler, and the celery worker are using the production Docker image. Please refer to `containers/docker-compose.prod.yml` to see how to launch these images for production.
 2. To get logs, make sure /var/log/querybook/ is mounted as a Docker volume so that the logs can be moved to the host machine.
 3. Use the /ping/ endpoint for health checks.
-    1. During deployments, you can create a file that has the path `/tmp/querybook/deploying` to make the health check endpoint /ping/ return 503 and remove it after completion.
+    1. During deployments, you can create a file that has the path `/tmp/querybook/deploying` (mount the directory from the host system as a volume) to make the health check endpoint /ping/ return 503 and remove it after completion.
 4. Please make sure celery worker is ran with concurrent mode as it is the only mode that can have a memory limit per worker.
 5. During worker deployments, you can run the following first to make the celery worker stop receving new tasks and exit once all current tasks are finished: `celery multi stopwait querybook_worker@%h -A tasks.all_tasks --pidfile=/opt/celery_%n.pid`. This will make deployment time take much longer but users' running queries won't be killed.


### PR DESCRIPTION
These 2 fields tmpfs and cap_add are not utilized by Querybook at all, removing them for simplicity sake.