### PR TITLE
ui: update data doc ui

### DIFF
--- a/querybook/webapp/__tests__/ui/__snapshots__/AsyncButton.test.js.snap
+++ b/querybook/webapp/__tests__/ui/__snapshots__/AsyncButton.test.js.snap
@@ -28,7 +28,7 @@ exports[`matches enzyme snapshots matches snapshot 1`] = `
 
 exports[`matches test renderer snapshot serializes the styles 1`] = `
 <span
-  className="StyledButton-aqwbwz-0 gNrSVW Button"
+  className="StyledButton-aqwbwz-0 fCJWAp Button"
   color="var(--text-light)"
   disabled={false}
   onClick={[Function]}

--- a/querybook/webapp/__tests__/ui/__snapshots__/Button.test.js.snap
+++ b/querybook/webapp/__tests__/ui/__snapshots__/Button.test.js.snap
@@ -7,7 +7,7 @@ exports[`matches enzyme snapshots matches snapshot - attached right 1`] = `
   className="Button"
   color="var(--text-light)"
   hoverBgColor="var(--bg-hover)"
-  hoverColor="var(--text)"
+  hoverColor="var(--text-hover)"
   onClick={[Function]}
   size="medium"
 >
@@ -24,7 +24,7 @@ exports[`matches enzyme snapshots matches snapshot - disbled 1`] = `
   color="var(--text-light)"
   disabled={true}
   hoverBgColor="var(--bg-hover)"
-  hoverColor="var(--text)"
+  hoverColor="var(--text-hover)"
   onClick={null}
   size="medium"
 >
@@ -40,7 +40,7 @@ exports[`matches enzyme snapshots matches snapshot - isLoading 1`] = `
   className="Button flex-row"
   color="var(--text-light)"
   hoverBgColor="var(--bg-hover)"
-  hoverColor="var(--text)"
+  hoverColor="var(--text-hover)"
   onClick={[Function]}
   size="medium"
 >
@@ -60,7 +60,7 @@ exports[`matches enzyme snapshots matches snapshot - mixed 1`] = `
   className="Button"
   color="var(--text-light)"
   hoverBgColor="var(--bg-hover)"
-  hoverColor="var(--text)"
+  hoverColor="var(--text-hover)"
   onClick={[Function]}
   pushable={true}
   size="small"
@@ -76,8 +76,8 @@ exports[`matches enzyme snapshots matches snapshot - text button 1`] = `
   bgColor="transparent"
   className="Button"
   color="var(--text-light)"
-  hoverBgColor="var(--bg-light)"
-  hoverColor="var(--text)"
+  hoverBgColor="var(--bg-hover)"
+  hoverColor="var(--text-hover)"
   onClick={[Function]}
   size="medium"
 >
@@ -93,7 +93,7 @@ exports[`matches enzyme snapshots matches snapshot - typed 1`] = `
   className="Button"
   color="var(--text-light)"
   hoverBgColor="var(--bg-hover)"
-  hoverColor="var(--text)"
+  hoverColor="var(--text-hover)"
   onClick={[Function]}
   size="medium"
 >
@@ -109,7 +109,7 @@ exports[`matches enzyme snapshots matches snapshot 1`] = `
   className="Button"
   color="var(--text-light)"
   hoverBgColor="var(--bg-hover)"
-  hoverColor="var(--text)"
+  hoverColor="var(--text-hover)"
   onClick={[Function]}
   size="medium"
 >
@@ -121,7 +121,7 @@ exports[`matches enzyme snapshots matches snapshot 1`] = `
 
 exports[`matches test renderer snapshot serializes the styles 1`] = `
 <span
-  className="StyledButton-aqwbwz-0 gNrSVW Button"
+  className="StyledButton-aqwbwz-0 fCJWAp Button"
   color="var(--text-light)"
   onClick={[Function]}
   size="medium"

--- a/querybook/webapp/__tests__/ui/__snapshots__/CopyButton.test.js.snap
+++ b/querybook/webapp/__tests__/ui/__snapshots__/CopyButton.test.js.snap
@@ -16,7 +16,7 @@ exports[`matches enzyme snapshots matches snapshot 1`] = `
 exports[`matches test renderer snapshot serializes the styles 1`] = `
 <span
   aria-label="Click To Copy"
-  className="StyledButton-aqwbwz-0 AXhBQ Button CopyButton flex-row"
+  className="StyledButton-aqwbwz-0 kyYyDb Button CopyButton flex-row"
   color="var(--text-light)"
   data-balloon-pos="up"
   fontWeight="700"

--- a/querybook/webapp/__tests__/ui/__snapshots__/Dropdown.test.js.snap
+++ b/querybook/webapp/__tests__/ui/__snapshots__/Dropdown.test.js.snap
@@ -12,6 +12,7 @@ exports[`matches enzyme snapshots matches snapshot 1`] = `
   >
     <ForwardRef
       icon="menu"
+      noPadding={true}
     />
   </div>
 </div>
@@ -28,7 +29,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
     className="Dropdown-trigger"
   >
     <span
-      className="IconButton"
+      className="IconButton no-padding"
     >
       <span
         className=" Icon  "

--- a/querybook/webapp/__tests__/ui/__snapshots__/Pagination.test.js.snap
+++ b/querybook/webapp/__tests__/ui/__snapshots__/Pagination.test.js.snap
@@ -88,7 +88,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
     className="Pagination-previous"
   >
     <span
-      className="StyledButton-aqwbwz-0 gNrSVW Button"
+      className="StyledButton-aqwbwz-0 fCJWAp Button"
       color="var(--text-light)"
       onClick={[Function]}
       size="medium"
@@ -102,7 +102,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
     className="Pagination-next"
   >
     <span
-      className="StyledButton-aqwbwz-0 gNrSVW Button"
+      className="StyledButton-aqwbwz-0 fCJWAp Button"
       color="var(--text-light)"
       onClick={[Function]}
       size="medium"
@@ -117,7 +117,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
   >
     <li>
       <span
-        className="StyledButton-aqwbwz-0 gNrSVW Button Pagination-page-button "
+        className="StyledButton-aqwbwz-0 fCJWAp Button Pagination-page-button "
         color="var(--text-light)"
         onClick={[Function]}
         size="medium"
@@ -129,7 +129,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
     </li>
     <li>
       <span
-        className="StyledButton-aqwbwz-0 gNrSVW Button Pagination-page-button current"
+        className="StyledButton-aqwbwz-0 fCJWAp Button Pagination-page-button current"
         color="var(--text-light)"
         onClick={[Function]}
         size="medium"
@@ -141,7 +141,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
     </li>
     <li>
       <span
-        className="StyledButton-aqwbwz-0 gNrSVW Button Pagination-page-button "
+        className="StyledButton-aqwbwz-0 fCJWAp Button Pagination-page-button "
         color="var(--text-light)"
         onClick={[Function]}
         size="medium"
@@ -153,7 +153,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
     </li>
     <li>
       <span
-        className="StyledButton-aqwbwz-0 gNrSVW Button Pagination-page-button "
+        className="StyledButton-aqwbwz-0 fCJWAp Button Pagination-page-button "
         color="var(--text-light)"
         onClick={[Function]}
         size="medium"
@@ -172,7 +172,7 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
     </li>
     <li>
       <span
-        className="StyledButton-aqwbwz-0 gNrSVW Button Pagination-page-button "
+        className="StyledButton-aqwbwz-0 fCJWAp Button Pagination-page-button "
         color="var(--text-light)"
         onClick={[Function]}
         size="medium"

--- a/querybook/webapp/__tests__/ui/__snapshots__/ResizableTextArea.test.js.snap
+++ b/querybook/webapp/__tests__/ui/__snapshots__/ResizableTextArea.test.js.snap
@@ -14,7 +14,7 @@ exports[`matches enzyme snapshots matches snapshot 1`] = `
 
 exports[`matches test renderer snapshot serializes the styles 1`] = `
 <textarea
-  className="ResizableTextArea__StyledTextarea-sc-1fskja0-0 eHAMQj ResizableTextArea"
+  className="ResizableTextArea__StyledTextarea-sc-1fskja0-0 gxaFas ResizableTextArea"
   disabled={false}
   onChange={[Function]}
   onInput={[Function]}

--- a/querybook/webapp/components/AccessRequestButton/AccessRequestButton.scss
+++ b/querybook/webapp/components/AccessRequestButton/AccessRequestButton.scss
@@ -1,0 +1,5 @@
+.AccessRequestButton {
+    .success-message {
+        color: var(--color-accent-dark);
+    }
+}

--- a/querybook/webapp/components/AccessRequestButton/AccessRequestButton.tsx
+++ b/querybook/webapp/components/AccessRequestButton/AccessRequestButton.tsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react';
+
 import { Button } from 'ui/Button/Button';
