### PR TITLE
fix: UI update key

### DIFF
--- a/querybook/webapp/const/keyMap.ts
+++ b/querybook/webapp/const/keyMap.ts
@@ -1,4 +1,5 @@
 import { merge } from 'lodash';
+import { isOSX } from 'lib/utils/os-platform';
 
 const DEFAULT_KEY_MAP = {
     overallUI: {
@@ -121,5 +122,25 @@ const DEFAULT_KEY_MAP = {
         },
     },
 };
+
+/**
+ * The default keymap is only MacOSX specific, however CMD auto maps
+ * to CTRL unless it is CodeMirror
+ *
+ * So for Windows (and linux?) we will convert the keymap for queryEditors
+ * to ensure it is compatible for other platforms as well
+ */
+if (!isOSX) {
+    const queryEditorConfig = DEFAULT_KEY_MAP.queryEditor;
+    for (const [_, keyConfig] of Object.entries(queryEditorConfig)) {
+        const keyConfigParts = keyConfig.key.split('-');
+        if (keyConfigParts.includes('Cmd')) {
+            // Swap Cmd with Ctrl
+            keyConfig.key = keyConfigParts
+                .map((part) => (part === 'Cmd' ? 'Ctrl' : part))
+                .join('-');
+        }
+    }
+}
 
 export default merge(DEFAULT_KEY_MAP, window.CUSTOM_KEY_MAP);

--- a/querybook/webapp/lib/utils/keyboard.ts
+++ b/querybook/webapp/lib/utils/keyboard.ts
@@ -1,8 +1,7 @@
 import { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { isOSX } from './os-platform';
 
 type AllKeyboardEvent = KeyboardEvent | ReactKeyboardEvent;
-
-export const isOSX = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
 
 const specialKeyChecker: Record<string, (e: AllKeyboardEvent) => boolean> = {
     CMD: (event: AllKeyboardEvent) => (isOSX ? event.metaKey : event.ctrlKey),

--- a/querybook/webapp/lib/utils/os-platform.ts
+++ b/querybook/webapp/lib/utils/os-platform.ts
@@ -1,0 +1,1 @@
+export const isOSX = navigator.platform.toUpperCase().indexOf('MAC') >= 0;


### PR DESCRIPTION
cmd+/ is wrongly passed for windows version of codemirror, pass in ctrl+/ instead