### PR TITLE
fix: sidebar icon padding

### DIFF
--- a/querybook/webapp/components/EnvironmentAppSidebar/EntitySidebar.scss
+++ b/querybook/webapp/components/EnvironmentAppSidebar/EntitySidebar.scss
@@ -12,17 +12,18 @@
 
     .apps-list {
         margin-bottom: 8px;
-        > * {
-            padding-bottom: 4px;
-            display: flex;
-            justify-content: center;
-        }
         .IconButton,
         .QueryExecutionButton,
         .InfoMenuButton,
         .QueryEngineStatusButton,
         .UserMenu {
             width: 100%;
+        }
+
+        .IconButton {
+            padding-bottom: 4px;
+            display: flex;
+            justify-content: center;
         }
     }
     .sidebar-list {


### PR DESCRIPTION
Noticed the sidebar icons are not even height, some are 54px and some are 58px (if it is an IconButton inside a div or a tag)
Before
<img width="57" alt="image" src="https://user-images.githubusercontent.com/8283407/158701201-d4cd3b9f-846e-428e-91d5-1f6cb1db9e49.png">


After
<img width="66" alt="image" src="https://user-images.githubusercontent.com/8283407/158701143-9090b8e0-6f41-4567-92ea-80f6d1a175b6.png">