+
+import './AccessRequestButton.scss';
 
 export const AccessRequestButton: React.FunctionComponent<{
     onAccessRequest: () => any;
@@ -9,7 +12,7 @@ export const AccessRequestButton: React.FunctionComponent<{
     return (
         <div className="AccessRequestButton">
             {accessRequsted ? (
-                'Access Request Sent!'
+                <div className="success-message">'Access Request Sent!'</div>
             ) : (
                 <Button
                     onClick={() => {

--- a/querybook/webapp/components/BoardList/BoardList.scss
+++ b/querybook/webapp/components/BoardList/BoardList.scss
@@ -5,8 +5,6 @@
         .SearchBar {
             flex: 1;
         }
-        border-bottom: var(--border);
-        padding-right: 4px;
     }
 
     .board-scroll-wrapper {

--- a/querybook/webapp/components/BoardList/BoardList.tsx
+++ b/querybook/webapp/components/BoardList/BoardList.tsx
@@ -46,18 +46,18 @@ export const BoardList: React.FunctionComponent<IProps> = ({
     );
     const boardRowRenderer = React.useCallback(
         (board: IBoard & { selected: boolean }) => {
-            const { name, public: publicBoard, selected } = board;
+            const { name, selected } = board;
             const className = clsx({
                 selected,
             });
-            const publicIcon = publicBoard && 'users';
+            const selectedIcon = selected && 'check';
 
             return (
                 <ListLink
                     className={className}
                     onClick={() => onBoardClick(board)}
                     isRow
-                    icon={publicIcon}
+                    icon={selectedIcon}
                     title={name}
                 />
             );
@@ -76,22 +76,22 @@ export const BoardList: React.FunctionComponent<IProps> = ({
                 />
             </div>
         ) : (
-            <div className="empty-message">No list found.</div>
+            <div className="empty-message m16">No list found</div>
         );
 
     return (
         <div className="BoardList">
-            <div className="list-header flex-row">
+            <div className="list-header flex-row mb8">
                 <SearchBar
                     value={filterStr}
                     onSearch={setFilterStr}
                     placeholder="Filter..."
-                    transparent
+                    className="mr12"
                 />
                 <IconButton
                     icon="plus"
                     tooltip={'New List'}
-                    tooltipPos={'right'}
+                    tooltipPos={'left'}
                     onClick={
                         onCreateBoardClick
                             ? onCreateBoardClick

--- a/querybook/webapp/components/DataDoc/DataDoc.scss
+++ b/querybook/webapp/components/DataDoc/DataDoc.scss
@@ -1,17 +1,3 @@
-@import './../../scss_variables.scss';
-
-@keyframes highlight-fade {
-    0% {
-        background-color: transparent;
-    }
-    25% {
-        background-color: var(--color-accent-lightest);
-    }
-    100% {
-        background-color: transparent;
-    }
-}
-
 // Temporal
 .temporal-edit-title-modal-wrapper {
     .close {
@@ -49,20 +35,21 @@
 
     .data-doc-content-container {
         flex: 0 1 var(--max-width);
-        padding: 36px 12px;
+        padding: 36px 0px 36px 24px;
         overflow: hidden;
 
         .data-doc-header {
-            padding: 36px 12px;
-            border-bottom: var(--border);
+            padding: 0px 12px 24px;
             color: var(--text-light);
 
             .data-doc-header-top {
+                align-items: end;
                 .data-doc-header-time {
-                    text-transform: uppercase;
                     font-size: var(--text-size);
-                    font-weight: bold;
-                    padding-left: 4px;
+                    padding-left: 8px;
+                    text-transform: uppercase;
+                    font-weight: var(--bold-font);
+                    color: var(--text-lightest);
                 }
                 .data-doc-header-users {
                     .ImpressionWidget {
@@ -73,7 +60,7 @@
 
             .IconButton,
             .ImpressionWidget {
-                margin-left: 8px;
+                margin-left: 16px;
             }
             .favorite-icon-button {
                 &.favorite-icon-button-favorited {
@@ -100,28 +87,12 @@
                 color: var(--text-light);
                 font-size: var(--xxxlarge-text-size);
                 font-weight: bold;
-
-                &::placeholder {
-                    color: var(--text-light);
-                }
             }
         }
 
         .data-doc-container {
             .data-doc-cell-container-pair {
-                &.highlight-cell {
-                    animation-name: highlight-fade;
-                    animation-duration: 2s;
-                }
-
                 position: relative;
-                &:hover {
-                    .data-doc-cell-divider-container {
-                        .block-crud-buttons {
-                            opacity: 1;
-                        }
-                    }
-                }
 
                 &.data-doc-cell-container-pair-final {
                     min-height: 48px;
@@ -134,7 +105,7 @@
 
                 .data-doc-cell-users {
                     top: 48px;
-                    left: -12px;
+                    left: -16px;
                     position: absolute;
 
                     .UserAvatar {
@@ -185,8 +156,35 @@
                     }
                 }
 
+                .DataDocQueryCell-more-button,
+                .QueryRunButton,
+                .additional-dropdown-button,
+                .add-snippet-wrapper,
+                .fullscreen-button-wrapper,
+                .chart-cell-controls {
+                    opacity: 0;
+                    transition: opacity 0.2s ease-out;
+                }
+
                 &:hover .add-new-line-button {
                     opacity: 1;
+                }
+
+                &:hover {
+                    .data-doc-cell-divider-container {
+                        .block-crud-buttons {
+                            opacity: 1;
+                        }
+                    }
+
+                    .DataDocQueryCell-more-button,
+                    .QueryRunButton,
+                    .additional-dropdown-button,
+                    .add-snippet-wrapper,
+                    .fullscreen-button-wrapper,
+                    .chart-cell-controls {
+                        opacity: 1;
+                    }
                 }
             }
         }

--- a/querybook/webapp/components/DataDoc/DataDoc.tsx
+++ b/querybook/webapp/components/DataDoc/DataDoc.tsx
@@ -667,8 +667,6 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
             <DataDocLeftSidebar
                 docId={dataDoc.id}
                 cells={dataDoc.dataDocCells}
-                defaultCollapse={defaultCollapseAllCells}
-                onCollapse={this.handleToggleCollapse}
             />
         );
 
@@ -680,6 +678,8 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
                 isSaving={isSavingDataDoc}
                 isEditable={isEditable}
                 isConnected={connected}
+                defaultCollapse={defaultCollapseAllCells}
+                onCollapse={this.handleToggleCollapse}
             />
         );
 

--- a/querybook/webapp/components/DataDoc/DataDocHeader.tsx
+++ b/querybook/webapp/components/DataDoc/DataDocHeader.tsx
@@ -57,7 +57,7 @@ export const DataDocHeader = React.forwardRef<HTMLDivElement, IProps>(
 
         return (
             <div className="data-doc-header" ref={ref} key="data-doc-header">
-                <div className="data-doc-header-top horizontal-space-between">
+                <div className="data-doc-header-top horizontal-space-between mb8">
                     <div className="data-doc-header-time flex-row mr8">
                         <p>{timeMessage}</p>
                         <IconButton

--- a/querybook/webapp/components/DataDocCell/DataDocCell.scss
+++ b/querybook/webapp/components/DataDocCell/DataDocCell.scss
@@ -1,8 +1,16 @@
 .DataDocCell {
     border-radius: var(--border-radius);
-    margin: 48px 16px;
+    margin: 36px 12px;
     &.collapsed {
         min-height: 0px;
         cursor: nesw-resize;
+    }
+
+    .empty-message {
+        color: var(--text-lightest);
+        font-weight: var(--bold-font);
+        display: flex;
+        justify-content: center;
+        font-size: var(--xlarge-text-size);
     }
 }

--- a/querybook/webapp/components/DataDocChartCell/DataDocChartCell.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChartCell.tsx
@@ -17,7 +17,6 @@ import { DataDocChartCellTable } from './DataDocChartCellTable';
 import { DataDocChartComposer } from './DataDocChartComposer';
 import { InfoButton } from 'ui/Button/InfoButton';
 import { Modal } from 'ui/Modal/Modal';
-import { Title } from 'ui/Title/Title';
 
 interface IProps {
     context: string;
@@ -186,13 +185,7 @@ export const DataDocChartCell = React.memo<IProps>(
                 transformedChartData == null ||
                 transformedChartData.length === 0
             ) {
-                return (
-                    <div>
-                        <Title subtitle size={1}>
-                            No Data
-                        </Title>
-                    </div>
-                );
+                return <div className="empty-message">No Data for Chart</div>;
             }
 
             let visualizationDOM: React.ReactChild;
@@ -235,7 +228,7 @@ export const DataDocChartCell = React.memo<IProps>(
 
         return (
             <div className={'DataDocChartCell'}>
-                <div className="horizontal-space-between">
+                <div className="chart-cell-controls horizontal-space-between">
                     <div>{renderPickerDOM()}</div>
                     <div className="flex-row">
                         <TextButton

--- a/querybook/webapp/components/DataDocLeftSidebar/DataDocContents.scss
+++ b/querybook/webapp/components/DataDocLeftSidebar/DataDocContents.scss
@@ -17,7 +17,10 @@
         }
 
         &:hover {
-            background-color: var(--color-accent-lightest);
+            color: var(--color-accent-dark);
+            .Icon {
+                color: var(--color-accent-dark);
+            }
         }
     }
 }

--- a/querybook/webapp/components/DataDocLeftSidebar/DataDocContents.tsx
+++ b/querybook/webapp/components/DataDocLeftSidebar/DataDocContents.tsx
@@ -66,7 +66,9 @@ export const DataDocContents: React.FC<{
                                     {cellQueryText}
                                 </>
                             );
-                            cellIcon = <Icon name="code" size={19} />;
+                            cellIcon = (
+                                <Icon name="terminal" size={16} color="light" />
+                            );
                             break;
                         }
                         case 'text': {
@@ -79,12 +81,24 @@ export const DataDocContents: React.FC<{
                                 })`}</i>
                             );
 
-                            cellIcon = <Icon name="type" size={19} />;
+                            cellIcon = (
+                                <Icon
+                                    name="align-left"
+                                    size={16}
+                                    color="light"
+                                />
+                            );
 
                             break;
                         }
                         case 'chart': {
-                            cellIcon = <Icon name="pie-chart" size={19} />;
+                            cellIcon = (
+                                <Icon
+                                    name="pie-chart"
+                                    size={16}
+                                    color="light"
+                                />
+                            );
                             cellText = (
                                 <b>
                                     {cell.meta['title'] ||

--- a/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.scss
+++ b/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.scss
@@ -11,7 +11,7 @@
         margin-top: 48px;
 
         &:not(.sidebar-content-default) {
-            background-color: var(--bg-light);
+            background-color: var(--bg-lightest);
         }
     }
 
@@ -45,11 +45,12 @@
 
         .contents-panel-header {
             padding-right: var(--padding);
-            background-color: var(--bg-lightest);
+            background-color: var(--bg-light);
             margin-bottom: var(--margin-xs);
-            .Title {
-                user-select: none;
-            }
+
+            user-select: none;
+            font-weight: var(--bold-font);
+            color: var(--text-light);
         }
     }
 

--- a/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.scss
+++ b/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.scss
@@ -47,6 +47,7 @@
             padding-right: var(--padding);
             background-color: var(--bg-light);
             margin-bottom: var(--margin-xs);
+            border-top-right-radius: var(--border-radius);
 
             user-select: none;
             font-weight: var(--bold-font);

--- a/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
+++ b/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
@@ -5,19 +5,18 @@ import { useSelector, useDispatch } from 'react-redux';
 import { setSidebarTableId } from 'redux/querybookUI/action';
 import { IStoreState } from 'redux/store/types';
 import { IDataCell } from 'const/datadoc';
-import { Button } from 'ui/Button/Button';
-import { Level } from 'ui/Level/Level';
-import { IconButton } from 'ui/Button/IconButton';
-import { Title } from 'ui/Title/Title';
-import './DataDocLeftSidebar.scss';
+
 import { DataDocContents } from './DataDocContents';
 import { DataTableViewMini } from 'components/DataTableViewMini/DataTableViewMini';
 
+import { Button } from 'ui/Button/Button';
+import { Level } from 'ui/Level/Level';
+import { IconButton } from 'ui/Button/IconButton';
+
+import './DataDocLeftSidebar.scss';
 interface IProps {
     docId: number;
     cells: IDataCell[];
-    onCollapse: () => any;
-    defaultCollapse: boolean;
 }
 
 type LeftSidebarContentState = 'contents' | 'table' | 'default';
@@ -25,8 +24,6 @@ type LeftSidebarContentState = 'contents' | 'table' | 'default';
 export const DataDocLeftSidebar: React.FunctionComponent<IProps> = ({
     docId,
     cells,
-    defaultCollapse,
-    onCollapse,
 }) => {
     const dispatch = useDispatch();
     const sidebarTableId = useSelector(
@@ -64,7 +61,7 @@ export const DataDocLeftSidebar: React.FunctionComponent<IProps> = ({
                         icon="arrow-left"
                         onClick={() => setContentState('default')}
                     />
-                    <Title size={6}>contents</Title>
+                    <div>contents</div>
                 </Level>
                 <DataDocContents cells={cells} docId={docId} />
             </div>
@@ -89,17 +86,6 @@ export const DataDocLeftSidebar: React.FunctionComponent<IProps> = ({
                     aria-label="Show doc contents"
                     data-balloon-pos="right"
                     color="light"
-                />
-                <br />
-                <IconButton
-                    icon={defaultCollapse ? 'maximize' : 'minimize'}
-                    tooltip={
-                        defaultCollapse
-                            ? 'Uncollapse all cells'
-                            : 'Collapse all cells'
-                    }
-                    tooltipPos="right"
-                    onClick={onCollapse}
                 />
             </div>
         );

--- a/querybook/webapp/components/DataDocNavigator/DataDocGridItem.scss
+++ b/querybook/webapp/components/DataDocNavigator/DataDocGridItem.scss
@@ -1,14 +1,12 @@
 .DataDocGridItem {
     .delete-grid-item-button {
-        padding: 0;
-        .Icon svg {
-            padding: 0;
-        }
-        visibility: hidden;
+        display: none;
+        padding: 0px;
     }
+
     &:hover {
         .delete-grid-item-button {
-            visibility: visible;
+            display: flex;
         }
     }
 }

--- a/querybook/webapp/components/DataDocNavigator/DataDocNavigatorBoardItem.tsx
+++ b/querybook/webapp/components/DataDocNavigator/DataDocNavigatorBoardItem.tsx
@@ -40,7 +40,7 @@ export const BoardListItemRow: React.FC<{
                             placeholder={null}
                             isRow
                         >
-                            <Icon size={16} className="mr4" name={icon} />
+                            <Icon size={16} name={icon} />
                             {title.length ? (
                                 <span className="ListLinkText">{title}</span>
                             ) : (

--- a/querybook/webapp/components/DataDocNavigator/DataDocNavigatorBoardSection.tsx
+++ b/querybook/webapp/components/DataDocNavigator/DataDocNavigatorBoardSection.tsx
@@ -466,13 +466,13 @@ const BoardExpandableList: React.FunctionComponent<{
             items.length > itemsToHideSet.size ? (
                 makeItemsDOM()
             ) : (
-                <div className="board-item-list-empty ph12">
-                    No items found in this list.
+                <div className="empty-message m16 flex-center">
+                    No items found in this list
                 </div>
             )
         ) : (
-            <div className="board-item-list-empty ph12">
-                No items in this list yet.
+            <div className="empty-message m16 flex-center">
+                No items in this list yet
             </div>
         );
 

--- a/querybook/webapp/components/DataDocNavigator/DataDocNavigatorBoardSection.tsx
+++ b/querybook/webapp/components/DataDocNavigator/DataDocNavigatorBoardSection.tsx
@@ -188,7 +188,7 @@ export const DataDocNavigatorBoardSection: React.FC<INavigatorBoardSectionProps>
     );
 
     const boardsDOM = collapsed ? null : (
-        <div>
+        <div className="ml8">
             {boards.map((board) => (
                 <NavigatorBoardView
                     key={board.id}

--- a/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.scss
+++ b/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.scss
@@ -9,7 +9,12 @@
         flex-direction: column;
 
         .query-metadata {
-            padding: 0px 10px;
+            padding: 0px 8px;
+            .QueryRunButton,
+            > .Dropdown {
+                padding-top: 8px;
+                padding-bottom: 8px;
+            }
         }
 
         .query-content {
@@ -47,6 +52,14 @@
         }
     }
 
+    .collapsed-query {
+        color: var(--text-lightest);
+        font-size: var(--med-text-size);
+        font-weight: var(--bold-font);
+
+        padding-top: 6px;
+    }
+
     .query-title {
         flex: 1;
 
@@ -66,19 +79,27 @@
             font-size: var(--text-size);
         }
 
-        .additional-dropdown-button {
-            @include pushable();
-            @include fancy-hover();
-
-            cursor: pointer;
-            margin-left: 5px;
-
+        .Dropdown-trigger {
             height: 100%;
-            font-size: 20px;
-            line-height: 38px;
+            .additional-dropdown-button {
+                cursor: pointer;
 
-            svg {
-                z-index: 4;
+                height: 100%;
+                width: 36px;
+                font-size: 20px;
+                line-height: 38px;
+
+                border-radius: var(--border-radius-sm);
+
+                svg {
+                    z-index: 4;
+                }
+                &:hover {
+                    background-color: var(--bg-hover);
+                }
+                &:focus {
+                    background-color: var(--bg-lightest);
+                }
             }
         }
     }
@@ -86,10 +107,10 @@
     .editor {
         position: relative;
         box-sizing: border-box;
-        margin: 5px 0px;
+        margin: 8px 0px;
 
         .QueryEditor .CodeMirror {
-            border-radius: var(--border-radius);
+            border-radius: var(--border-radius-sm);
         }
 
         .fullscreen-button-wrapper {
@@ -102,10 +123,11 @@
                 background-color: transparent;
             }
         }
-    }
 
-    .add-snippet-wrapper {
-        text-align: center;
-        margin-top: 5px;
+        .add-snippet-wrapper {
+            position: absolute;
+            top: 10px;
+            right: 42px;
+        }
     }
 }

--- a/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.scss
+++ b/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.scss
@@ -10,11 +10,11 @@
 
         .query-metadata {
             padding: 0px 8px;
-            .QueryRunButton,
-            > .Dropdown {
-                padding-top: 8px;
-                padding-bottom: 8px;
-            }
+        }
+
+        .engine-selector-button {
+            padding-top: 8px;
+            padding-bottom: 8px;
         }
 
         .query-content {
@@ -79,26 +79,28 @@
             font-size: var(--text-size);
         }
 
-        .Dropdown-trigger {
-            height: 100%;
-            .additional-dropdown-button {
-                cursor: pointer;
-
+        .query-cell-additional-dropdown {
+            .Dropdown-trigger {
                 height: 100%;
-                width: 36px;
-                font-size: 20px;
-                line-height: 38px;
+                .additional-dropdown-button {
+                    cursor: pointer;
 
-                border-radius: var(--border-radius-sm);
+                    height: 100%;
+                    width: 36px;
+                    font-size: 20px;
+                    line-height: 38px;
 
-                svg {
-                    z-index: 4;
-                }
-                &:hover {
-                    background-color: var(--bg-hover);
-                }
-                &:focus {
-                    background-color: var(--bg-lightest);
+                    border-radius: var(--border-radius-sm);
+
+                    svg {
+                        z-index: 4;
+                    }
+                    &:hover {
+                        background-color: var(--bg-hover);
+                    }
+                    &:focus {
+                        background-color: var(--bg-lightest);
+                    }
                 }
             }
         }

--- a/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
+++ b/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
@@ -494,6 +494,7 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
             <Icon
                 className="additional-dropdown-button flex-center"
                 name="more-vertical"
+                color="light"
             />
         );
     }
@@ -570,15 +571,25 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
         const queryCollapsed = this.queryCollapsed;
 
         const fullScreenButton = (
-            <div className="fullscreen-button-wrapper">
+            <div className="fullscreen-button-wrapper mt4">
                 <Button
-                    icon="maximize"
+                    icon={isFullScreen ? 'minimize-2' : 'maximize-2'}
                     onClick={toggleFullScreen}
                     theme="text"
                     pushable
                 />
             </div>
         );
+        const openSnippetDOM =
+            query.trim().length === 0 && isEditable ? (
+                <div className="add-snippet-wrapper">
+                    <TextButton
+                        title="Add Template"
+                        onClick={this.toggleInsertQuerySnippetModal}
+                    />
+                </div>
+            ) : null;
+
         const editorDOM = !queryCollapsed && (
             <div className="editor">
                 {fullScreenButton}
@@ -598,18 +609,9 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
                     height={isFullScreen ? 'full' : 'auto'}
                     allowFullScreen={false}
                 />
+                {openSnippetDOM}
             </div>
         );
-
-        const openSnippetDOM =
-            query.trim().length === 0 && isEditable ? (
-                <div className="add-snippet-wrapper flex-center">
-                    <TextButton
-                        title="Add Template"
-                        onClick={this.toggleInsertQuerySnippetModal}
-                    />
-                </div>
-            ) : null;
 
         const insertQuerySnippetModalDOM = showQuerySnippetModal ? (
             <Modal
@@ -640,7 +642,6 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
         return (
             <>
                 {editorDOM}
-                {openSnippetDOM}
                 {insertQuerySnippetModalDOM}
                 {templatedQueryViewModalDOM}
             </>
@@ -721,9 +722,9 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
 
         return showCollapsed ? (
             <div className={classes}>
-                <div className="query-title flex-row">
+                <div className="collapsed-query flex-row">
+                    <Icon name="terminal" className="mt4 mr8" />
                     <span>{this.dataCellTitle}</span>
-                    <span>{'{...}'}</span>
                 </div>
             </div>
         ) : isFullScreen ? (

--- a/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
+++ b/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
@@ -425,6 +425,7 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
 
         return additionalButtons.length > 0 ? (
             <Dropdown
+                className="query-cell-additional-dropdown"
                 customButtonRenderer={this.additionalDropDownButtonFormatter}
                 isRight
             >

--- a/querybook/webapp/components/DataDocQueryExecutions/DataDocQueryExecutions.scss
+++ b/querybook/webapp/components/DataDocQueryExecutions/DataDocQueryExecutions.scss
@@ -3,17 +3,14 @@
     font-weight: 700;
 
     .execution-selector-section {
-        margin-top: 8px;
-
-        .execution-selector-bottom {
-            margin-left: auto;
-            > span {
-                margin-left: 4px;
-            }
+        margin-bottom: 4px;
+        .date-text {
+            color: var(--text-light);
         }
     }
 
     .QueryExecution {
-        margin-top: 2px;
+        margin-top: 4px;
+        margin-bottom: 4px;
     }
 }

--- a/querybook/webapp/components/DataDocQueryExecutions/DataDocQueryExecutions.tsx
+++ b/querybook/webapp/components/DataDocQueryExecutions/DataDocQueryExecutions.tsx
@@ -124,7 +124,7 @@ export const DataDocQueryExecutions: React.FunctionComponent<IProps> = React.mem
             }
 
             return (
-                <div className="execution-selector-section flex-row">
+                <div className="execution-selector-section horizontal-space-between">
                     <QueryExecutionPicker
                         queryExecutionId={currentExecution?.id}
                         onSelection={handleQueryExecutionSelected}

--- a/querybook/webapp/components/DataDocRightSidebar/DataDocRightSidebar.tsx
+++ b/querybook/webapp/components/DataDocRightSidebar/DataDocRightSidebar.tsx
@@ -100,6 +100,16 @@ export const DataDocRightSidebar: React.FunctionComponent<IProps> = ({
                     }}
                 />
                 <IconButton
+                    icon={defaultCollapse ? 'maximize-2' : 'minimize-2'}
+                    tooltip={
+                        defaultCollapse
+                            ? 'Uncollapse query cells'
+                            : 'Collapse query cells'
+                    }
+                    tooltipPos="left"
+                    onClick={onCollapse}
+                />
+                <IconButton
                     icon="loader"
                     className={isSaving ? '' : 'hide-button'}
                     title="Saving"
@@ -112,16 +122,6 @@ export const DataDocRightSidebar: React.FunctionComponent<IProps> = ({
                         'connected-button ' + (isConnected ? 'hide-button' : '')
                     }
                     color="accent"
-                />
-                <IconButton
-                    icon={defaultCollapse ? 'maximize-2' : 'minimize-2'}
-                    tooltip={
-                        defaultCollapse
-                            ? 'Uncollapse query cells'
-                            : 'Collapse query cells'
-                    }
-                    tooltipPos="left"
-                    onClick={onCollapse}
                 />
             </div>
             <div className="DataDocRightSidebar-button-section-bottom flex-column">

--- a/querybook/webapp/components/DataDocRightSidebar/DataDocRightSidebar.tsx
+++ b/querybook/webapp/components/DataDocRightSidebar/DataDocRightSidebar.tsx
@@ -20,6 +20,9 @@ interface IProps {
 
     changeDataDocMeta: (docId: number, meta: Record<string, any>) => any;
     onClone: () => any;
+
+    onCollapse: () => any;
+    defaultCollapse: boolean;
 }
 
 export const DataDocRightSidebar: React.FunctionComponent<IProps> = ({
@@ -31,6 +34,9 @@ export const DataDocRightSidebar: React.FunctionComponent<IProps> = ({
     isConnected,
 
     dataDoc,
+
+    onCollapse,
+    defaultCollapse,
 }) => {
     const numAnnouncements = useAnnouncements().length;
 
@@ -106,6 +112,16 @@ export const DataDocRightSidebar: React.FunctionComponent<IProps> = ({
                         'connected-button ' + (isConnected ? 'hide-button' : '')
                     }
                     color="accent"
+                />
+                <IconButton
+                    icon={defaultCollapse ? 'maximize-2' : 'minimize-2'}
+                    tooltip={
+                        defaultCollapse
+                            ? 'Uncollapse query cells'
+                            : 'Collapse query cells'
+                    }
+                    tooltipPos="left"
+                    onClick={onCollapse}
                 />
             </div>
             <div className="DataDocRightSidebar-button-section-bottom flex-column">

--- a/querybook/webapp/components/DataDocStatementExecution/DataDocStatementExecution.scss
+++ b/querybook/webapp/components/DataDocStatementExecution/DataDocStatementExecution.scss
@@ -49,10 +49,9 @@
         display: flex;
         flex-direction: column;
         background-color: var(--bg);
-        padding: 15px;
+        padding: 8px 16px;
 
         .StatementResultTable {
-            flex: 1;
             overflow: hidden;
             display: flex;
             .Table {

--- a/querybook/webapp/components/DataDocStatementExecution/StatementLog.tsx
+++ b/querybook/webapp/components/DataDocStatementExecution/StatementLog.tsx
@@ -84,7 +84,7 @@ export const StatementLog: React.FunctionComponent<IStatementLogProps> = ({
     const toggleFullScreenButtonDOM = (
         <SoftButton
             color="light"
-            icon="maximize"
+            icon="maximize-2"
             title={fullScreen ? 'Exit Fullscreen (Esc)' : 'Fullscreen'}
             onClick={toggleFullscreen}
             className="toggle-fullscreen-button"

--- a/querybook/webapp/components/DataDocStatementExecution/StatementResult.tsx
+++ b/querybook/webapp/components/DataDocStatementExecution/StatementResult.tsx
@@ -75,7 +75,7 @@ export const StatementResult: React.FC<IProps> = ({
     const exploreButtonDOM = (
         <TextButton
             onClick={onFullscreenToggle}
-            icon={isFullscreen ? 'minimize' : 'maximize'}
+            icon={isFullscreen ? 'x' : 'maximize-2'}
             title={isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}
             size="small"
         />

--- a/querybook/webapp/components/DataDocStatementExecutionBar/DataDocStatementExecutionBar.scss
+++ b/querybook/webapp/components/DataDocStatementExecutionBar/DataDocStatementExecutionBar.scss
@@ -4,4 +4,7 @@
     .Dropdown-trigger {
         display: flex;
     }
+    .Button {
+        margin-left: 8px;
+    }
 }

--- a/querybook/webapp/components/DataDocTextCell/DataDocTextCell.scss
+++ b/querybook/webapp/components/DataDocTextCell/DataDocTextCell.scss
@@ -5,7 +5,7 @@
     font-size: var(--text-size);
 
     &:focus-within {
-        background-color: var(--bg-light);
+        background-color: var(--bg-lightest);
     }
 
     &:hover {

--- a/querybook/webapp/components/DataDocViewersBadge/DataDocViewersBadge.scss
+++ b/querybook/webapp/components/DataDocViewersBadge/DataDocViewersBadge.scss
@@ -12,7 +12,7 @@
         flex-direction: row;
 
         .viewers-badge-share-button {
-            margin-left: 15px;
+            margin-left: 24px;
         }
     }
 }

--- a/querybook/webapp/components/DataDocViewersList/DataDocViewersList.scss
+++ b/querybook/webapp/components/DataDocViewersList/DataDocViewersList.scss
@@ -1,15 +1,13 @@
 .DataDocViewersList {
     width: 400px;
 
-    > div:not(:last-child) {
-        padding-left: 8px;
-        padding-right: 8px;
+    > div {
+        margin-top: 16px;
     }
 
     .public-row-description {
-        border-top: var(--border);
-        padding-top: 1rem;
         text-align: center;
+        color: var(--text-light);
     }
 
     .datadoc-add-user-row {
@@ -36,16 +34,6 @@
         overflow-y: auto;
         padding-bottom: 0rem;
         padding-top: 0rem;
-        border-top: var(--border);
-
-        > div {
-            padding-left: 8px;
-            padding-right: 8px;
-        }
-
-        > div:not(:last-child) {
-            border-bottom: var(--border);
-        }
     }
 
     .viewers-user-row {

--- a/querybook/webapp/components/DataDocViewersList/DataDocViewersList.tsx
+++ b/querybook/webapp/components/DataDocViewersList/DataDocViewersList.tsx
@@ -22,7 +22,7 @@ import { UserBadge } from 'components/UserBadge/UserBadge';
 import { UserSelect } from 'components/UserSelect/UserSelect';
 
 import { Tabs } from 'ui/Tabs/Tabs';
-import { Title } from 'ui/Title/Title';
+
 import './DataDocViewersList.scss';
 
 interface IDataDocViewersListProps {
@@ -153,14 +153,14 @@ export const DataDocViewersList: React.FunctionComponent<IDataDocViewersListProp
           ));
 
     const contentDOM = (
-        <div className="viewers-list-wrapper mt16">
+        <div className="viewers-list-wrapper">
             {accessRequestListDOM}
             {viewersListDOM}
         </div>
     );
     const dataDocPublicRow = (
         <>
-            <div className="public-row-switch pv16">
+            <div className="public-row-switch">
                 <Tabs
                     selectedTabKey={dataDoc.public ? 'Public' : 'Private'}
                     pills
@@ -178,16 +178,18 @@ export const DataDocViewersList: React.FunctionComponent<IDataDocViewersListProp
                 />
             </div>
             <div className="public-row-description">
-                <Title size={6} subtitle className="mb8">
+                <div>
                     {dataDoc.public
                         ? 'This document can be viewed by anyone.'
                         : 'Only invited users can view this document.'}
-                </Title>
+                </div>
                 {isEditor ? null : (
-                    <AccessRequestButton
-                        onAccessRequest={handleDataDocAccessRequest}
-                        isEdit
-                    />
+                    <div className="mt12">
+                        <AccessRequestButton
+                            onAccessRequest={handleDataDocAccessRequest}
+                            isEdit
+                        />
+                    </div>
                 )}
             </div>
         </>

--- a/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentAppSidebar.scss
+++ b/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentAppSidebar.scss
@@ -74,13 +74,44 @@
     &.collapsed {
         .sidebar-environment-picker {
             text-align: center;
-            border-bottom: solid 1px transparent;
-            .EnvironmentDropdownButton .Dropdown-trigger {
-                display: flex;
-                justify-content: center;
+            .collapsed-env {
+                padding: var(--padding-sm);
             }
         }
 
         border-right: var(--border);
+    }
+
+    .env-icon {
+        font-size: var(--xxxsmall-text-size);
+        font-family: var(--font-monospace);
+        background-color: var(--bg-light);
+        color: var(--text);
+        border-radius: var(--border-radius-sm);
+        transition: background-color 0.3s ease-out;
+        user-select: none;
+
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
+
+        width: 36px;
+        height: 36px;
+
+        &.selected {
+            font-weight: var(--bold-font);
+            color: var(--color-accent-dark);
+            background-color: var(--color-accent-lightest-0);
+        }
+
+        &.disabled {
+            opacity: 0.45;
+            cursor: not-allowed;
+        }
+
+        .env-icon-text {
+            word-break: break-all;
+            text-align: center;
+        }
     }
 }

--- a/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentAppSidebar.tsx
+++ b/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentAppSidebar.tsx
@@ -4,7 +4,6 @@ import clsx from 'clsx';
 import { navigateWithinEnv } from 'lib/utils/query-string';
 import { useEvent } from 'hooks/useEvent';
 import { matchKeyMap, KeyMap } from 'lib/utils/keyboard';
-import { getAbbrEnvName } from 'lib/utils';
 import { useSelector } from 'react-redux';
 import { currentEnvironmentSelector } from 'redux/environment/selector';
 import { Entity } from './types';
@@ -16,6 +15,7 @@ import { DataDocNavigator } from 'components/DataDocNavigator/DataDocNavigator';
 import { EnvironmentTopbar } from './EnvironmentTopbar';
 import { EntitySidebar } from './EntitySidebar';
 import { EnvironmentDropdownButton } from './EnvironmentDropdownButton';
+import { EnvironmentIcon } from './EnvironmentIcon';
 
 import { Sidebar } from 'ui/Sidebar/Sidebar';
 import { Icon } from 'ui/Icon/Icon';
@@ -115,11 +115,11 @@ export const EnvironmentAppSidebar: React.FunctionComponent = () => {
         <div className="collapsed-env">
             <EnvironmentDropdownButton
                 customButtonRenderer={() => (
-                    <div className="env-icon selected">
-                        <span className="env-icon-text">
-                            {getAbbrEnvName(currentEnvironment?.name)}
-                        </span>
-                    </div>
+                    <EnvironmentIcon
+                        disabled={false}
+                        selected={true}
+                        environmentName={currentEnvironment.name}
+                    />
                 )}
             />
         </div>

--- a/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentAppSidebar.tsx
+++ b/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentAppSidebar.tsx
@@ -2,20 +2,24 @@ import React from 'react';
 import clsx from 'clsx';
 
 import { navigateWithinEnv } from 'lib/utils/query-string';
+import { useEvent } from 'hooks/useEvent';
+import { matchKeyMap, KeyMap } from 'lib/utils/keyboard';
+import { getAbbrEnvName } from 'lib/utils';
+import { useSelector } from 'react-redux';
+import { currentEnvironmentSelector } from 'redux/environment/selector';
+import { Entity } from './types';
 
 import { QuerySnippetNavigator } from 'components/QuerySnippetNavigator/QuerySnippetNavigator';
 import { DataDocSchemaNavigator } from 'components/DataDocSchemaNavigator/DataDocSchemaNavigator';
 import { QueryViewNavigator } from 'components/QueryViewNavigator/QueryViewNavigator';
 import { DataDocNavigator } from 'components/DataDocNavigator/DataDocNavigator';
-import { Sidebar } from 'ui/Sidebar/Sidebar';
-import { Icon } from 'ui/Icon/Icon';
-
-import { Entity } from './types';
 import { EnvironmentTopbar } from './EnvironmentTopbar';
 import { EntitySidebar } from './EntitySidebar';
 import { EnvironmentDropdownButton } from './EnvironmentDropdownButton';
-import { useEvent } from 'hooks/useEvent';
-import { matchKeyMap, KeyMap } from 'lib/utils/keyboard';
+
+import { Sidebar } from 'ui/Sidebar/Sidebar';
+import { Icon } from 'ui/Icon/Icon';
+
 import './EnvironmentAppSidebar.scss';
 
 const SIDEBAR_WIDTH = 320;
@@ -23,6 +27,8 @@ const SIDEBAR_WIDTH = 320;
 export const EnvironmentAppSidebar: React.FunctionComponent = () => {
     const [collapsed, setCollapsed] = React.useState(false);
     const [entity, setEntity] = React.useState<Entity>('datadoc');
+
+    const currentEnvironment = useSelector(currentEnvironmentSelector);
 
     const handleEntitySelect = React.useCallback((e: Entity) => {
         setCollapsed(false);
@@ -106,7 +112,17 @@ export const EnvironmentAppSidebar: React.FunctionComponent = () => {
     );
 
     const environmentPickerSection = collapsed ? (
-        <EnvironmentDropdownButton />
+        <div className="collapsed-env">
+            <EnvironmentDropdownButton
+                customButtonRenderer={() => (
+                    <div className="env-icon selected">
+                        <span className="env-icon-text">
+                            {getAbbrEnvName(currentEnvironment?.name)}
+                        </span>
+                    </div>
+                )}
+            />
+        </div>
     ) : (
         <EnvironmentTopbar />
     );

--- a/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentDropdownButton.scss
+++ b/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentDropdownButton.scss
@@ -1,5 +1,4 @@
 .EnvironmentDropdownButton {
-    background-color: var(--bg-lightest);
     .environment-name.environment-disabled {
         cursor: not-allowed;
         color: var(--text-light);

--- a/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentDropdownButton.tsx
+++ b/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentDropdownButton.tsx
@@ -17,7 +17,8 @@ import './EnvironmentDropdownButton.scss';
 
 export const EnvironmentDropdownButton: React.FunctionComponent<{
     skip?: number;
-}> = ({ skip = 0 }) => {
+    customButtonRenderer?: () => React.ReactNode;
+}> = ({ skip = 0, customButtonRenderer }) => {
     const environments = useSelector(environmentsSelector);
     const currentEnvironment = useSelector(currentEnvironmentSelector);
     const userEnvironmentNames = useSelector(userEnvironmentNamesSelector);
@@ -51,7 +52,10 @@ export const EnvironmentDropdownButton: React.FunctionComponent<{
     });
 
     return (
-        <Dropdown className="EnvironmentDropdownButton">
+        <Dropdown
+            className="EnvironmentDropdownButton"
+            customButtonRenderer={customButtonRenderer}
+        >
             <ListMenu items={environmentItems} type="select" />
         </Dropdown>
     );

--- a/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentIcon.tsx
+++ b/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentIcon.tsx
@@ -1,0 +1,33 @@
+import clsx from 'clsx';
+import * as React from 'react';
+
+interface IProps {
+    selected: boolean;
+    disabled: boolean;
+    environmentName: string;
+}
+
+export const EnvironmentIcon: React.FunctionComponent<IProps> = ({
+    selected,
+    disabled,
+    environmentName,
+}) => {
+    const envName = React.useMemo(() => {
+        const firstWordMatch = environmentName.match(/([a-zA-Z0-9]+)/);
+        return firstWordMatch
+            ? firstWordMatch[1].slice(0, 10).toLocaleUpperCase()
+            : '';
+    }, [environmentName]);
+
+    return (
+        <span
+            className={clsx({
+                'env-icon': true,
+                disabled,
+                selected,
+            })}
+        >
+            <span className="env-icon-text">{envName}</span>
+        </span>
+    );
+};

--- a/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentTopbar.scss
+++ b/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentTopbar.scss
@@ -3,6 +3,8 @@
     flex-direction: row;
     padding: var(--padding-sm);
     background-color: var(--bg-lightest);
+    // match when collapsed
+    margin-left: 1px;
 
     .env-icon-wrapper {
         display: inline-block;
@@ -11,36 +13,7 @@
             margin-left: var(--margin-xs);
         }
     }
-    .env-icon {
-        font-size: var(--xxxsmall-text-size);
-        font-family: var(--font-monospace);
-        background-color: var(--bg-light);
-        color: var(--text);
-        border-radius: var(--border-radius-sm);
-        transition: background-color 0.3s ease-out;
-        user-select: none;
-
-        display: inline-flex;
-        justify-content: center;
-        align-items: center;
-
-        width: 36px;
-        height: 36px;
-
-        &.selected {
-            font-weight: var(--bold-font);
-            color: var(--color-accent-dark);
-            background-color: var(--color-accent-lightest-0);
-        }
-
-        &.disabled {
-            opacity: 0.45;
-            cursor: not-allowed;
-        }
-
-        .env-icon-text {
-            word-break: break-all;
-            text-align: center;
-        }
+    .Dropdown {
+        margin-right: 8px;
     }
 }

--- a/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentTopbar.tsx
+++ b/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentTopbar.tsx
@@ -7,14 +7,16 @@ import {
     userEnvironmentNamesSelector,
     orderedEnvironmentsSelector,
 } from 'redux/environment/selector';
-import { titleize } from 'lib/utils';
+import { getAbbrEnvName, titleize } from 'lib/utils';
 
-import './EnvironmentTopbar.scss';
-import { Level } from 'ui/Level/Level';
 import { EnvironmentDropdownButton } from './EnvironmentDropdownButton';
+
+import { Level } from 'ui/Level/Level';
 import { Link } from 'ui/Link/Link';
 
-const NUMBER_OF_ICONS_TO_SHOW = 5;
+import './EnvironmentTopbar.scss';
+
+const NUMBER_OF_ICONS_TO_SHOW = 1;
 
 export const EnvironmentTopbar: React.FC = React.memo(() => {
     const environments = useSelector(orderedEnvironmentsSelector);
@@ -32,10 +34,7 @@ export const EnvironmentTopbar: React.FC = React.memo(() => {
                 : false;
             const accessible = userEnvironmentNames.has(environment.name);
 
-            const firstWordMatch = environment.name.match(/([a-zA-Z0-9]+)/);
-            const envName = firstWordMatch
-                ? firstWordMatch[1].slice(0, 10).toLocaleUpperCase()
-                : '';
+            const envName = getAbbrEnvName(environment.name);
 
             return (
                 <Link

--- a/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentTopbar.tsx
+++ b/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentTopbar.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import clsx from 'clsx';
 
 import {
     currentEnvironmentSelector,
     userEnvironmentNamesSelector,
     orderedEnvironmentsSelector,
 } from 'redux/environment/selector';
-import { getAbbrEnvName, titleize } from 'lib/utils';
+import { titleize } from 'lib/utils';
 
 import { EnvironmentDropdownButton } from './EnvironmentDropdownButton';
 
@@ -15,6 +14,7 @@ import { Level } from 'ui/Level/Level';
 import { Link } from 'ui/Link/Link';
 
 import './EnvironmentTopbar.scss';
+import { EnvironmentIcon } from './EnvironmentIcon';
 
 const NUMBER_OF_ICONS_TO_SHOW = 5;
 
@@ -34,8 +34,6 @@ export const EnvironmentTopbar: React.FC = React.memo(() => {
                 : false;
             const accessible = userEnvironmentNames.has(environment.name);
 
-            const envName = getAbbrEnvName(environment.name);
-
             return (
                 <Link
                     key={environment.id}
@@ -50,15 +48,11 @@ export const EnvironmentTopbar: React.FC = React.memo(() => {
                     data-balloon-length="medium"
                     to={accessible ? `/${environment.name}/` : null}
                 >
-                    <span
-                        className={clsx({
-                            'env-icon': true,
-                            disabled: !accessible,
-                            selected,
-                        })}
-                    >
-                        <span className="env-icon-text">{envName}</span>
-                    </span>
+                    <EnvironmentIcon
+                        disabled={!accessible}
+                        selected={selected}
+                        environmentName={environment.name}
+                    />
                 </Link>
             );
         });

--- a/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentTopbar.tsx
+++ b/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentTopbar.tsx
@@ -16,7 +16,7 @@ import { Link } from 'ui/Link/Link';
 
 import './EnvironmentTopbar.scss';
 
-const NUMBER_OF_ICONS_TO_SHOW = 1;
+const NUMBER_OF_ICONS_TO_SHOW = 5;
 
 export const EnvironmentTopbar: React.FC = React.memo(() => {
     const environments = useSelector(orderedEnvironmentsSelector);

--- a/querybook/webapp/components/ImpressionWidget/ImpressionWidget.scss
+++ b/querybook/webapp/components/ImpressionWidget/ImpressionWidget.scss
@@ -1,7 +1,7 @@
 .ImpressionWidget {
     background-color: var(--icon);
     color: var(--text-invert);
-    border-radius: var(--border-radius);
+    border-radius: var(--border-radius-sm);
     display: inline-flex;
     align-items: center;
     padding: 0px 4px;

--- a/querybook/webapp/components/ImpressionWidget/ImpressionWidgetMenu.scss
+++ b/querybook/webapp/components/ImpressionWidget/ImpressionWidgetMenu.scss
@@ -1,14 +1,8 @@
 .ImpressionWidgetMenu {
-    min-width: 500px;
+    min-width: 480px;
     .ImpressionWidgetUsers,
     .ImpressionWidgetTimeseries {
         flex: 1;
         width: 100%;
-    }
-
-    .ImpressionWidgetUsers {
-        .Table {
-            border-radius: 0;
-        }
     }
 }

--- a/querybook/webapp/components/ImpressionWidget/ImpressionWidgetMenu.tsx
+++ b/querybook/webapp/components/ImpressionWidget/ImpressionWidgetMenu.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import { Line } from 'react-chartjs-2';
 import 'chartjs-adapter-moment';
+
 import { generateFormattedDate } from 'lib/utils/datetime';
 import { ImpressionType } from 'const/impression';
 import { useResource } from 'hooks/useResource';
+import { ImpressionResource } from 'resource/impression';
 
 import { UserName } from 'components/UserBadge/UserName';
 
@@ -12,7 +14,6 @@ import { Table } from 'ui/Table/Table';
 import { Tabs } from 'ui/Tabs/Tabs';
 
 import './ImpressionWidgetMenu.scss';
-import { ImpressionResource } from 'resource/impression';
 
 interface IProps {
     type: ImpressionType;
@@ -30,7 +31,7 @@ export const ImpressionWidgetMenu: React.FunctionComponent<IProps> = (
             <ImpressionWidgetTimeseries {...props} />
         );
     return (
-        <div className="ImpressionWidgetMenu flex-column">
+        <div className="ImpressionWidgetMenu flex-column p8">
             <Tabs
                 selectedTabKey={menuTab}
                 items={[
@@ -38,6 +39,8 @@ export const ImpressionWidgetMenu: React.FunctionComponent<IProps> = (
                     { key: 'timeseries', name: 'Views Over Time' },
                 ]}
                 onSelect={setMenuTab}
+                pills
+                className="mb16"
             />
             {contentDOM}
         </div>

--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -608,9 +608,9 @@ export class QueryEditor extends React.PureComponent<
         });
 
         const fullScreenButton = allowFullScreen && (
-            <div className="fullscreen-button-wrapper">
+            <div className="fullscreen-button-wrapper mt4">
                 <Button
-                    icon="maximize"
+                    icon={fullScreen ? 'minimize-2' : 'maximize-2'}
                     onClick={this.toggleFullScreen}
                     theme="text"
                     pushable

--- a/querybook/webapp/components/QueryExecution/ExecutedQueryCell.scss
+++ b/querybook/webapp/components/QueryExecution/ExecutedQueryCell.scss
@@ -1,11 +1,10 @@
 .ExecutedQueryCell {
-    border-radius: 5px;
-    background: var(--bg-query-editor);
+    border-radius: var(--border-radius-sm);
 
-    .execution-header {
-        margin: 0;
-        padding: 10px;
-        border-bottom: var(--border);
+    .engine-text {
+        color: var(--text-light);
+        text-transform: uppercase;
+        font-weight: normal;
     }
 
     .code-highlight {

--- a/querybook/webapp/components/QueryExecution/ExecutedQueryCell.tsx
+++ b/querybook/webapp/components/QueryExecution/ExecutedQueryCell.tsx
@@ -5,11 +5,13 @@ import { UnControlled as ReactCodeMirror } from 'react-codemirror2';
 import styled from 'styled-components';
 
 import { IQueryExecution } from 'const/queryExecution';
-import { titleize, getCodeEditorTheme } from 'lib/utils';
+import { getCodeEditorTheme } from 'lib/utils';
 import { queryEngineByIdEnvSelector } from 'redux/queryEngine/selector';
 import { IStoreState } from 'redux/store/types';
 
 import { Loading } from 'ui/Loading/Loading';
+import { TextButton } from 'ui/Button/Button';
+
 import './ExecutedQueryCell.scss';
 
 const EmbeddedCodeMirrorContainer = styled.div`
@@ -95,26 +97,27 @@ export const ExecutedQueryCell: React.FunctionComponent<IProps> = ({
     };
 
     const changeCellContextButton = changeCellContext && (
-        <span
-            className="query-execution-button"
-            aria-label={'Copy and Paste this into the query editor above'}
-            data-balloon-pos={'up'}
-            key={'replace'}
+        <TextButton
             onClick={() => {
                 changeCellContext(query);
             }}
-        >
-            Paste in Editor
-        </span>
+            aria-label={'Copy and Paste this into the query editor above'}
+            data-balloon-pos={'left'}
+            key="replace"
+            size="small"
+            icon="terminal"
+            title="Paste Query in Editor"
+        />
     );
 
     const queryEngine = queryEngineById[queryExecution.engine_id];
     const headerDOM = (
         <div className="execution-header horizontal-space-between">
-            <div>
-                <div>{`Engine: ${titleize(queryEngine.name)}`}</div>
+            <div className="flex-row">
+                <div className="engine-text mr8">Engine</div>
+                <div className="engine-name">{queryEngine.name}</div>
             </div>
-            <div>{changeCellContextButton}</div>
+            {changeCellContextButton}
         </div>
     );
 
@@ -132,7 +135,7 @@ export const ExecutedQueryCell: React.FunctionComponent<IProps> = ({
     );
 
     return (
-        <div className="ExecutedQueryCell">
+        <div className="ExecutedQueryCell mb4">
             {headerDOM}
             {codeDOM}
         </div>

--- a/querybook/webapp/components/QueryExecution/QueryExecution.scss
+++ b/querybook/webapp/components/QueryExecution/QueryExecution.scss
@@ -25,4 +25,8 @@
     .statement-selector-button {
         display: inline-block;
     }
+
+    .run-time-message {
+        color: var(--text-light);
+    }
 }

--- a/querybook/webapp/components/QueryExecution/QueryExecution.tsx
+++ b/querybook/webapp/components/QueryExecution/QueryExecution.tsx
@@ -231,7 +231,7 @@ export const QueryExecution: React.FC<IProps> = ({
         );
 
         return (
-            <div className="statement-header">
+            <div className="statement-header horizontal-space-between mb4">
                 <div className="statement-header-top">
                     <div className="run-header-left">{statementTab}</div>
                 </div>

--- a/querybook/webapp/components/QueryExecutionBar/QueryExecutionBar.scss
+++ b/querybook/webapp/components/QueryExecutionBar/QueryExecutionBar.scss
@@ -1,5 +1,3 @@
-@import './../../scss_variables.scss';
-
 .QueryExecutionBar {
     display: flex;
     align-items: center;

--- a/querybook/webapp/components/QueryExecutionBar/QueryExecutionBar.tsx
+++ b/querybook/webapp/components/QueryExecutionBar/QueryExecutionBar.tsx
@@ -26,11 +26,11 @@ export const QueryExecutionBar: React.FunctionComponent<IProps> = ({
     );
 
     const executionDateDOM = (
-        <span>
+        <div className="date-text mr16">
             {generateFormattedDate(queryExecution.created_at, 'X') +
                 ', ' +
                 moment.utc(queryExecution.created_at, 'X').fromNow()}
-        </span>
+        </div>
     );
 
     const notificationButtonDOM = queryExecution.status <=
@@ -46,11 +46,11 @@ export const QueryExecutionBar: React.FunctionComponent<IProps> = ({
             {executionDateDOM}
             {notificationButtonDOM}
             <CopyButton
-                type="text"
                 size="small"
                 copyText={permalink}
                 icon="link"
                 title="Share Execution"
+                type="text"
             />
         </>
     );

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.scss
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.scss
@@ -1,30 +1,39 @@
 .QueryRunButton {
+    .Button {
+        height: 100%;
+        width: 120px;
+        display: flex;
+        justify-content: center;
+        margin: 0px 16px;
+        font-weight: bold;
+    }
     .run-selection {
         line-height: 24px;
-    }
-
-    & .QueryEngineSelector .engine-selector-button {
-        border-left: none;
-        border-bottom-left-radius: 0;
-        border-top-left-radius: 0;
     }
 }
 
 .QueryEngineSelector {
     display: inline-block;
+    height: 100%;
+    .Dropdown {
+        height: 100%;
+        .Dropdown-trigger {
+            height: 100%;
+            .engine-selector-button {
+                min-width: 120px;
+                border-radius: var(--border-radius-sm);
 
-    .engine-selector-button {
-        padding: 5.5px 8px;
-        border: var(--border);
-        border-radius: var(--border-radius);
+                user-select: none;
 
-        user-select: none;
+                font-size: var(--small-text-size);
 
-        font-weight: bold;
-        color: var(--text-dark);
-        font-size: var(--small-text-size);
-        .fa {
-            margin-left: 5px;
+                &:hover {
+                    background-color: var(--bg-hover);
+                }
+                &:focus {
+                    background-color: var(--bg-lightest);
+                }
+            }
         }
     }
 

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
@@ -70,7 +70,7 @@ export const QueryRunButton = React.forwardRef<
                     'run-selection': !!hasSelection,
                 })}
                 title={hasSelection ? 'Run Selection' : null}
-                icon={hasSelection ? null : 'play'}
+                icon={<Icon name="play" fill />}
                 aria-label={`Execute (${EXECUTE_QUERY_SHORTCUT})`}
                 data-balloon-pos={runButtonTooltipPos}
                 color="accent"

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
@@ -120,7 +120,7 @@ export const QueryEngineSelector: React.FC<IQueryEngineSelectorProps> = ({
         return (
             <div className="engine-selector-button flex-center ph8">
                 <StatusIcon status={iconClass} />
-                <div className="ml4"> {queryEngineName}</div>
+                <div className="ml4">{queryEngineName}</div>
                 <Icon
                     name="chevron-down"
                     className="ml4"

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
@@ -14,6 +14,7 @@ import { ListMenu } from 'ui/Menu/ListMenu';
 import { StatusIcon } from 'ui/StatusIcon/StatusIcon';
 
 import './QueryRunButton.scss';
+import { Icon } from 'ui/Icon/Icon';
 
 const EXECUTE_QUERY_SHORTCUT = getShortcutSymbols(
     KeyMap.queryEditor.runQuery.key
@@ -72,12 +73,12 @@ export const QueryRunButton = React.forwardRef<
                 icon={hasSelection ? null : 'play'}
                 aria-label={`Execute (${EXECUTE_QUERY_SHORTCUT})`}
                 data-balloon-pos={runButtonTooltipPos}
+                color="accent"
             />
         );
 
         return (
-            <div className="QueryRunButton flex-row">
-                {runButtonDOM}
+            <div className="QueryRunButton flex-row ml16">
                 <QueryEngineSelector
                     disabled={disabled}
                     queryEngineById={queryEngineById}
@@ -85,6 +86,7 @@ export const QueryRunButton = React.forwardRef<
                     engineId={engineId}
                     onEngineIdSelect={onEngineIdSelect}
                 />
+                {runButtonDOM}
             </div>
         );
     }
@@ -116,12 +118,15 @@ export const QueryEngineSelector: React.FC<IQueryEngineSelectorProps> = ({
         const queryEngineName = queryEngineById[engineId].name;
 
         return (
-            <div className="engine-selector-button flex-row">
-                <StatusIcon status={iconClass} />{' '}
-                <span>
-                    {queryEngineName}{' '}
-                    <i className="fa fa-caret-down caret-icon" />
-                </span>
+            <div className="engine-selector-button flex-center ph8">
+                <StatusIcon status={iconClass} />
+                <div className="ml4"> {queryEngineName}</div>
+                <Icon
+                    name="chevron-down"
+                    className="ml4"
+                    size={24}
+                    color="light"
+                />
             </div>
         );
     };

--- a/querybook/webapp/components/UserBadge/UserAvatar.tsx
+++ b/querybook/webapp/components/UserBadge/UserAvatar.tsx
@@ -18,13 +18,13 @@ export interface IUserAvatarComponentProps
     onClick?: () => any;
 }
 
-const defaultNoUserBackground = '#F65B50';
+const defaultNoUserBackground = '#909090';
 const defaultUserIconBackgrounds = [
-    '#FF6400',
-    '#FAB904',
-    '#0FA573',
-    '#4A90E2',
-    '#B469EB',
+    '#f683ad',
+    '#85d0ce',
+    '#bdda57',
+    '#ffd275',
+    '#f5ac72',
 ];
 
 function getUserIconBackgroundColor(name: string) {

--- a/querybook/webapp/index.scss
+++ b/querybook/webapp/index.scss
@@ -36,13 +36,11 @@
 }
 
 .empty-message {
-    margin-top: 20%;
-    padding: 0px 20%;
-    text-align: center;
-    font-size: var(--xxxlarge-text-size);
-    font-weight: bold;
-    color: var(--text-light);
-    user-select: none;
+    color: var(--text-lightest);
+    font-weight: var(--bold-font);
+    display: flex;
+    justify-content: center;
+    font-size: var(--xlarge-text-size);
 }
 
 .ReactVirtualized__Grid {

--- a/querybook/webapp/lib/utils/index.ts
+++ b/querybook/webapp/lib/utils/index.ts
@@ -293,10 +293,3 @@ export function getChangedObject(
 
     return ret;
 }
-
-export function getAbbrEnvName(name: string = '') {
-    const firstWordMatch = name.match(/([a-zA-Z0-9]+)/);
-    return firstWordMatch
-        ? firstWordMatch[1].slice(0, 10).toLocaleUpperCase()
-        : '';
-}

--- a/querybook/webapp/lib/utils/index.ts
+++ b/querybook/webapp/lib/utils/index.ts
@@ -293,3 +293,10 @@ export function getChangedObject(
 
     return ret;
 }
+
+export function getAbbrEnvName(name: string = '') {
+    const firstWordMatch = name.match(/([a-zA-Z0-9]+)/);
+    return firstWordMatch
+        ? firstWordMatch[1].slice(0, 10).toLocaleUpperCase()
+        : '';
+}

--- a/querybook/webapp/scss_variables.scss
+++ b/querybook/webapp/scss_variables.scss
@@ -18,7 +18,7 @@
 
     &::before {
         background: var(--bg-hover);
-        border-radius: var(--border-radius);
+        border-radius: var(--border-radius-sm);
         content: ' ' !important;
         height: 100%;
         left: 0;

--- a/querybook/webapp/stylesheets/_html.scss
+++ b/querybook/webapp/stylesheets/_html.scss
@@ -318,3 +318,7 @@ blockquote {
 ::-webkit-scrollbar-corner {
     background: rgba(0, 0, 0, 0);
 }
+
+::placeholder {
+    color: var(--text-lightest);
+}

--- a/querybook/webapp/stylesheets/_variables.scss
+++ b/querybook/webapp/stylesheets/_variables.scss
@@ -70,6 +70,7 @@ body {
     --text: var(--color-invert-2);
     --text-dark: var(--color-invert);
     --text-light: var(--color-invert-5);
+    --text-lightest: var(--color-primary-5);
     --text-hover: var(--color-invert-3);
 
     --text-title: var(--color-invert-3);
@@ -121,8 +122,8 @@ body {
     --bg-text-select: var(--color-transparent-light);
 
     --bg-terminal: var(--color-primary-1);
-    --bg-query-editor: var(--color-primary-1);
-    --bg-query-editor-gutter: var(--color-primary-2);
+    --bg-query-editor: var(--bg-lightest);
+    --bg-query-editor-gutter: var(--bg-light);
 
     // Colors: Special Elements
     --red-highlight: rgba(189, 8, 28, 0.5);

--- a/querybook/webapp/ui/Button/Button.tsx
+++ b/querybook/webapp/ui/Button/Button.tsx
@@ -12,7 +12,7 @@ import {
 
 export type ButtonProps = React.HTMLAttributes<HTMLSpanElement> &
     ISharedButtonProps & {
-        icon?: string | React.ComponentType<IIconProps>;
+        icon?: string | React.ReactElement<IIconProps>;
         title?: string;
         className?: string;
 

--- a/querybook/webapp/ui/Button/ButtonTheme.ts
+++ b/querybook/webapp/ui/Button/ButtonTheme.ts
@@ -21,17 +21,20 @@ interface IButtonColorConfig {
 
 const buttonThemeToProps: Record<ButtonColorType, IButtonColorConfig> = {
     confirm: {
-        primary: 'var(--color-true-dark)',
+        primary: 'var(--color-true)',
+        primaryHover: 'var(--color-true-dark)',
         secondary: 'var(--color-true-lightest-0)',
         secondaryHover: 'var(--color-true-lightest)',
     },
     cancel: {
-        primary: 'var(--color-false-dark)',
+        primary: 'var(--color-false)',
+        primaryHover: 'var(--color-false-dark)',
         secondary: 'var(--color-false-lightest-0)',
         secondaryHover: 'var(--color-false-lightest)',
     },
     accent: {
-        primary: 'var(--color-accent-dark)',
+        primary: 'var(--color-accent)',
+        primaryHover: 'var(--color-accent-dark)',
         secondary: 'var(--color-accent-lightest-0)',
         secondaryHover: 'var(--color-accent-lightest)',
     },

--- a/querybook/webapp/ui/Button/ButtonTheme.ts
+++ b/querybook/webapp/ui/Button/ButtonTheme.ts
@@ -22,27 +22,28 @@ interface IButtonColorConfig {
 const buttonThemeToProps: Record<ButtonColorType, IButtonColorConfig> = {
     confirm: {
         primary: 'var(--color-true-dark)',
-        secondary: 'var(--color-true-dark)',
-        secondaryHover: 'var(--color-true)',
+        secondary: 'var(--color-true-lightest-0)',
+        secondaryHover: 'var(--color-true-lightest)',
     },
     cancel: {
         primary: 'var(--color-false-dark)',
-        secondary: 'var(--color-false-dark)',
-        secondaryHover: 'var(--color-false)',
+        secondary: 'var(--color-false-lightest-0)',
+        secondaryHover: 'var(--color-false-lightest)',
     },
     accent: {
         primary: 'var(--color-accent-dark)',
-        secondary: 'var(--color-accent-light)',
+        secondary: 'var(--color-accent-lightest-0)',
+        secondaryHover: 'var(--color-accent-lightest)',
     },
     light: {
         primary: 'var(--text-light)',
-        primaryHover: 'var(--text)',
+        primaryHover: 'var(--text-hover)',
         secondary: 'var(--bg-lightest)',
         secondaryHover: 'var(--bg-hover)',
     },
     default: {
         primary: 'var(--text-light)',
-        primaryHover: 'var(--text)',
+        primaryHover: 'var(--text-hover)',
         secondary: 'var(--bg-light)',
         secondaryHover: 'var(--bg-hover)',
     },
@@ -66,7 +67,7 @@ export function computeStyleButtonProps(
                 colorConfig.secondaryHover || colorConfig.secondary;
         } else {
             themeProps.color = 'var(--bg)';
-            themeProps.hoverColor = 'var(--bg-light)';
+            themeProps.hoverColor = 'var(--text-hover)';
             themeProps.bgColor = colorConfig.primary;
             themeProps.hoverBgColor =
                 colorConfig.primaryHover || colorConfig.primary;
@@ -75,7 +76,7 @@ export function computeStyleButtonProps(
         themeProps.color = colorConfig.primary;
         themeProps.hoverColor = colorConfig.primaryHover || colorConfig.primary;
         themeProps.bgColor = 'transparent';
-        themeProps.hoverBgColor = 'var(--bg-light)';
+        themeProps.hoverBgColor = 'var(--bg-hover)';
     }
 
     return themeProps;

--- a/querybook/webapp/ui/Dropdown/Dropdown.scss
+++ b/querybook/webapp/ui/Dropdown/Dropdown.scss
@@ -7,6 +7,7 @@
     .Dropdown-trigger {
         cursor: pointer;
         display: flex;
+        justify-content: center;
     }
 
     .Dropdown-menu {
@@ -17,7 +18,7 @@
         z-index: 20;
         box-shadow: var(--box-shadow);
         border-radius: var(--border-radius-sm);
-        // overflow: hidden;
+        font-size: var(--small-text-size);
     }
 
     &.is-right {

--- a/querybook/webapp/ui/Dropdown/Dropdown.tsx
+++ b/querybook/webapp/ui/Dropdown/Dropdown.tsx
@@ -83,7 +83,7 @@ export const Dropdown: React.FunctionComponent<IProps> = ({
     const buttonDOM = customButtonRenderer ? (
         customButtonRenderer()
     ) : (
-        <IconButton icon={menuIcon} />
+        <IconButton icon={menuIcon} noPadding />
     );
 
     const customFormatClass = customButtonRenderer ? ' custom-format ' : '';

--- a/querybook/webapp/ui/Icon/Icon.scss
+++ b/querybook/webapp/ui/Icon/Icon.scss
@@ -23,6 +23,9 @@
     &.warning {
         color: var(--color-warning-dark);
     }
+    &.light {
+        color: var(--icon);
+    }
 }
 
 @keyframes loading {

--- a/querybook/webapp/ui/Icon/Icon.tsx
+++ b/querybook/webapp/ui/Icon/Icon.tsx
@@ -13,7 +13,7 @@ export interface IIconProps {
     color?: TButtonColors;
 }
 
-export type TButtonColors = 'accent' | 'true' | 'false' | 'warning';
+export type TButtonColors = 'accent' | 'true' | 'false' | 'warning' | 'light';
 
 export const Icon: React.FunctionComponent<IIconProps> = React.memo(
     ({

--- a/querybook/webapp/ui/Link/ListLink.scss
+++ b/querybook/webapp/ui/Link/ListLink.scss
@@ -3,7 +3,7 @@
 .ListLink {
     display: flex;
     align-items: center;
-    padding: 4px 10px 4px 4px;
+    padding: 4px;
     color: var(--text-dark);
     cursor: pointer;
     user-select: none;
@@ -12,7 +12,6 @@
     .ListLinkPlaceholder {
         flex-grow: 1;
         margin-left: 4px;
-        margin-right: 12px;
         font-size: var(--small-text-size);
         line-height: 27px;
         @include one-line-ellipsis();
@@ -26,21 +25,22 @@
         font-style: italic;
     }
 
-    .Icon {
-        flex-shrink: 1;
-        svg {
-            padding: 20%;
-        }
+    .ListLinkText + .Icon,
+    .Icon + .Icon {
+        margin-left: 8px;
     }
 
     &.row {
-        padding: 4.5px 10px 4.5px 4.5px;
         .ListLinkText,
         .ListLinkPlaceholder {
             line-height: normal;
             margin-left: 0px;
         }
+        .Icon + .ListLinkText {
+            margin-left: 4px !important;
+        }
     }
+
     &.selected {
         font-weight: var(--bold-font);
         color: var(--color-accent-dark);

--- a/querybook/webapp/ui/Link/ListLink.tsx
+++ b/querybook/webapp/ui/Link/ListLink.tsx
@@ -36,7 +36,7 @@ export const ListLink: React.FunctionComponent<IProps> = React.memo(
                 ) : placeholder ? (
                     <span className="ListLinkPlaceholder">{placeholder}</span>
                 ) : null}
-                {icon && <Icon name={icon} />}
+                {icon && <Icon name={icon} size={16} />}
                 {children}
             </Link>
         );

--- a/querybook/webapp/ui/Menu/Menu.scss
+++ b/querybook/webapp/ui/Menu/Menu.scss
@@ -24,6 +24,7 @@
 
         .Menu-icon {
             width: 18px;
+            margin-top: 2px;
         }
 
         &:hover {

--- a/querybook/webapp/ui/Popover/Popover.scss
+++ b/querybook/webapp/ui/Popover/Popover.scss
@@ -50,7 +50,7 @@
         border: var(--border);
         border-radius: var(--border-radius-sm);
         box-shadow: var(--box-shadow);
-        padding: var(--padding);
+        padding: var(--padding-lg);
         overflow: hidden;
 
         position: relative;

--- a/querybook/webapp/ui/ResizableTextArea/ResizableTextArea.tsx
+++ b/querybook/webapp/ui/ResizableTextArea/ResizableTextArea.tsx
@@ -21,7 +21,7 @@ export interface IResizableTextareaProps
 
 const StyledTextarea = styled.textarea`
     color: inherit;
-    border-radius: var(--border-radius);
+    border-radius: var(--border-radius-sm);
     border: var(--border);
     display: block;
     max-width: 100%;

--- a/querybook/webapp/ui/Table/Table.scss
+++ b/querybook/webapp/ui/Table/Table.scss
@@ -1,6 +1,6 @@
 .Table.ReactTable {
     border: none;
-    border-radius: var(--border-radius);
+    border-radius: var(--border-radius-sm);
     background: var(--bg-lightest);
     font-weight: 500;
     overflow: hidden;

--- a/querybook/webapp/ui/Tabs/Tabs.scss
+++ b/querybook/webapp/ui/Tabs/Tabs.scss
@@ -42,7 +42,7 @@
                 a {
                     color: var(--text);
                 }
-                &:not(.pills) {
+                &:not(&.pills) {
                     border-radius: var(--border-radius-sm);
                 }
             }
@@ -63,13 +63,13 @@
         ul {
             border-radius: var(--border-radius-sm);
             li {
-                background-color: var(--bg-lightest);
+                background-color: var(--bg-light);
                 padding: 4px 16px;
                 border-bottom: none;
 
                 &.active {
                     border-radius: 0px;
-                    background-color: var(--bg-light);
+                    background-color: var(--color-accent-lightest-0);
                     a {
                         color: var(--color-accent-dark);
                     }

--- a/querybook/webapp/ui/Tabs/Tabs.scss
+++ b/querybook/webapp/ui/Tabs/Tabs.scss
@@ -42,7 +42,14 @@
                 a {
                     color: var(--text);
                 }
-                &:not(&.pills) {
+            }
+        }
+    }
+
+    &:not(.pills) {
+        ul {
+            li {
+                &:not(.active):hover {
                     border-radius: var(--border-radius-sm);
                 }
             }

--- a/querybook/webapp/ui/Tag/Tag.scss
+++ b/querybook/webapp/ui/Tag/Tag.scss
@@ -7,7 +7,7 @@
 .TagGroup {
     display: inline-flex;
     margin: 2px 4px;
-    border-radius: var(--border-radius);
+    border-radius: var(--border-radius-sm);
     cursor: default;
 }
 


### PR DESCRIPTION
<img width="1791" alt="Screen Shot 2022-02-15 at 11 44 31 AM" src="https://user-images.githubusercontent.com/29313935/154137278-56ceb879-fa32-4bfb-8989-882074ddfcfe.png">

- update hover/non-hover states for query and chart cell
- update no data message
- update popovers for board list, viewer stats, access
- update table of contents
- move collapse/expand button
- update collapsed query ui
- some updates on navbar (listitems)


next step: datadoc modals