### PR TITLE
chore: upgrade to redshift_connector 2.0.907

### DIFF
--- a/requirements/engine/redshift.txt
+++ b/requirements/engine/redshift.txt
@@ -1,2 +1,2 @@
 sqlalchemy-redshift==0.8.9
-redshift_connector==2.0.902
+redshift_connector==2.0.907


### PR DESCRIPTION
updates Redshift operator dependency to use the latest version of redshit_connector