### PR TITLE
refactor: standardize button margin, simplify right sidebar

### DIFF
--- a/querybook/webapp/__tests__/ui/__snapshots__/AsyncButton.test.js.snap
+++ b/querybook/webapp/__tests__/ui/__snapshots__/AsyncButton.test.js.snap
@@ -28,7 +28,7 @@ exports[`matches enzyme snapshots matches snapshot 1`] = `
 
 exports[`matches test renderer snapshot serializes the styles 1`] = `
 <span
-  className="StyledButton-aqwbwz-0 eZYUp Button"
+  className="StyledButton-aqwbwz-0 bodqBd Button"
   color="var(--text-color)"
   disabled={false}
   onClick={[Function]}

--- a/querybook/webapp/__tests__/ui/__snapshots__/Button.test.js.snap
+++ b/querybook/webapp/__tests__/ui/__snapshots__/Button.test.js.snap
@@ -126,7 +126,7 @@ exports[`matches enzyme snapshots matches snapshot 1`] = `
 
 exports[`matches test renderer snapshot serializes the styles 1`] = `
 <span
-  className="StyledButton-aqwbwz-0 eZYUp Button"
+  className="StyledButton-aqwbwz-0 bodqBd Button"
   color="var(--text-color)"
   onClick={[Function]}
   size="medium"

--- a/querybook/webapp/__tests__/ui/__snapshots__/CopyButton.test.js.snap
+++ b/querybook/webapp/__tests__/ui/__snapshots__/CopyButton.test.js.snap
@@ -16,7 +16,7 @@ exports[`matches enzyme snapshots matches snapshot 1`] = `
 exports[`matches test renderer snapshot serializes the styles 1`] = `
 <span
   aria-label="Click To Copy"
-  className="StyledButton-aqwbwz-0 jBXKFp Button CopyButton flex-row"
+  className="StyledButton-aqwbwz-0 dEmTPM Button CopyButton flex-row"
   color="var(--text-color)"
   data-balloon-pos="up"
   fontWeight="700"

--- a/querybook/webapp/__tests__/ui/__snapshots__/Pagination.test.js.snap
+++ b/querybook/webapp/__tests__/ui/__snapshots__/Pagination.test.js.snap
@@ -88,7 +88,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
     className="Pagination-previous"
   >
     <span
-      className="StyledButton-aqwbwz-0 eZYUp Button"
+      className="StyledButton-aqwbwz-0 bodqBd Button"
       color="var(--text-color)"
       onClick={[Function]}
       size="medium"
@@ -102,7 +102,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
     className="Pagination-next"
   >
     <span
-      className="StyledButton-aqwbwz-0 eZYUp Button"
+      className="StyledButton-aqwbwz-0 bodqBd Button"
       color="var(--text-color)"
       onClick={[Function]}
       size="medium"
@@ -117,7 +117,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
   >
     <li>
       <span
-        className="StyledButton-aqwbwz-0 eZYUp Button Pagination-page-button "
+        className="StyledButton-aqwbwz-0 bodqBd Button Pagination-page-button "
         color="var(--text-color)"
         onClick={[Function]}
         size="medium"
@@ -129,7 +129,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
     </li>
     <li>
       <span
-        className="StyledButton-aqwbwz-0 eZYUp Button Pagination-page-button current"
+        className="StyledButton-aqwbwz-0 bodqBd Button Pagination-page-button current"
         color="var(--text-color)"
         onClick={[Function]}
         size="medium"
@@ -141,7 +141,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
     </li>
     <li>
       <span
-        className="StyledButton-aqwbwz-0 eZYUp Button Pagination-page-button "
+        className="StyledButton-aqwbwz-0 bodqBd Button Pagination-page-button "
         color="var(--text-color)"
         onClick={[Function]}
         size="medium"
@@ -153,7 +153,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
     </li>
     <li>
       <span
-        className="StyledButton-aqwbwz-0 eZYUp Button Pagination-page-button "
+        className="StyledButton-aqwbwz-0 bodqBd Button Pagination-page-button "
         color="var(--text-color)"
         onClick={[Function]}
         size="medium"
@@ -172,7 +172,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
     </li>
     <li>
       <span
-        className="StyledButton-aqwbwz-0 eZYUp Button Pagination-page-button "
+        className="StyledButton-aqwbwz-0 bodqBd Button Pagination-page-button "
         color="var(--text-color)"
         onClick={[Function]}
         size="medium"

--- a/querybook/webapp/__tests__/ui/__snapshots__/ToggleButton.test.js.snap
+++ b/querybook/webapp/__tests__/ui/__snapshots__/ToggleButton.test.js.snap
@@ -1,33 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`matches enzyme snapshots matches snapshot - unchecked 1`] = `
-<div
-  className="ToggleButton "
+<Button
+  className="ToggleButton"
+  color="default"
   onClick={[Function]}
+  size="medium"
+  theme="outline"
 >
-  <Button
-    className=""
-    color="default"
-    size="medium"
-    theme="outline"
-  >
-    Testing
-  </Button>
-</div>
+  Testing
+</Button>
 `;
 
 exports[`matches enzyme snapshots matches snapshot 1`] = `
-<div
+<Button
   className="ToggleButton checked"
+  color="default"
   onClick={[Function]}
+  size="medium"
+  theme="outline"
 >
-  <Button
-    className=""
-    color="default"
-    size="medium"
-    theme="outline"
-  >
-    Testing
-  </Button>
-</div>
+  Testing
+</Button>
 `;

