### PR TITLE
feat: add ability to swap lines in QueryEditor

### DIFF
--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -215,6 +215,9 @@ export class QueryEditor extends React.PureComponent<
                 [KeyMap.queryEditor.autocomplete.key]: 'autocomplete',
                 [KeyMap.queryEditor.indentLess.key]: 'indentLess',
                 [KeyMap.queryEditor.toggleComment.key]: 'toggleComment',
+                [KeyMap.queryEditor.swapLineUp.key]: 'swapLineUp',
+                [KeyMap.queryEditor.swapLineDown.key]: 'swapLineDown',
+
                 [KeyMap.queryEditor.openTable.key]: this.onOpenTableModal,
                 [KeyMap.queryEditor.formatQuery.key]: this.formatQuery,
                 ...keyMap,

--- a/querybook/webapp/const/keyMap.ts
+++ b/querybook/webapp/const/keyMap.ts
@@ -92,6 +92,15 @@ const DEFAULT_KEY_MAP = {
             key: 'Cmd-/',
             name: 'Toggle comment',
         },
+        swapLineUp: {
+            key: 'Alt-Up',
+            name: 'Swap current line with the previous line',
+        },
+        swapLineDown: {
+            key: 'Alt-Down',
+            name: 'Swap current line with the next line',
+        },
+
         openTable: {
             key: 'Cmd-P',
             name: 'Open table modal if on a table',

--- a/querybook/webapp/lib/codemirror/custom-commands.ts
+++ b/querybook/webapp/lib/codemirror/custom-commands.ts
@@ -1,0 +1,101 @@
+import { CommandActions, Pos, Pass } from 'codemirror';
+
+export function attachCustomCommand(commands: CommandActions) {
+    // Copied from https://github.com/codemirror/CodeMirror/blob/bd1b7d2976d768ae4e3b8cf209ec59ad73c0305a/keymap/sublime.js#L244
+    (commands as any).swapLineUp = (cm) => {
+        if (cm.isReadOnly()) {
+            return Pass;
+        }
+        const ranges = cm.listSelections();
+        const linesToMove = [];
+        let at = cm.firstLine() - 1;
+        const newSels = [];
+        // eslint-disable-next-line @typescript-eslint/prefer-for-of
+        for (let i = 0; i < ranges.length; i++) {
+            const range = ranges[i];
+            const from = range.from().line - 1;
+            let to = range.to().line;
+            newSels.push({
+                anchor: Pos(range.anchor.line - 1, range.anchor.ch),
+                head: Pos(range.head.line - 1, range.head.ch),
+            });
+            if (range.to().ch === 0 && !range.empty()) {
+                --to;
+            }
+            if (from > at) {
+                linesToMove.push(from, to);
+            } else if (linesToMove.length) {
+                linesToMove[linesToMove.length - 1] = to;
+            }
+            at = to;
+        }
+        cm.operation(() => {
+            for (let i = 0; i < linesToMove.length; i += 2) {
+                const from = linesToMove[i];
+                const to = linesToMove[i + 1];
+                const line = cm.getLine(from);
+                cm.replaceRange(
+                    '',
+                    Pos(from, 0),
+                    Pos(from + 1, 0),
+                    '+swapLine'
+                );
+                if (to > cm.lastLine()) {
+                    cm.replaceRange(
+                        '\n' + line,
+                        Pos(cm.lastLine()),
+                        null,
+                        '+swapLine'
+                    );
+                } else {
+                    cm.replaceRange(line + '\n', Pos(to, 0), null, '+swapLine');
+                }
+            }
+            cm.setSelections(newSels);
+            cm.scrollIntoView();
+        });
+    };
+
+    // Copied from https://github.com/codemirror/CodeMirror/blob/bd1b7d2976d768ae4e3b8cf209ec59ad73c0305a/keymap/sublime.js#L271
+    (commands as any).swapLineDown = (cm) => {
+        if (cm.isReadOnly()) {
+            return Pass;
+        }
+        const ranges = cm.listSelections();
+        const linesToMove = [];
+        let at = cm.lastLine() + 1;
+        for (let i = ranges.length - 1; i >= 0; i--) {
+            const range = ranges[i];
+            let from = range.to().line + 1;
+            const to = range.from().line;
+            if (range.to().ch === 0 && !range.empty()) {
+                from--;
+            }
+            if (from < at) {
+                linesToMove.push(from, to);
+            } else if (linesToMove.length) {
+                linesToMove[linesToMove.length - 1] = to;
+            }
+            at = to;
+        }
+        cm.operation(() => {
+            for (let i = linesToMove.length - 2; i >= 0; i -= 2) {
+                const from = linesToMove[i];
+                const to = linesToMove[i + 1];
+                const line = cm.getLine(from);
+                if (from === cm.lastLine()) {
+                    cm.replaceRange('', Pos(from - 1), Pos(from), '+swapLine');
+                } else {
+                    cm.replaceRange(
+                        '',
+                        Pos(from, 0),
+                        Pos(from + 1, 0),
+                        '+swapLine'
+                    );
+                }
+                cm.replaceRange(line + '\n', Pos(to, 0), null, '+swapLine');
+            }
+            cm.scrollIntoView();
+        });
+    };
+}

--- a/querybook/webapp/lib/codemirror/index.ts
+++ b/querybook/webapp/lib/codemirror/index.ts
@@ -31,9 +31,11 @@ import 'codemirror/addon/runmode/runmode';
 // Search highlighting
 import 'codemirror/addon/search/match-highlighter.js';
 
+// Custom editor command
+import { attachCustomCommand } from './custom-commands';
+
 // Local styling
 import './editor_styles.scss';
-import { attachCustomCommand } from './custom-commands';
 
 declare module 'codemirror' {
     // This is copied from runmode.d.ts. Not sure how to import it :(

--- a/querybook/webapp/lib/codemirror/index.ts
+++ b/querybook/webapp/lib/codemirror/index.ts
@@ -33,6 +33,7 @@ import 'codemirror/addon/search/match-highlighter.js';
 
 // Local styling
 import './editor_styles.scss';
+import { attachCustomCommand } from './custom-commands';
 
 declare module 'codemirror' {
     // This is copied from runmode.d.ts. Not sure how to import it :(
@@ -47,6 +48,8 @@ declare module 'codemirror' {
         keyMap: Record<string, string | (() => any)>
     ): Record<string, string | (() => any)>;
 }
+
+attachCustomCommand(CodeMirror.commands);
 
 export default CodeMirror;
 


### PR DESCRIPTION
This is achieved by reusing the sublime keymap implementation provided here: https://github.com/codemirror/CodeMirror/blob/bd1b7d2976d768ae4e3b8cf209ec59ad73c0305a/keymap/sublime.js#L271