### PR TITLE
feat: UDF support

### DIFF
--- a/docs_website/docs/integrations/customize_html.md
+++ b/docs_website/docs/integrations/customize_html.md
@@ -120,3 +120,56 @@ window.DATA_TABLE_SEARCH_CONFIG = {
     }),
 };
 ```
+
+### Customize UDF Support
+
+If your query engine supports UDFs/Stored Procedures, you can use the custom UDF plugin to let users add UDFs easily in the query editor. The UDF editor in Querybook allows users to quickly create UDFs by filling out a form.
+
+Also note that if it something standard, please contribute it to the open source repo!
+
+Here is an minimal example that adds mysql UDF, it is not an complete example:
+
+```typescript
+window.CUSTOM_ENGINE_UDFS = {
+    engineLanguage: 'mysql',
+    supportedUDFLanguages: [
+        {
+            displayName: 'SQL',
+            name: 'sql', // Used as LANGUAGE ... in UDF, for mysql only sql works
+            codeEditorMode: 'text/x-mysql', // this mode is used by codemirror for editor support
+        },
+    ],
+    dataTypes: [
+        'varchar',
+        'double',
+        'integer',
+    ],
+    renderer: (config) => {
+       renderer: (config) => {
+        const {
+            functionName,
+            udfLanguage,
+            outputType,
+            parameters,
+            script,
+        } = config;
+
+        /*
+            Example MYSQL stored procedure:
+            CREATE PROCEDURE exampleFunc(IN rating varchar(50))
+            BEGIN
+                select abc from table where r = rating;
+            END
+        */
+
+        const createStatement = `CREATE PROCEDURE ${functionName}`;
+        const udfSignature = `(${parameters
+            .map((param) => `IN ${param.name} ${param.type}`)
+            .join(', ')})`;
+        const code = `BEGIN\n${script}\nEND`;
+
+        return `${createStatement}${udfSignature}\n${code};`;
+    },
+    },
+}
+```

--- a/querybook/webapp/__tests__/lib/utils/udf.test.ts
+++ b/querybook/webapp/__tests__/lib/utils/udf.test.ts
@@ -1,0 +1,55 @@
+import { UDFEngineConfigsByLanguage } from 'lib/utils/udf';
+
+const bigqueryUDFConfig = UDFEngineConfigsByLanguage['bigquery'];
+
+test('BigQuery SQL UDF', () => {
+    expect(
+        bigqueryUDFConfig.renderer({
+            functionName: 'AddFourAndDivide',
+            parameters: [
+                {
+                    name: 'x',
+                    type: 'INT64',
+                },
+                {
+                    name: 'y',
+                    type: 'INT64',
+                },
+            ],
+            outputType: 'FLOAT64',
+            script: '(x + 4) / y',
+            udfLanguage: 'sql',
+        })
+    ).toEqual(
+        `CREATE TEMP FUNCTION AddFourAndDivide(x INT64, y INT64)
+RETURNS FLOAT64
+AS ((x + 4) / y);`
+    );
+});
+
+test('BigQuery Javascript UDF', () => {
+    expect(
+        bigqueryUDFConfig.renderer({
+            functionName: 'multiplyInputs',
+            parameters: [
+                {
+                    name: 'x',
+                    type: 'FLOAT64',
+                },
+                {
+                    name: 'y',
+                    type: 'FLOAT64',
+                },
+            ],
+            outputType: 'FLOAT64',
+            script: 'return x*y;',
+            udfLanguage: 'js',
+        })
+    ).toEqual(
+        `CREATE TEMP FUNCTION multiplyInputs(x FLOAT64, y FLOAT64)
+RETURNS FLOAT64
+LANGUAGE js AS r"""
+    return x*y;
+""";`
+    );
+});

--- a/querybook/webapp/components/UDFForm/UDFForm.scss
+++ b/querybook/webapp/components/UDFForm/UDFForm.scss
@@ -1,0 +1,8 @@
+.UDFForm {
+    padding: 16px;
+    .UDFForm-parameters {
+        background-color: var(--light-bg-color);
+        padding: 12px;
+        margin: 16px 0px;
+    }
+}

--- a/querybook/webapp/components/UDFForm/UDFForm.tsx
+++ b/querybook/webapp/components/UDFForm/UDFForm.tsx
@@ -1,0 +1,206 @@
+import { FieldArray, Formik } from 'formik';
+import React, { useMemo } from 'react';
+import * as Yup from 'yup';
+
+import { IOptions } from 'lib/utils/react-select';
+import { IUDFRendererValues, UDFEngineConfigsByLanguage } from 'lib/utils/udf';
+
+import { Button, SoftButton } from 'ui/Button/Button';
+import { IconButton } from 'ui/Button/IconButton';
+import { FormField } from 'ui/Form/FormField';
+import { SimpleField } from 'ui/FormikField/SimpleField';
+import { Title } from 'ui/Title/Title';
+
+import { UDFTypeSelect } from './UDFTypeSelect';
+import './UDFForm.scss';
+
+interface IUDFFormProps {
+    onConfirm: (udfScript: string) => void;
+    engineLanguage: string;
+}
+
+const UDFFormValuesSchema = Yup.object().shape({
+    functionName: Yup.string().min(1).required(),
+    udfLanguage: Yup.string().min(1).required(),
+    script: Yup.string().min(1).required(),
+    // All other fields are optional
+});
+
+export const UDFForm: React.FC<IUDFFormProps> = ({
+    onConfirm,
+    engineLanguage,
+}) => {
+    const engineUDFConfig = UDFEngineConfigsByLanguage[engineLanguage];
+    const languageOptions: IOptions<string> = useMemo(
+        () =>
+            engineUDFConfig.supportedUDFLanguages.map((languageConfig) => ({
+                label: languageConfig.displayName ?? languageConfig.name,
+                value: languageConfig.name,
+            })),
+        [engineUDFConfig]
+    );
+
+    const initialValues: IUDFRendererValues = useMemo(
+        () => ({
+            functionName: '',
+            udfLanguage: languageOptions[0].value,
+            outputType: '',
+            parameters: [],
+            script: '',
+        }),
+        [languageOptions]
+    );
+
+    return (
+        <div className="UDFForm">
+            <Formik
+                validateOnMount
+                initialValues={initialValues}
+                onSubmit={(formValues: IUDFRendererValues) => {
+                    onConfirm(engineUDFConfig.renderer(formValues));
+                }}
+                validationSchema={UDFFormValuesSchema}
+            >
+                {({ values, handleSubmit, isValid }) => {
+                    const selectedLanguageConfig = engineUDFConfig.supportedUDFLanguages.find(
+                        (l) => l.name === values.udfLanguage
+                    );
+
+                    const parametersDOM = selectedLanguageConfig?.noParameters ? null : (
+                        <FieldArray
+                            name="parameters"
+                            render={(arrayHelper) => {
+                                const parameterRowsDOM = values.parameters.map(
+                                    (_, idx) => (
+                                        <div key={idx} className="flex-row">
+                                            <div className="flex4">
+                                                <SimpleField
+                                                    type="input"
+                                                    name={`parameters[${idx}].name`}
+                                                    label={() => null}
+                                                />
+                                            </div>
+                                            <div className="flex4">
+                                                <FormField label={() => null}>
+                                                    <UDFTypeSelect
+                                                        name={`parameters[${idx}].type`}
+                                                        dataTypes={
+                                                            engineUDFConfig.dataTypes
+                                                        }
+                                                    />
+                                                </FormField>
+                                            </div>
+
+                                            <div className="flex1">
+                                                <IconButton
+                                                    icon="x"
+                                                    onClick={() =>
+                                                        arrayHelper.remove(idx)
+                                                    }
+                                                />
+                                            </div>
+                                        </div>
+                                    )
+                                );
+
+                                return (
+                                    <div className="UDFForm-parameters">
+                                        <Title size={6}>Parameters</Title>
+                                        <div className="flex-row">
+                                            <Title
+                                                className="flex4 ml16"
+                                                size={7}
+                                                subtitle
+                                            >
+                                                Name
+                                            </Title>
+                                            <Title
+                                                className="flex4 ml16"
+                                                size={7}
+                                                subtitle
+                                            >
+                                                Type
+                                            </Title>
+                                            <div className="flex1" />
+                                        </div>
+
+                                        {parameterRowsDOM}
+                                        <div className="center-align">
+                                            <SoftButton
+                                                size="small"
+                                                title="Add New Parameter"
+                                                icon="plus"
+                                                onClick={() =>
+                                                    arrayHelper.push({
+                                                        name: '',
+                                                        type: '',
+                                                    })
+                                                }
+                                            />
+                                        </div>
+                                    </div>
+                                );
+                            }}
+                        />
+                    );
+
+                    return (
+                        <>
+                            <SimpleField
+                                name="functionName"
+                                type="input"
+                                label="Function Name *"
+                                stacked
+                                required
+                            />
+                            <div className="flex-row">
+                                <div className="flex1">
+                                    <SimpleField
+                                        type="react-select"
+                                        name="udfLanguage"
+                                        label="Language *"
+                                        options={languageOptions}
+                                        stacked
+                                    />
+                                </div>
+                                <div className="flex1">
+                                    {selectedLanguageConfig?.noOutputType ? null : (
+                                        <FormField label="Output Type" stacked>
+                                            <UDFTypeSelect
+                                                name="outputType"
+                                                dataTypes={
+                                                    engineUDFConfig.dataTypes
+                                                }
+                                            />
+                                        </FormField>
+                                    )}
+                                </div>
+                            </div>
+                            {parametersDOM}
+                            <SimpleField
+                                type="code-editor"
+                                name="script"
+                                label="Code *"
+                                mode={
+                                    selectedLanguageConfig?.codeEditorMode ??
+                                    'sql'
+                                }
+                                stacked
+                                required
+                            />
+
+                            <div className="right-align">
+                                <Button
+                                    onClick={() => handleSubmit()}
+                                    disabled={!isValid}
+                                >
+                                    Submit
+                                </Button>
+                            </div>
+                        </>
+                    );
+                }}
+            </Formik>
+        </div>
+    );
+};

--- a/querybook/webapp/components/UDFForm/UDFForm.tsx
+++ b/querybook/webapp/components/UDFForm/UDFForm.tsx
@@ -10,11 +10,11 @@ import { IconButton } from 'ui/Button/IconButton';
 import { FormField } from 'ui/Form/FormField';
 import { SimpleField } from 'ui/FormikField/SimpleField';
 import { Title } from 'ui/Title/Title';
+import { Link } from 'ui/Link/Link';
+import { Message } from 'ui/Message/Message';
 
 import { UDFTypeSelect } from './UDFTypeSelect';
 import './UDFForm.scss';
-import { Message } from 'ui/Message/Message';
-import { Link } from 'ui/Link/Link';
 
 interface IUDFFormProps {
     onConfirm: (udfScript: string) => void;

--- a/querybook/webapp/components/UDFForm/UDFForm.tsx
+++ b/querybook/webapp/components/UDFForm/UDFForm.tsx
@@ -13,6 +13,8 @@ import { Title } from 'ui/Title/Title';
 
 import { UDFTypeSelect } from './UDFTypeSelect';
 import './UDFForm.scss';
+import { Message } from 'ui/Message/Message';
+import { Link } from 'ui/Link/Link';
 
 interface IUDFFormProps {
     onConfirm: (udfScript: string) => void;
@@ -47,8 +49,9 @@ export const UDFForm: React.FC<IUDFFormProps> = ({
             outputType: '',
             parameters: [],
             script: '',
+            ...engineUDFConfig.prefills,
         }),
-        [languageOptions]
+        [languageOptions, engineUDFConfig]
     );
 
     return (
@@ -146,6 +149,18 @@ export const UDFForm: React.FC<IUDFFormProps> = ({
 
                     return (
                         <>
+                            {engineUDFConfig.docs?.length > 0 && (
+                                <Message type="tip">
+                                    <div>
+                                        <b>UDF Docs:</b>
+                                    </div>
+                                    {engineUDFConfig.docs.map((doc, idx) => (
+                                        <Link key={idx} to={doc.url}>
+                                            {doc.name ?? doc.url}
+                                        </Link>
+                                    ))}
+                                </Message>
+                            )}
                             <SimpleField
                                 name="functionName"
                                 type="input"

--- a/querybook/webapp/components/UDFForm/UDFTypeSelect.tsx
+++ b/querybook/webapp/components/UDFForm/UDFTypeSelect.tsx
@@ -1,0 +1,40 @@
+import { useField } from 'formik';
+import { IOptions, makeReactSelectStyle } from 'lib/utils/react-select';
+import React, { useMemo } from 'react';
+import CreatableSelect from 'react-select/creatable';
+
+const reactSelectStyle = makeReactSelectStyle(true);
+
+interface IUDFTypeSelectProps {
+    dataTypes: string[];
+    /**
+     * For formik
+     */
+    name: string;
+}
+export const UDFTypeSelect: React.FC<IUDFTypeSelectProps> = ({
+    dataTypes,
+    name,
+}) => {
+    const [field, , helper] = useField(name);
+    const typeOptions: IOptions<string> = useMemo(
+        () =>
+            dataTypes.map((dateType) => ({
+                label: dateType,
+                value: dateType,
+            })),
+        [dataTypes]
+    );
+
+    return (
+        <CreatableSelect
+            isClearable
+            styles={reactSelectStyle}
+            value={{ label: field.value, value: field.value }}
+            onChange={(option) => {
+                helper.setValue(option ? option.value : '');
+            }}
+            options={typeOptions}
+        />
+    );
+};

--- a/querybook/webapp/components/UDFForm/UDFTypeSelect.tsx
+++ b/querybook/webapp/components/UDFForm/UDFTypeSelect.tsx
@@ -2,6 +2,7 @@ import { useField } from 'formik';
 import { IOptions, makeReactSelectStyle } from 'lib/utils/react-select';
 import React, { useMemo } from 'react';
 import CreatableSelect from 'react-select/creatable';
+import { overlayRoot } from 'ui/Overlay/Overlay';
 
 const reactSelectStyle = makeReactSelectStyle(true);
 
@@ -34,6 +35,7 @@ export const UDFTypeSelect: React.FC<IUDFTypeSelectProps> = ({
             onChange={(option) => {
                 helper.setValue(option ? option.value : '');
             }}
+            menuPortalTarget={overlayRoot}
             options={typeOptions}
         />
     );

--- a/querybook/webapp/lib/codemirror/index.ts
+++ b/querybook/webapp/lib/codemirror/index.ts
@@ -2,7 +2,6 @@ import * as CodeMirror from 'codemirror';
 import 'codemirror/lib/codemirror.css';
 
 // From codemirror non-react package:
-import 'codemirror/mode/python/python';
 import 'codemirror/mode/sql/sql';
 
 // Lint addon

--- a/querybook/webapp/lib/utils/udf.ts
+++ b/querybook/webapp/lib/utils/udf.ts
@@ -1,0 +1,192 @@
+import { arrayGroupByField } from '.';
+
+export interface IUDFRendererValues {
+    functionName: string;
+    udfLanguage: string;
+    outputType: string;
+    parameters: Array<{
+        name: string;
+        type: string;
+    }>;
+    script: string;
+}
+
+export interface IUDFEngineConfig {
+    engineLanguage: string;
+    supportedUDFLanguages: Array<{
+        /**
+         * Used as display option, if not provided, name would be used
+         */
+        displayName?: string;
+        /**
+         * Used in rendering
+         */
+        name: string;
+        /**
+         * Mode for the code editor (codemirror)
+         */
+        codeEditorMode: string;
+
+        /**
+         * If true, outputType is ignored in both form UI and rendering
+         */
+        noOutputType?: boolean;
+
+        /**
+         * If true, parameters is ignored in both form UI and rendering
+         */
+        noParameters?: boolean;
+    }>;
+    /**
+     * This does not need to be comprehensive, we
+     * will allow users to define new types if it
+     * is recursive, like STRUCT<...>
+     */
+    dataTypes: string[];
+    renderer: (config: IUDFRendererValues) => string;
+}
+
+function indentCode(code: string, numberOfSpaces: number) {
+    const spaces = ' '.repeat(numberOfSpaces);
+    return code
+        .split('\n')
+        .map((line) => spaces + line)
+        .join('\n');
+}
+
+const bigqueryUDFConfig: IUDFEngineConfig = {
+    engineLanguage: 'bigquery',
+    supportedUDFLanguages: [
+        {
+            displayName: 'JavaScript',
+            name: 'js',
+            codeEditorMode: 'javascript',
+        },
+        {
+            displayName: 'SQL',
+            name: 'sql',
+            codeEditorMode: 'sql',
+        },
+    ],
+    // from https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
+    dataTypes: [
+        'STRUCT',
+        'ARRAY',
+        'BOOL',
+        'BYTES',
+        'DATE',
+        'DATETIME',
+        'GEOGRAPHY',
+        'INTERVAL',
+        'JSON',
+        'INT64',
+        'INT',
+        'SMALLINT',
+        'INTEGER',
+        'BIGINT',
+        'TINYINT',
+        'BYTEINT',
+        'NUMERIC',
+        'DECIMAL',
+        'BIGNUMERIC',
+        'BIGDECIMAL',
+        'FLOAT64',
+        'STRING',
+        'TIME',
+        'TIMESTAMP',
+        'ANY TYPE',
+    ],
+    renderer: (config) => {
+        const {
+            functionName,
+            udfLanguage,
+            outputType,
+            parameters,
+            script,
+        } = config;
+
+        /*
+            There are 3 parts in UDF generation:
+            CREATE FUNC ...    <- create statement
+            (parameters) RETURNS type <- udf signature
+            LANGUAGE js AS ... <- code
+        */
+
+        const createStatement = `CREATE TEMP FUNCTION ${functionName}`;
+        let udfSignature = `(${parameters
+            .map((param) => `${param.name} ${param.type}`)
+            .join(', ')})`;
+        let code = '';
+        if (udfLanguage === 'sql') {
+            if (outputType !== 'ANY TYPE') {
+                udfSignature += `\nRETURNS ${outputType}`;
+            }
+            code = `AS (${script})`;
+        } else if (udfLanguage === 'js') {
+            udfSignature += `\nRETURNS ${outputType}`;
+            code = `LANGUAGE js AS r"""\n${indentCode(script, 4)}\n"""`;
+        }
+
+        return `${createStatement}${udfSignature}\n${code};`;
+    },
+};
+
+// This is non-standard, so it is only included as a reference
+// If your SparkSQL supports it, consider adding it via plugins
+// eslint-disable-next-line unused-imports/no-unused-vars
+const sparkSQLScalaUDF: IUDFEngineConfig = {
+    engineLanguage: 'sparksql',
+    supportedUDFLanguages: [
+        {
+            displayName: 'Scala',
+            name: 'scala',
+            codeEditorMode: 'text/x-scala',
+            noParameters: true,
+        },
+    ],
+    dataTypes: [
+        'StringType',
+        'ShortType',
+        'ArrayType',
+        'IntegerType',
+        'MapType',
+        'LongType',
+        'StructType',
+        'FloatType',
+        'DateType',
+        'DoubleType',
+        'TimestampType',
+        'DecimalType',
+        'BooleanType',
+        'ByteType',
+        'CalendarIntervalType',
+        'HiveStringType',
+        'BinaryType',
+        'ObjectType',
+        'NumericType',
+        'NullType',
+    ],
+    renderer: (config) => {
+        const indentedScript = indentCode(config.script, 4);
+
+        return `CREATE FUNCTION ${config.functionName}
+LANGUAGE ${config.udfLanguage}
+RETURNS ${config.outputType}
+BEGIN
+${indentedScript}
+END;`;
+    },
+};
+
+const UDFEngineConfigs: IUDFEngineConfig[] = [bigqueryUDFConfig].concat(
+    window.CUSTOM_ENGINE_UDFS ?? []
+);
+
+export const UDFEngineConfigsByLanguage = arrayGroupByField(
+    UDFEngineConfigs,
+    'engineLanguage'
+);
+
+export function doesLanguageSupportUDF(language: string) {
+    return language in UDFEngineConfigsByLanguage;
+}

--- a/querybook/webapp/lib/utils/udf.ts
+++ b/querybook/webapp/lib/utils/udf.ts
@@ -43,7 +43,22 @@ export interface IUDFEngineConfig {
      * is recursive, like STRUCT<...>
      */
     dataTypes: string[];
+
+    /**
+     * Convert IUDFRendererValues to SQL string
+     */
     renderer: (config: IUDFRendererValues) => string;
+
+    /**
+     * If provided, doc links will be shown on top of modal to provide a guide
+     * for the user. Name is optional, if not provided, the url link is shown.
+     */
+    docs?: Array<{ name?: string; url: string }>;
+
+    /**
+     * If provided, the forms will be prefilled with the initial values
+     */
+    prefills?: Partial<IUDFRendererValues>;
 }
 
 function indentCode(code: string, numberOfSpaces: number) {
@@ -96,6 +111,7 @@ const bigqueryUDFConfig: IUDFEngineConfig = {
         'TIMESTAMP',
         'ANY TYPE',
     ],
+
     renderer: (config) => {
         const {
             functionName,
@@ -129,53 +145,14 @@ const bigqueryUDFConfig: IUDFEngineConfig = {
 
         return `${createStatement}${udfSignature}\n${code};`;
     },
-};
 
-// This is non-standard, so it is only included as a reference
-// If your SparkSQL supports it, consider adding it via plugins
-// eslint-disable-next-line unused-imports/no-unused-vars
-const sparkSQLScalaUDF: IUDFEngineConfig = {
-    engineLanguage: 'sparksql',
-    supportedUDFLanguages: [
+    docs: [
         {
-            displayName: 'Scala',
-            name: 'scala',
-            codeEditorMode: 'text/x-scala',
-            noParameters: true,
+            name: 'BigQuery UDF Guide',
+            url:
+                'https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions#sql-udf-structure',
         },
     ],
-    dataTypes: [
-        'StringType',
-        'ShortType',
-        'ArrayType',
-        'IntegerType',
-        'MapType',
-        'LongType',
-        'StructType',
-        'FloatType',
-        'DateType',
-        'DoubleType',
-        'TimestampType',
-        'DecimalType',
-        'BooleanType',
-        'ByteType',
-        'CalendarIntervalType',
-        'HiveStringType',
-        'BinaryType',
-        'ObjectType',
-        'NumericType',
-        'NullType',
-    ],
-    renderer: (config) => {
-        const indentedScript = indentCode(config.script, 4);
-
-        return `CREATE FUNCTION ${config.functionName}
-LANGUAGE ${config.udfLanguage}
-RETURNS ${config.outputType}
-BEGIN
-${indentedScript}
-END;`;
-    },
 };
 
 const UDFEngineConfigs: IUDFEngineConfig[] = [bigqueryUDFConfig].concat(

--- a/querybook/webapp/types.d.ts
+++ b/querybook/webapp/types.d.ts
@@ -4,7 +4,7 @@ import type {
     IColumnDetector,
     IColumnTransformer,
 } from 'lib/query-result/types';
-
+import type { IUDFEngineConfig } from 'lib/utils/udf';
 import { IDataTableSearchState } from 'redux/dataTableSearch/types';
 
 declare global {
@@ -35,6 +35,7 @@ declare global {
             string,
             Record<string, { key?: string; name?: string }>
         >;
+        CUSTOM_ENGINE_UDFS?: IUDFEngineConfig[];
     }
 
     // Injected via Webpack

--- a/querybook/webapp/ui/Form/FormField.tsx
+++ b/querybook/webapp/ui/Form/FormField.tsx
@@ -20,6 +20,7 @@ export interface IFormFieldProps {
     label?: StringOrRender;
     help?: StringOrRender;
     error?: StringOrRender;
+    className?: string;
 }
 export interface IFormFieldSectionProps {
     className?: string;
@@ -32,6 +33,7 @@ export const FormField: React.FunctionComponent<IFormFieldProps> = ({
     help,
     required,
     error,
+    className,
 }) => {
     const labelDOM = label ? (
         <>
@@ -72,10 +74,11 @@ export const FormField: React.FunctionComponent<IFormFieldProps> = ({
 
     return (
         <div
-            className={clsx({
-                FormField: true,
-                'FormField-stacked': stacked,
-            })}
+            className={clsx(
+                'FormField',
+                stacked && 'FormField-stacked',
+                className
+            )}
         >
             {labelDOM}
             {contentDOM}

--- a/querybook/webapp/ui/FormikField/CodeEditorField.tsx
+++ b/querybook/webapp/ui/FormikField/CodeEditorField.tsx
@@ -1,0 +1,72 @@
+import React, { useCallback, useMemo } from 'react';
+import { useField } from 'formik';
+import { Controlled as ReactCodeMirror } from 'react-codemirror2';
+import type { Editor, EditorConfiguration } from 'codemirror';
+import { useSelector } from 'react-redux';
+import { IStoreState } from 'redux/store/types';
+import { getCodeEditorTheme } from 'lib/utils';
+import { KeyMap } from 'lib/utils/keyboard';
+
+import 'codemirror/mode/javascript/javascript';
+import 'codemirror/mode/clike/clike';
+
+export interface ICodeEditorFieldProps {
+    name: string;
+    mode?: string;
+}
+
+const CodeEditorField: React.FC<ICodeEditorFieldProps> = ({
+    name,
+    mode,
+    ...CodeEditorProps
+}) => {
+    const [, meta, helpers] = useField(name);
+
+    const { value } = meta;
+    const { setValue, setTouched } = helpers;
+
+    const editorTheme = useSelector((state: IStoreState) =>
+        getCodeEditorTheme(state.user.computedSettings.theme)
+    );
+
+    const handleEditorMount = useCallback((editor: Editor) => {
+        setTimeout(() => {
+            editor.refresh();
+        }, 50);
+    }, []);
+
+    const options: EditorConfiguration = useMemo(
+        () => ({
+            mode: mode ?? '', // Temporarily hardcoded
+            indentWithTabs: true,
+            lineNumbers: true,
+            gutters: ['CodeMirror-lint-markers'],
+            extraKeys: {
+                [KeyMap.queryEditor.autocomplete.key]: 'autocomplete',
+                [KeyMap.queryEditor.indentLess.key]: 'indentLess',
+                [KeyMap.queryEditor.toggleComment.key]: 'toggleComment',
+            },
+            indentUnit: 4,
+            theme: editorTheme,
+            matchBrackets: true,
+            autoCloseBrackets: true,
+            highlightSelectionMatches: true,
+        }),
+        [mode, editorTheme]
+    );
+
+    return (
+        <ReactCodeMirror
+            editorDidMount={handleEditorMount}
+            options={options}
+            value={value}
+            onBeforeChange={(_, __, newValue) => {
+                setTouched(true);
+                setValue(newValue);
+            }}
+            {...CodeEditorProps}
+        />
+    );
+};
+
+export default CodeEditorField;

--- a/querybook/webapp/ui/FormikField/CodeEditorField.tsx
+++ b/querybook/webapp/ui/FormikField/CodeEditorField.tsx
@@ -9,6 +9,7 @@ import { KeyMap } from 'lib/utils/keyboard';
 
 import 'codemirror/mode/javascript/javascript';
 import 'codemirror/mode/clike/clike';
+import { StyledQueryEditor } from 'components/QueryEditor/StyledQueryEditor';
 
 export interface ICodeEditorFieldProps {
     name: string;
@@ -56,16 +57,18 @@ const CodeEditorField: React.FC<ICodeEditorFieldProps> = ({
     );
 
     return (
-        <ReactCodeMirror
-            editorDidMount={handleEditorMount}
-            options={options}
-            value={value}
-            onBeforeChange={(_, __, newValue) => {
-                setTouched(true);
-                setValue(newValue);
-            }}
-            {...CodeEditorProps}
-        />
+        <StyledQueryEditor height="auto">
+            <ReactCodeMirror
+                editorDidMount={handleEditorMount}
+                options={options}
+                value={value}
+                onBeforeChange={(_, __, newValue) => {
+                    setTouched(true);
+                    setValue(newValue);
+                }}
+                {...CodeEditorProps}
+            />
+        </StyledQueryEditor>
     );
 };
 

--- a/querybook/webapp/ui/FormikField/SimpleField.tsx
+++ b/querybook/webapp/ui/FormikField/SimpleField.tsx
@@ -15,6 +15,11 @@ import {
     ToggleSwitchField,
 } from './ToggleSwitchField';
 import { IRichTextFieldProps, RichTextField } from './RichTextField';
+import type { ICodeEditorFieldProps } from './CodeEditorField';
+
+// Since this is rarely used (only UDF) and quite heavy (multiple language defs), it is
+// lazily imported
+const CodeEditorField = React.lazy(() => import('./CodeEditorField'));
 
 // Simple Field is the amalgamation of all custom field,
 // it contains all the simple use case of field
@@ -59,6 +64,10 @@ interface ISimpleDatePickerProps extends IBaseProps {
     type: 'datepicker';
 }
 
+interface ISimpleCodeEditorProps extends IBaseProps, ICodeEditorFieldProps {
+    type: 'code-editor';
+}
+
 type Props =
     | ISimpleCheckboxProps
     | ISimpleInputProps
@@ -68,7 +77,8 @@ type Props =
     | ISimpleTextareaProps
     | ISimpleRichTextProps
     | ISimpleReactSelectProps
-    | ISimpleDatePickerProps;
+    | ISimpleDatePickerProps
+    | ISimpleCodeEditorProps;
 
 export const SimpleField: React.FC<Props> = ({
     name,
@@ -139,7 +149,15 @@ export const SimpleField: React.FC<Props> = ({
         );
     } else if (type === 'datepicker') {
         fieldDOM = <DatePickerField name={name} />;
+    } else if (type === 'code-editor') {
+        fieldDOM = (
+            <CodeEditorField
+                name={name}
+                {...(otherProps as ICodeEditorFieldProps)}
+            />
+        );
     }
+
     return (
         <FormField
             label={title}


### PR DESCRIPTION
Now users can add UDFs easily in Adhoc Query Editor. To do so they need to fill out a form with language and parameters.
![image](https://user-images.githubusercontent.com/8283407/152630319-9e65ac82-78a9-4280-b6dc-7a6fc7638d61.png)
![image](https://user-images.githubusercontent.com/8283407/152630438-d6fcd0f9-7cff-4426-8357-14069fe4d1d2.png)



You can add UDF in adhoc or query cell
![image](https://user-images.githubusercontent.com/8283407/152630670-f4bcd288-12a4-4f70-8cb4-c03ba86cb020.png)

![image](https://user-images.githubusercontent.com/8283407/152630323-ab87ca6e-ac91-4a19-8cb3-ddfa4113f02f.png)
^ note that this shows presto for testing reasons


Currently, this is only added for BigQuery but more can be added as plugins or directly in the OS repo.
Also added unit tests for query generation as well as documentation