### PR TITLE
fix: Update typing-extensions to fix dependency mismatch and tests

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -39,4 +39,4 @@ beautifulsoup4==4.8.2
 markdown2
 
 # Utils
-typing-extensions==3.7.4.1
+typing-extensions==3.10.0.0


### PR DESCRIPTION
Updating the version of `typing-extensions` to fix this conflicting dependency:

```
ERROR: Cannot install -r requirements/dev.txt (line 5) and typing-extensions==3.7.4.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested typing-extensions==3.7.4.1
    black 22.3.0 depends on typing-extensions>=3.10.0.0; python_version < "3.10"
```

This also fixes the following error in Python tests:

```
E   ImportError: cannot import name 'ParamSpec' from 'typing_extensions' (/opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages/typing_extensions.py)
------------------------------- Captured stderr --------------------------------
[2022-04-26 Tue 03:20:10] - /home/runner/work/querybook/querybook/querybook/server/lib/utils/import_helper.py - DEBUG   "Cannot import notifier_plugin.ALL_PLUGIN_NOTIFIERS due to: No module named 'notifier_plugin'"
```