### PR TITLE
feat: Allow users to manually refresh metastore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
+++ b/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
@@ -64,9 +64,9 @@ function useRefreshMetastore(table: IDataTable) {
         refreshRequest.finally(() => setIsRefreshing(false));
 
         toast.promise(refreshRequest, {
-            loading: 'Refreshing table from metastore...',
+            loading: 'Refreshing table from metastore',
             success: 'Successfully updated table!',
-            error: 'Failed to update table from Metastore',
+            error: 'Failed to update table from metastore',
         });
     }, [dispatch, table.id]);
 

--- a/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
+++ b/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
@@ -1,5 +1,4 @@
-import React, { useCallback } from 'react';
-import { bind } from 'lodash-decorators';
+import React, { useCallback, useState } from 'react';
 import * as DraftJs from 'draft-js';
 
 import {
@@ -14,6 +13,7 @@ import { generateFormattedDate } from 'lib/utils/datetime';
 import { getAppName } from 'lib/utils/global';
 import { titleize } from 'lib/utils';
 import { getHumanReadableByteSize } from 'lib/utils/number';
+import { useDispatch } from 'react-redux';
 
 import {
     DataTableStats,
@@ -23,7 +23,7 @@ import {
     DataTableViewQueryUsers,
     useLoadQueryUsers,
 } from 'components/DataTableViewQueryExample/DataTableViewQueryUsers';
-import { TextButton } from 'ui/Button/Button';
+import { SoftButton, TextButton } from 'ui/Button/Button';
 import { EditableTextField } from 'ui/EditableTextField/EditableTextField';
 import { Message } from 'ui/Message/Message';
 import './DataTableViewOverview.scss';
@@ -36,6 +36,8 @@ import {
 } from 'components/DataTableViewQueryExample/DataTableViewQueryEngines';
 import { ShowMoreText } from 'ui/ShowMoreText/ShowMoreText';
 import { KeyContentDisplay } from 'ui/KeyContentDisplay/KeyContentDisplay';
+import { refreshDataTableInMetastore } from 'redux/dataSources/action';
+import toast from 'react-hot-toast';
 
 const dataTableDetailsRows = [
     'type',
@@ -49,6 +51,27 @@ const dataTableDetailsRows = [
     'location',
     'column_count',
 ];
+
+function useRefreshMetastore(table: IDataTable) {
+    const dispatch = useDispatch();
+    const [isRefreshing, setIsRefreshing] = useState(false);
+
+    const handleRefreshTable = useCallback(() => {
+        setIsRefreshing(true);
+        const refreshRequest = (dispatch(
+            refreshDataTableInMetastore(table.id)
+        ) as unknown) as Promise<void>;
+        refreshRequest.finally(() => setIsRefreshing(false));
+
+        toast.promise(refreshRequest, {
+            loading: 'Refreshing table from metastore...',
+            success: 'Successfully updated table!',
+            error: 'Failed to update table from Metastore',
+        });
+    }, [dispatch, table.id]);
+
+    return [handleRefreshTable, isRefreshing] as const;
+}
 
 export interface IQuerybookTableViewOverviewProps {
     table: IDataTable;
@@ -64,148 +87,158 @@ export interface IQuerybookTableViewOverviewProps {
     onExampleFilter: (params: IPaginatedQuerySampleFilters) => any;
 }
 
-export class DataTableViewOverview extends React.PureComponent<IQuerybookTableViewOverviewProps> {
-    @bind
-    public onDescriptionSave(description: DraftJs.ContentState) {
-        const table = this.props.table;
-        return this.props.updateDataTableDescription(table.id, description);
-    }
+export const DataTableViewOverview: React.FC<IQuerybookTableViewOverviewProps> = ({
+    table,
+    tableName,
+    tableWarnings,
+    onExampleFilter,
+    updateDataTableDescription,
+}) => {
+    const onDescriptionSave = useCallback(
+        (description: DraftJs.ContentState) =>
+            updateDataTableDescription(table.id, description),
+        [updateDataTableDescription, table]
+    );
 
-    public render() {
-        const { table, tableName, tableWarnings, onExampleFilter } = this.props;
-        const description = table.description ? (
-            <EditableTextField
-                value={table.description as DraftJs.ContentState}
-                onSave={this.onDescriptionSave}
-            />
-        ) : null;
+    const [handleRefreshTable, isRefreshingTable] = useRefreshMetastore(table);
 
-        const detailsDOM = dataTableDetailsRows
-            .filter((row) => table[row] != null)
-            .map((row) => {
-                let value: string = '';
-                switch (row) {
-                    case 'table_created_at':
-                    case 'table_updated_at': {
-                        value = table[row]
-                            ? generateFormattedDate(table[row])
-                            : '';
-                        break;
-                    }
-                    case 'data_size_bytes': {
-                        value = getHumanReadableByteSize(table[row]);
-                        break;
-                    }
-                    default:
-                        value = table[row];
+    const description = table.description ? (
+        <EditableTextField
+            value={table.description as DraftJs.ContentState}
+            onSave={onDescriptionSave}
+        />
+    ) : null;
+
+    const detailsDOM = dataTableDetailsRows
+        .filter((row) => table[row] != null)
+        .map((row) => {
+            let value: string = '';
+            switch (row) {
+                case 'table_created_at':
+                case 'table_updated_at': {
+                    value = table[row] ? generateFormattedDate(table[row]) : '';
+                    break;
                 }
-                return (
-                    <KeyContentDisplay
-                        key={row}
-                        keyString={titleize(row, '_', ' ')}
-                    >
-                        {value}
-                    </KeyContentDisplay>
-                );
-            });
-
-        const rawMetastoreInfoDOM = table.hive_metastore_description ? (
-            <pre>
-                <ShowMoreText
-                    seeLess
-                    length={200}
-                    text={table.hive_metastore_description}
-                />
-            </pre>
-        ) : null;
-
-        const descriptionSection = (
-            <DataTableViewOverviewSection title="Description">
-                {description}
-            </DataTableViewOverviewSection>
-        );
-
-        const metaSection = (
-            <DataTableViewOverviewSection title="Meta info">
+                case 'data_size_bytes': {
+                    value = getHumanReadableByteSize(table[row]);
+                    break;
+                }
+                default:
+                    value = table[row];
+            }
+            return (
                 <KeyContentDisplay
-                    key="created"
-                    keyString={`First created in ${getAppName()}`}
+                    key={row}
+                    keyString={titleize(row, '_', ' ')}
                 >
-                    {generateFormattedDate(table.created_at)}
+                    {value}
                 </KeyContentDisplay>
-                <KeyContentDisplay
-                    key="pulled"
-                    keyString="Last pulled from metastore"
-                >
-                    {generateFormattedDate(table.updated_at)}
-                </KeyContentDisplay>
-            </DataTableViewOverviewSection>
-        );
-        const detailsSection = (
-            <DataTableViewOverviewSection title="Details">
-                {detailsDOM}
-            </DataTableViewOverviewSection>
-        );
+            );
+        });
 
-        const hiveMetastoreSection = (
-            <DataTableViewOverviewSection title="Raw Metastore Info">
-                {rawMetastoreInfoDOM}
-            </DataTableViewOverviewSection>
-        );
+    const rawMetastoreInfoDOM = table.hive_metastore_description ? (
+        <pre>
+            <ShowMoreText
+                seeLess
+                length={200}
+                text={table.hive_metastore_description}
+            />
+        </pre>
+    ) : null;
 
-        const sampleQueriesSection = (
-            <DataTableViewOverviewSection title="Sample DataDocs">
-                <TextButton
-                    onClick={() =>
-                        navigateWithinEnv(
-                            `/search/?searchType=DataDoc&searchString=${tableName}`,
-                            {
-                                isModal: true,
-                            }
-                        )
-                    }
-                >
-                    View Sample DataDocs
-                </TextButton>
-            </DataTableViewOverviewSection>
-        );
+    const descriptionSection = (
+        <DataTableViewOverviewSection title="Description">
+            {description}
+        </DataTableViewOverviewSection>
+    );
 
-        const warningSection = tableWarnings.length ? (
-            <DataTableViewOverviewSection title="User Warnings">
-                <>
-                    {tableWarnings.map((warning) => {
-                        const isError =
-                            warning.severity === DataTableWarningSeverity.ERROR;
-                        return (
-                            <Message
-                                key={warning.id}
-                                title={isError ? 'Error' : 'Warning'}
-                                message={warning.message}
-                                type={isError ? 'error' : 'warning'}
-                            />
-                        );
-                    })}
-                </>
-            </DataTableViewOverviewSection>
-        ) : null;
+    const metaSection = (
+        <DataTableViewOverviewSection title="Meta info">
+            <KeyContentDisplay
+                key="created"
+                keyString={`First created in ${getAppName()}`}
+            >
+                {generateFormattedDate(table.created_at)}
+            </KeyContentDisplay>
+            <KeyContentDisplay
+                key="pulled"
+                keyString="Last pulled from metastore"
+            >
+                {generateFormattedDate(table.updated_at)}
+            </KeyContentDisplay>
+            <SoftButton
+                className="mt8"
+                icon="RefreshCw"
+                title="Refresh from metastore"
+                onClick={handleRefreshTable}
+                disabled={isRefreshingTable}
+            />
+        </DataTableViewOverviewSection>
+    );
+    const detailsSection = (
+        <DataTableViewOverviewSection title="Details">
+            {detailsDOM}
+        </DataTableViewOverviewSection>
+    );
 
-        return (
-            <div className="QuerybookTableViewOverview pb24">
-                {warningSection}
-                {descriptionSection}
-                <TableInsightsSection
-                    tableId={table.id}
-                    onClick={onExampleFilter}
-                />
-                {detailsSection}
-                <TableStatsSection tableId={table.id} />
-                {hiveMetastoreSection}
-                {metaSection}
-                {sampleQueriesSection}
-            </div>
-        );
-    }
-}
+    const hiveMetastoreSection = (
+        <DataTableViewOverviewSection title="Raw Metastore Info">
+            {rawMetastoreInfoDOM}
+        </DataTableViewOverviewSection>
+    );
+
+    const sampleQueriesSection = (
+        <DataTableViewOverviewSection title="Sample DataDocs">
+            <TextButton
+                onClick={() =>
+                    navigateWithinEnv(
+                        `/search/?searchType=DataDoc&searchString=${tableName}`,
+                        {
+                            isModal: true,
+                        }
+                    )
+                }
+            >
+                View Sample DataDocs
+            </TextButton>
+        </DataTableViewOverviewSection>
+    );
+
+    const warningSection = tableWarnings.length ? (
+        <DataTableViewOverviewSection title="User Warnings">
+            <>
+                {tableWarnings.map((warning) => {
+                    const isError =
+                        warning.severity === DataTableWarningSeverity.ERROR;
+                    return (
+                        <Message
+                            key={warning.id}
+                            title={isError ? 'Error' : 'Warning'}
+                            message={warning.message}
+                            type={isError ? 'error' : 'warning'}
+                        />
+                    );
+                })}
+            </>
+        </DataTableViewOverviewSection>
+    ) : null;
+
+    return (
+        <div className="QuerybookTableViewOverview pb24">
+            {warningSection}
+            {descriptionSection}
+            <TableInsightsSection
+                tableId={table.id}
+                onClick={onExampleFilter}
+            />
+            {detailsSection}
+            <TableStatsSection tableId={table.id} />
+            {hiveMetastoreSection}
+            {metaSection}
+            {sampleQueriesSection}
+        </div>
+    );
+};
 
 const TableInsightsSection: React.FC<{
     tableId: number;

--- a/querybook/webapp/redux/dataSources/action.ts
+++ b/querybook/webapp/redux/dataSources/action.ts
@@ -84,25 +84,27 @@ export function fetchQueryMetastore(): ThunkResult<Promise<IQueryMetastore[]>> {
     };
 }
 
+function receiveRawDataTable(rawTable: IDataTable) {
+    const normalizedData = normalize(rawTable, dataTableSchema);
+    const {
+        dataSchema = {},
+        dataTable = {},
+        dataColumn = {},
+        dataTableWarning = {},
+    } = normalizedData.entities;
+
+    return receiveDataTable(
+        dataSchema,
+        dataTable,
+        dataColumn,
+        dataTableWarning
+    );
+}
+
 export function fetchDataTable(tableId: number): ThunkResult<Promise<any>> {
     return async (dispatch) => {
         const { data } = await TableResource.get(tableId);
-        const normalizedData = normalize(data, dataTableSchema);
-        const {
-            dataSchema = {},
-            dataTable = {},
-            dataColumn = {},
-            dataTableWarning = {},
-        } = normalizedData.entities;
-
-        dispatch(
-            receiveDataTable(
-                dataSchema,
-                dataTable,
-                dataColumn,
-                dataTableWarning
-            )
-        );
+        dispatch(receiveRawDataTable(data));
     };
 }
 
@@ -119,6 +121,15 @@ export function fetchDataTableIfNeeded(
                 return Promise.resolve(table);
             }
         }
+    };
+}
+
+export function refreshDataTableInMetastore(
+    tableId: number
+): ThunkResult<Promise<void>> {
+    return async (dispatch) => {
+        const { data } = await TableResource.refresh(tableId);
+        dispatch(receiveRawDataTable(data));
     };
 }
 

--- a/querybook/webapp/resource/table.ts
+++ b/querybook/webapp/resource/table.ts
@@ -143,6 +143,9 @@ export const TableResource = {
 
         return ds.update<IDataTable>(`/table/${tableId}/`, params);
     },
+
+    refresh: (tableId: number) =>
+        ds.update<IDataTable>(`/table/${tableId}/refresh/`),
 };
 
 export const TableColumnResource = {


### PR DESCRIPTION
Now users can directly make metastore loader load the table:
<img width="1461" alt="image" src="https://user-images.githubusercontent.com/8283407/160932862-f89d8060-23dc-479e-9092-9cb8110a6114.png">
<img width="325" alt="image" src="https://user-images.githubusercontent.com/8283407/160932897-3eac7959-e708-477e-b5d3-732449ed4d86.png">
