### PR TITLE
fix: Change Loader to loader for admin metastore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.2.5",
+    "version": "3.2.6",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/components/AppAdmin/AdminMetastore.tsx
+++ b/querybook/webapp/components/AppAdmin/AdminMetastore.tsx
@@ -266,7 +266,7 @@ export const AdminMetastore: React.FunctionComponent<IProps> = ({
                     <div className="AdminForm-left">
                         <SimpleField
                             stacked
-                            name="Loader"
+                            name="loader"
                             type="react-select"
                             options={Object.values(metastoreLoaders).map(
                                 (l) => ({


### PR DESCRIPTION
Loader was used which causes the select option to never show up