### PR TITLE
Pass utf8 as default charset into mysqld command (fixes #842)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,7 @@ services:
             interval: 30s
             timeout: 30s
             retries: 3
+        command: ['--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
     elasticsearch:
         container_name: querybook_elasticsearch
         image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2


### PR DESCRIPTION
Pass utf8 as default charset into mysqld command (fixes #842)