### PR TITLE
fix: upgrade elasticsearch to 7.16.2 to fix log4j issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
             timeout: 30s
             retries: 3
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.15.1
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2
         environment:
             cluster.name: docker-cluster
             bootstrap.memory_lock: 'true'

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -117,7 +117,7 @@ elasticsearch:
   image:
     repository: docker.elastic.co/elasticsearch/elasticsearch
     pullPolicy: IfNotPresent
-    tag: "7.15.1"
+    tag: "7.16.2"
   extraEnvs:
     - name: ES_JAVA_OPTS
       value: -Xms512m -Xmx512m

--- a/k8s/elasticsearch-deployment.yaml
+++ b/k8s/elasticsearch-deployment.yaml
@@ -41,7 +41,7 @@ spec:
                         value: docker-cluster
                       - name: discovery.type
                         value: single-node
-                  image: docker.elastic.co/elasticsearch/elasticsearch:7.15.1
+                  image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2
                   #   livenessProbe:
                   #       httpGet:
                   #           path: /_cluster/health

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ pyyaml==5.4.1
 sqlalchemy==1.3.17
 pymysql==0.9.3
 requests==2.22.0
-elasticsearch==7.16.2
+elasticsearch==7.13.4
 
 # Query meta
 sqlparse==0.2.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ pyyaml==5.4.1
 sqlalchemy==1.3.17
 pymysql==0.9.3
 requests==2.22.0
-elasticsearch==7.13.4
+elasticsearch==7.16.2
 
 # Query meta
 sqlparse==0.2.3


### PR DESCRIPTION
Context: https://www.elastic.co/blog/new-elasticsearch-and-logstash-releases-upgrade-apache-log4j2