### PR TITLE
FLOAT column type fails on Row Samples functionality

### DIFF
--- a/querybook/server/lib/query_analysis/samples.py
+++ b/querybook/server/lib/query_analysis/samples.py
@@ -200,6 +200,7 @@ common_sql_types = {
     "real": QuerybookColumnType.Number,
     "numeric": QuerybookColumnType.Number,
     "decimal": QuerybookColumnType.Number,
+    "float": QuerybookColumnType.Number,
     "double": QuerybookColumnType.Number,
     # Time
     "date": QuerybookColumnType.String,


### PR DESCRIPTION
When in the Row Samples feature, a user tries to generate samples filtering the data by some float column.
The UI displays a modal error and does not return the information.
By analyzing the API request, the generated query is treating the float column as a string, adding quotes around the value.