### PR TITLE
Remove empty space for tables in data docs

### DIFF
--- a/querybook/webapp/components/StatementResultTable/StatementResultTable.tsx
+++ b/querybook/webapp/components/StatementResultTable/StatementResultTable.tsx
@@ -145,6 +145,7 @@ export const StatementResultTable: React.FunctionComponent<{
     return (
         <StyledTableWrapper fontSize={tableFontSize}>
             <Table
+                minRows={0}
                 stickyHeader
                 className="-highlight force-scrollbar-x"
                 defaultPageSize={


### PR DESCRIPTION
As a QueryBook user we need to be able to review result sets quickly and easily in order to determine if we have the right data sets without exporting.

 

Right now the use of space can be frustrating to work with and annoying forcing users to do downloads.  Example:

The result screen (resultset) after executing the query will show the amount of free space allocated by the drop down and not the result amount itself.  So if I had 18 records but set 25
 it shows space for 25 instead of just 18

![exOld](https://user-images.githubusercontent.com/59963571/154950207-f3cbfef8-5bcb-49e1-8803-7f76710705a6.png)

![exNew](https://user-images.githubusercontent.com/59963571/154950197-3850071f-7d6a-4512-9fc3-bc166605784f.png)