### PR TITLE
Add execution time for Runs

### DIFF
--- a/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentAppSidebar.tsx
+++ b/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentAppSidebar.tsx
@@ -18,7 +18,7 @@ import { useEvent } from 'hooks/useEvent';
 import { matchKeyMap, KeyMap } from 'lib/utils/keyboard';
 import './EnvironmentAppSidebar.scss';
 
-const SIDEBAR_WIDTH = 320;
+const SIDEBAR_WIDTH = 360;
 
 export const EnvironmentAppSidebar: React.FunctionComponent = () => {
     const [collapsed, setCollapsed] = React.useState(false);

--- a/querybook/webapp/components/QueryViewNavigator/QueryResult.tsx
+++ b/querybook/webapp/components/QueryViewNavigator/QueryResult.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import moment from 'moment';
 import clsx from 'clsx';
+import styled from 'styled-components';
 
 import { queryStatusToStatusIcon } from 'const/queryStatus';
 import { IQueryExecution } from 'const/queryExecution';
@@ -15,6 +16,41 @@ interface IProps {
     queryEngineById: Record<number, IQueryEngine>;
     onClick: (queryExecution: IQueryExecution) => any;
 }
+
+const TimeContainer = styled.div`
+    display: flex;
+`;
+
+const ExecutionTime = styled.div`
+    margin-right: 10px;
+`;
+
+function calculateExecutionTime(createdAt: number, completedAt: number) {
+    const executionTime = Math.ceil(completedAt - createdAt);
+    const date = new Date(null);
+    date.setSeconds(executionTime);
+
+    return date.toISOString().substr(11, 8);
+}
+
+const GetExecutionTime: React.FunctionComponent<{
+    createdAt: number;
+    completedAt: number;
+}> = ({ createdAt, completedAt }) => {
+    const hoursAndMinutesTime = useMemo(() => {
+        if (!completedAt) {
+            return 'Ex. time: --:--:--';
+        }
+
+        if (createdAt - completedAt === 0) {
+            return 'Ex. time: Less 1 sec.';
+        }
+
+        return `Ex. time: ${calculateExecutionTime(createdAt, completedAt)}`;
+    }, [createdAt, completedAt]);
+
+    return <ExecutionTime>{hoursAndMinutesTime}</ExecutionTime>;
+};
 
 export const QueryResult: React.FunctionComponent<IProps> = ({
     queryEngineById,
@@ -48,9 +84,13 @@ export const QueryResult: React.FunctionComponent<IProps> = ({
                 <div>
                     <UserName uid={queryExecution.uid} />
                 </div>
-                <div>
+                <TimeContainer>
+                    <GetExecutionTime
+                        completedAt={queryExecution.completed_at}
+                        createdAt={queryExecution.created_at}
+                    />
                     {moment.utc(queryExecution.created_at, 'X').fromNow()}
-                </div>
+                </TimeContainer>
             </div>
         </div>
     );

--- a/querybook/webapp/const/queryExecution.ts
+++ b/querybook/webapp/const/queryExecution.ts
@@ -32,6 +32,7 @@ export interface IQueryExecutionViewer {
 export interface IQueryExecution {
     id: number;
     created_at: number;
+    completed_at?: number;
     status: number;
     task_id: string;
 


### PR DESCRIPTION
This PR adds an execution time for runs.

If the time is less than 1 second, a user will see the message: 'Less 1 sec.'.
if an item is in progress, a user will see '--:--:--' instead of time.
![Adhoc Query - Querybook 2022-02-10 07-51-56](https://user-images.githubusercontent.com/59963571/153413367-951d76e3-2169-4b09-a59a-daade646d6d8.png)

