### PR TITLE
Add drag n drop for database names

### DIFF
--- a/querybook/webapp/components/DataTableNavigator/DataTableNavigator.tsx
+++ b/querybook/webapp/components/DataTableNavigator/DataTableNavigator.tsx
@@ -15,7 +15,7 @@ import { currentEnvironmentSelector } from 'redux/environment/selector';
 import { Dispatch, IStoreState } from 'redux/store/types';
 import { UrlContextMenu } from 'ui/ContextMenu/UrlContextMenu';
 import { InfinityScroll } from 'ui/InfinityScroll/InfinityScroll';
-import { ListLink } from 'ui/Link/ListLink';
+import { TableListLink } from 'ui/Link/TableListLink';
 import { Popover } from 'ui/Popover/Popover';
 import { PopoverHoverWrapper } from 'ui/Popover/PopoverHoverWrapper';
 import { makeSelectOptions, Select } from 'ui/Select/Select';
@@ -183,13 +183,13 @@ export const DataTableNavigator: React.FC<IDataTableNavigatorProps> = ({
                 <PopoverHoverWrapper>
                     {(showPopover, anchorElement) => (
                         <>
-                            <ListLink
+                            <TableListLink
                                 className={className}
                                 onClick={(event) =>
                                     handleTableRowClick(table.id, event)
                                 }
-                                isRow
                                 title={table.full_name}
+                                schema={table.schema}
                             />
                             <UrlContextMenu
                                 url={tableUrl}

--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -637,8 +637,18 @@ export class QueryEditor extends React.PureComponent<
                     onKeyDown={this.onKeyDown}
                     onFocus={this.onFocus}
                     onBlur={this.onBlur}
+                    onDrop={this.onDropHandler}
                 />
             </StyledQueryEditor>
         );
+    }
+
+    private onDropHandler(editor, event) {
+        editor.focus();
+        const { pageX, pageY } = event;
+        editor.setCursor(editor.coordsChar({ left: pageX, top: pageY }));
+
+        const databaseName = event.dataTransfer.getData('fullDBName');
+        editor.replaceRange(` ${databaseName} `, editor.getCursor());
     }
 }

--- a/querybook/webapp/ui/Link/Link.tsx
+++ b/querybook/webapp/ui/Link/Link.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { stopPropagation as stopPropagationFunc } from 'lib/utils/noop';
 
-const StyledLink = styled('a')`
+export const StyledLink = styled('a')`
     ${({ naturalLink }) =>
         naturalLink &&
         `

--- a/querybook/webapp/ui/Link/TableLink.tsx
+++ b/querybook/webapp/ui/Link/TableLink.tsx
@@ -1,0 +1,50 @@
+import React, { useCallback } from 'react';
+import { StyledLink } from './Link';
+import { useDrag } from 'react-dnd';
+
+export interface ILinkProps {
+    onClick: (to: React.MouseEvent) => any;
+    fullDBName: string;
+}
+
+export const TableLink: React.FC<ILinkProps> = ({
+    onClick,
+    children,
+    fullDBName,
+}) => {
+    const [, drag] = useDrag({
+        type: 'dbName',
+        item: {
+            type: 'dbName',
+        },
+    });
+
+    const handleClick = useCallback(
+        (e: React.MouseEvent<HTMLAnchorElement>) => {
+            if (e.button !== 0) {
+                // If it is not a left click, ignore
+                return;
+            }
+
+            onClick(e);
+        },
+        [onClick]
+    );
+
+    const handleDragStart = useCallback(
+        (e) => {
+            e.dataTransfer.setData('fullDBName', fullDBName);
+        },
+        [fullDBName]
+    );
+
+    return (
+        <StyledLink
+            ref={drag}
+            onDragStart={handleDragStart}
+            onMouseDown={handleClick}
+        >
+            {children}
+        </StyledLink>
+    );
+};

--- a/querybook/webapp/ui/Link/TableListLink.tsx
+++ b/querybook/webapp/ui/Link/TableListLink.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import { StyledText } from 'ui/StyledText/StyledText';
+import { ILinkProps } from './Link';
+import { TableLink } from './TableLink';
+
+import './ListLink.scss';
+
+interface IProps extends ILinkProps {
+    title: string;
+    schema: string;
+    onClick: (to: React.MouseEvent) => any;
+}
+
+export const TableListLink: React.FunctionComponent<IProps> = React.memo(
+    ({ title, children, schema, onClick }) => {
+        return (
+            <TableLink fullDBName={`${schema}.${title}`} onClick={onClick}>
+                <StyledText className="ListLinkText" size="small">
+                    {title}
+                </StyledText>
+
+                {children}
+            </TableLink>
+        );
+    }
+);


### PR DESCRIPTION
As a QueryBook user I would like a option when you can insert table names to the query interfaces (adhoc/Datadoc) to improve efficiency from browsing tables to querying them.
This commit is added a drag and drop feature to querybook.
![Снимок экрана от 2022-03-24 17-51-10](https://user-images.githubusercontent.com/59963571/159960823-ac846ee3-78bc-41bc-b606-0f97965cfc48.jpg)

