### PR TITLE
fix: Use default plugins when imported plugins is an empty list

### DIFF
--- a/querybook/server/lib/utils/import_helper.py
+++ b/querybook/server/lib/utils/import_helper.py
@@ -60,7 +60,7 @@ def import_module_with_default(module_path: str, module_variable: str = None, **
         if module_variable is not None:
             plugin_value = getattr(plugin_value, module_variable, None)
 
-        if plugin_value is None and has_default:
+        if not plugin_value and has_default:
             plugin_value = kwargs["default"]
 
         return plugin_value


### PR DESCRIPTION
Plugins are loaded from a variable in a module, and if no plugins are specified, a default value may be applied.  The previous behavior only checked for `None`, which does not match an empty list.  This prevents `EmailNotifier` from being loaded as the default notifier plugin:

```
ALL_PLUGIN_NOTIFIERS = []
``` 

This change more broadly matches undefined plugin configurations and applies the defaults (if any).

As far as I can tell, the only impact of this bug is the notifier module, as it's the only one that provides a default plugin list.