--- a/querybook/webapp/components/ConfirmationManager/ConfirmationMessage.tsx
+++ b/querybook/webapp/components/ConfirmationManager/ConfirmationMessage.tsx
@@ -81,10 +81,6 @@ export const ConfirmationMessage: React.FunctionComponent<IConfirmationMessagePr
         actionButtons.shift();
     }
 
-    const actionsDOM = actionButtons.map((buttonDOM, index) => (
-        <div key={index}>{buttonDOM}</div>
-    ));
-
     return (
         <Modal
             onHide={onHide}
@@ -97,7 +93,7 @@ export const ConfirmationMessage: React.FunctionComponent<IConfirmationMessagePr
                     <div className="confirmation-message">{message}</div>
                 </div>
                 <div className="confirmation-buttons flex-right">
-                    {actionsDOM}
+                    {actionButtons}
                 </div>
             </div>
         </Modal>

--- a/querybook/webapp/components/DataDocRightSidebar/DataDocRightSidebar.scss
+++ b/querybook/webapp/components/DataDocRightSidebar/DataDocRightSidebar.scss
@@ -1,13 +1,6 @@
 .DataDocRightSidebar {
     .DataDocRightSidebar-button-section {
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-
         .DataDocRightSidebar-button-section-top {
-            display: flex;
-            flex-direction: column;
-
             .connected-button {
                 color: var(--color-false);
             }
@@ -18,10 +11,6 @@
                     cursor: unset;
                 }
             }
-        }
-        .DataDocRightSidebar-button-section-bottom {
-            display: flex;
-            flex-direction: column;
         }
     }
 

--- a/querybook/webapp/components/DataDocRightSidebar/DataDocRightSidebar.tsx
+++ b/querybook/webapp/components/DataDocRightSidebar/DataDocRightSidebar.tsx
@@ -81,7 +81,7 @@ export const DataDocRightSidebar: React.FunctionComponent<IProps> = ({
     );
 
     const buttonSection = (
-        <div className="DataDocRightSidebar-button-section">
+        <div className="DataDocRightSidebar-button-section vertical-space-between">
             <div className="DataDocRightSidebar-button-section-top flex-column">
                 <IconButton
                     icon="arrow-up"

--- a/querybook/webapp/ui/Button/StyledButton.tsx
+++ b/querybook/webapp/ui/Button/StyledButton.tsx
@@ -33,6 +33,9 @@ export const StyledButton = styled.span<StyledButtonProps>`
 
     color: ${(props) => props.color || 'inherit'};
     background-color: ${(props) => props.bgColor || 'inherit'};
+    & + & {
+        ${(props) => (props.size === 'small' ? '' : 'margin-left: 4px;')};
+    }
 
     &:hover,
     &.active {
@@ -58,7 +61,6 @@ export const StyledButton = styled.span<StyledButtonProps>`
     ${(props) => (props.fontWeight ? `font-weight: ${props.fontWeight}` : '')};
 
     cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};
-    margin: ${(props) => (props.size === 'small' ? '0px' : '0px 4px')};
     padding: ${(props) => (props.size === 'small' ? '1px 4px' : '4px 8px')};
 
     white-space: nowrap;

--- a/querybook/webapp/ui/GenericCRUD/GenericCRUD.tsx
+++ b/querybook/webapp/ui/GenericCRUD/GenericCRUD.tsx
@@ -116,8 +116,8 @@ export function GenericCRUD<T extends Record<any, any>>({
                             {renderItem(values, setFieldValue)}
                             {errorSection}
                             <div className="pv8 right-align">
-                                <div>{deleteButton}</div>
-                                <div>{saveButton}</div>
+                                {deleteButton}
+                                {saveButton}
                             </div>
                         </div>
                     );

--- a/querybook/webapp/ui/ToggleButton/ToggleButton.scss
+++ b/querybook/webapp/ui/ToggleButton/ToggleButton.scss
@@ -1,9 +1,7 @@
-.ToggleButton {
+.ToggleButton.Button {
     &.checked {
-        .Button {
-            background-color: var(--color-accent-bg);
-            border-color: var(--color-accent-text);
-            color: var(--color-accent-text);
-        }
+        background-color: var(--color-accent-bg);
+        border-color: var(--color-accent-text);
+        color: var(--color-accent-text);
     }
 }

--- a/querybook/webapp/ui/ToggleButton/ToggleButton.tsx
+++ b/querybook/webapp/ui/ToggleButton/ToggleButton.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import React from 'react';
 
 import { Button, ButtonProps } from 'ui/Button/Button';
@@ -16,10 +17,11 @@ export const ToggleButton: React.FunctionComponent<IToggleButtonProps> = ({
     title,
     ...otherProps
 }) => (
-    <div
-        className={`ToggleButton ${checked ? 'checked' : ''}`}
+    <Button
+        {...otherProps}
         onClick={() => onClick(!checked)}
+        className={clsx('ToggleButton', checked && 'checked')}
     >
-        <Button {...otherProps}>{title}</Button>
-    </div>
+        {title}
+    </Button>
 );


### PR DESCRIPTION
UI looks exactly the same
- Remove default margins for buttons, only keep sibling selector
- Use shared css classes for data doc right sidebar