### PR TITLE
ui: various ui updates

### DIFF
--- a/querybook/webapp/__tests__/ui/__snapshots__/KeyboardKey.test.js.snap
+++ b/querybook/webapp/__tests__/ui/__snapshots__/KeyboardKey.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`matches enzyme snapshots matches snapshot 1`] = `
 <KeyboardKey__StyledKeyboardKey>
-  TEST
+  test
 </KeyboardKey__StyledKeyboardKey>
 `;
 
@@ -10,6 +10,6 @@ exports[`matches test renderer snapshot serializes the styles 1`] = `
 <span
   className="KeyboardKey__StyledKeyboardKey-sc-1o6e5rh-0 fqnvqI KeyboardKey mr4"
 >
-  TEST
+  test
 </span>
 `;

--- a/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
+++ b/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
@@ -11,7 +11,7 @@ import { DataTableViewMini } from 'components/DataTableViewMini/DataTableViewMin
 
 import { Level } from 'ui/Level/Level';
 import { IconButton } from 'ui/Button/IconButton';
-
+import { InfoButton } from 'ui/Button/InfoButton';
 import './DataDocLeftSidebar.scss';
 interface IProps {
     docId: number;
@@ -60,7 +60,13 @@ export const DataDocLeftSidebar: React.FunctionComponent<IProps> = ({
                         icon="ArrowLeft"
                         onClick={() => setContentState('default')}
                     />
-                    <div>contents</div>
+                    <div>
+                        <span className="mr4">contents</span>
+                        <InfoButton layout={['right', 'top']}>
+                            Click to jump to the corresponding cell. Drag cells
+                            to reorder them.
+                        </InfoButton>
+                    </div>
                 </Level>
                 <DataDocContents cells={cells} docId={docId} />
             </div>

--- a/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
+++ b/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
@@ -60,7 +60,7 @@ export const DataDocLeftSidebar: React.FunctionComponent<IProps> = ({
                         icon="ArrowLeft"
                         onClick={() => setContentState('default')}
                     />
-                    <div>
+                    <div className="flex-row">
                         <span className="mr4">contents</span>
                         <InfoButton layout={['right', 'top']}>
                             Click to jump to the corresponding cell. Drag cells

--- a/querybook/webapp/components/DataDocScheduleList/DataDocScheduleList.tsx
+++ b/querybook/webapp/components/DataDocScheduleList/DataDocScheduleList.tsx
@@ -9,6 +9,7 @@ import { Pagination } from 'ui/Pagination/Pagination';
 import { DebouncedInput } from 'ui/DebouncedInput/DebouncedInput';
 import { Checkbox } from 'ui/Checkbox/Checkbox';
 import { Container } from 'ui/Container/Container';
+import { EmptyText } from 'ui/StyledText/StyledText';
 
 import './DataDocScheduleList.scss';
 
@@ -125,6 +126,13 @@ const DataDocScheduleList: React.FC = () => {
                         key={docWithSchedule.doc.id}
                     />
                 ))}
+                {dataDocsWithSchedule.length === 0 && (
+                    <EmptyText>
+                        {filters.scheduled_only
+                            ? 'No scheduled DataDocs found'
+                            : 'No DataDocs found'}
+                    </EmptyText>
+                )}
                 {totalPages > 1 && (
                     <Pagination
                         currentPage={page}

--- a/querybook/webapp/components/DataDocScheduleList/DataDocScheduleList.tsx
+++ b/querybook/webapp/components/DataDocScheduleList/DataDocScheduleList.tsx
@@ -129,8 +129,8 @@ const DataDocScheduleList: React.FC = () => {
                 {dataDocsWithSchedule.length === 0 && (
                     <EmptyText>
                         {filters.scheduled_only
-                            ? 'No scheduled DataDocs found'
-                            : 'No DataDocs found'}
+                            ? 'No Scheduled DataDocs'
+                            : 'No DataDocs'}
                     </EmptyText>
                 )}
                 {totalPages > 1 && (

--- a/querybook/webapp/lib/utils/keyboard.ts
+++ b/querybook/webapp/lib/utils/keyboard.ts
@@ -77,11 +77,11 @@ export function getKeySymbol(key: string) {
         ? SpecialKeyToSymbol.OSX
         : SpecialKeyToSymbol.Windows;
 
-    return upperKey in specialKeyMap ? specialKeyMap[upperKey] : upperKey;
+    return upperKey in specialKeyMap ? specialKeyMap[upperKey] : key;
 }
 
 export function getShortcutSymbols(keyString: string) {
-    return keyString.split('-').map(getKeySymbol).join('');
+    return keyString.split('-').map(getKeySymbol).join(' ');
 }
 
 export { default as KeyMap } from 'const/keyMap';

--- a/querybook/webapp/redux/scheduledDataDoc/types.ts
+++ b/querybook/webapp/redux/scheduledDataDoc/types.ts
@@ -14,8 +14,8 @@ export interface IScheduledDocFilters {
 }
 export interface IScheduledDoc {
     doc: IDataDoc;
-    last_record: ITaskStatusRecord;
-    schedule: ITaskSchedule;
+    last_record?: ITaskStatusRecord;
+    schedule?: ITaskSchedule;
 }
 
 export interface IReceiveDocWithScheduleAction extends Action {

--- a/querybook/webapp/ui/StyledText/StyledText.tsx
+++ b/querybook/webapp/ui/StyledText/StyledText.tsx
@@ -208,6 +208,7 @@ export const EmptyText: React.FunctionComponent<IStyledTextProps> = ({
         weight="bold"
         size="large"
         center
+        noUserSelect
         {...elementProps}
     >
         {children}


### PR DESCRIPTION
- Show tooltip about how to use data doc contents (table of contents) 
![image](https://user-images.githubusercontent.com/8283407/159768078-deac1156-2eaa-486b-a030-fc0af93593b8.png)
- Show Empty message if there are no scheduled docs
    - Also remove user select for empty message
- Make keyboard shortcuts slightly more readable 