### PR TITLE
patch: update Presto proxy auth behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.1.3",
+    "version": "3.1.4",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/lib/utils/utils.py
+++ b/querybook/server/lib/utils/utils.py
@@ -5,30 +5,8 @@ from datetime import datetime, date
 from functools import wraps
 
 from lib.logger import get_logger
-from requests.auth import HTTPBasicAuth, HTTPProxyAuth
-
 
 LOG = get_logger(__file__)
-
-
-# from: https://stackoverflow.com/questions/9026016/python-requests-library-combine-httpproxyauth-with-httpbasicauth
-class HTTPBasicAndProxyAuth:
-    def __init__(self, basic_up, proxy_up):
-        # basic_up is a tuple with username, password
-        self.basic_auth = HTTPBasicAuth(*basic_up)
-        # proxy_up is a tuple with proxy username, password
-        self.proxy_auth = HTTPProxyAuth(*proxy_up)
-
-    def __call__(self, r):
-        # this emulates what basicauth and proxyauth do in their __call__()
-        # first add r.headers['Authorization']
-        r = self.basic_auth(r)
-        # then add r.headers['Proxy-Authorization']
-        r = self.proxy_auth(r)
-        # and return the request, as the auth object should do
-        return r
-
-
 _epoch = datetime.utcfromtimestamp(0)
 
 


### PR DESCRIPTION
Presto user proxy can be done by passing a different principal user name directly. We will skip modifying the request's auth http header. This should not change any of the existing behaviors