### PR TITLE
fix: Reset Trino cursor rows between statements

### DIFF
--- a/querybook/server/lib/query_executor/clients/trino.py
+++ b/querybook/server/lib/query_executor/clients/trino.py
@@ -35,6 +35,7 @@ class TrinoCursor(CursorBaseClass):
         self._request = cursor._request
 
     def _init_query_state_vars(self):
+        self.rows = []
         self._tracking_url = None
         self._percent_complete = 0
 


### PR DESCRIPTION
Fixes an issue when running multiple statements using Trino: the cursor accumulates rows in a list that is not reset between statements, so each subsequent statement includes all the rows from previous statements.