### PR TITLE
fix: add pseudo element between nested menus

### DIFF
--- a/querybook/webapp/ui/Dropdown/Dropdown.scss
+++ b/querybook/webapp/ui/Dropdown/Dropdown.scss
@@ -39,16 +39,30 @@
 
     &.Dropdown-nested-menu {
         .Dropdown-menu {
+            display: flex;
             top: 0px;
-            left: 0px;
-            margin-left: calc(100% + 8px);
         }
-    }
-    &.Dropdown-nested-menu.nested-right {
-        .Dropdown-menu {
-            left: auto;
-            right: 0px;
-            margin-right: calc(100% + 8px);
+        &:not(.nested-right) {
+            .Dropdown-menu {
+                left: 100%;
+                margin-left: 8px;
+
+                &::before {
+                    content: ' ';
+                    width: 8px;
+                }
+            }
+        }
+        &.nested-right {
+            .Dropdown-menu {
+                right: 0px;
+                margin-right: 100%;
+
+                &::after {
+                    content: ' ';
+                    width: 8px;
+                }
+            }
         }
     }
 }

--- a/querybook/webapp/ui/Dropdown/Dropdown.tsx
+++ b/querybook/webapp/ui/Dropdown/Dropdown.tsx
@@ -37,6 +37,7 @@ export const Dropdown: React.FunctionComponent<IProps> = ({
     const popoverRef = React.useRef<HTMLDivElement>(null);
 
     const [active, setActive] = React.useState(false);
+
     // Hover Based Dropdown control
     const handleMouseEnter = React.useCallback(() => {
         if (hoverable) {


### PR DESCRIPTION
Add pseudo element in between the nested menus so it doesn't collapse unexpectedly
![image](https://user-images.githubusercontent.com/8283407/163086521-af4bbd42-2d23-4607-8b7c-83d31fd38682.png)
