### PR TITLE
fix: Make username case-sensitive in bind LDAP login

### DIFF
--- a/querybook/server/app/auth/ldap_auth.py
+++ b/querybook/server/app/auth/ldap_auth.py
@@ -131,7 +131,7 @@ def search_user_by_uid(
     apply_filter: bool = False,
 ) -> Optional[Tuple[str, Dict]]:
     search_filter = (
-        f"(&({QuerybookSettings.LDAP_UID_FIELD}={uid})"
+        f"(&({QuerybookSettings.LDAP_UID_FIELD}:caseExactMatch:={uid})"
         + (_get_ldap_filter() if apply_filter else "(objectClass=*)")
         + ")"
     )

--- a/querybook/tests/test_app/test_auth/test_ldap_auth.py
+++ b/querybook/tests/test_app/test_auth/test_ldap_auth.py
@@ -116,8 +116,9 @@ class MockLdapUID(MockLdap):
         base: str, scope: int, filterstr: str, attrlist: List[str]
     ) -> List[Tuple]:
         if (
-            (filterstr == "(&(uid=unknown)(objectClass=*))")
-            or (filterstr == "(&(uid=newmaj)(sn=Unknown))")
+            (filterstr == "(&(uid:caseExactMatch:=unknown)(objectClass=*))")
+            or (filterstr == "(&(uid:caseExactMatch:=NEWMAJ)(objectClass=*))")
+            or (filterstr == "(&(uid:caseExactMatch:=newmaj)(sn=Unknown))")
             or (filterstr == "(sn=Unknown)")
             or (base == "uid=unknown,ou=people,dc=querybook,dc=com")
             or (base == "uid=newmaj,ou=people,dc=querybook,dc=unknown")
@@ -127,11 +128,11 @@ class MockLdapUID(MockLdap):
         elif scope == 2 and (
             (
                 base == "ou=people,dc=querybook,dc=com"
-                and filterstr == "(&(uid=newmaj)(objectClass=*))"
+                and filterstr == "(&(uid:caseExactMatch:=newmaj)(objectClass=*))"
             )
             or (
                 base == "ou=people,dc=querybook,dc=com"
-                and filterstr == "(&(uid=newmaj)(sn=Newman))"
+                and filterstr == "(&(uid:caseExactMatch:=newmaj)(sn=Newman))"
             )
             or (
                 base == "uid=newmaj,ou=people,dc=querybook,dc=com"
@@ -171,7 +172,7 @@ class MockLdapCN(MockLdap):
         if scope == 2 and (
             (
                 base == "ou=people,dc=querybook,dc=com"
-                and filterstr == "(&(uid=newmaj)(objectClass=*))"
+                and filterstr == "(&(uid:caseExactMatch:=newmaj)(objectClass=*))"
             )
             or (
                 base == "cn=John Newman,ou=people,dc=querybook,dc=com"
@@ -323,10 +324,10 @@ def test_ldap_get_transformed_username_uid(
 @pytest.mark.parametrize(
     "ldap_filter, use_bind, exp_filter",
     [
-        ("uid=newmaj", True, "(uid=newmaj)"),
-        ("(uid=newmaj)", True, "(uid=newmaj)"),
+        ("uid:caseExactMatch:=newmaj", True, "(uid:caseExactMatch:=newmaj)"),
+        ("(uid:caseExactMatch:=newmaj)", True, "(uid:caseExactMatch:=newmaj)"),
         (None, True, "(objectClass=*)"),
-        ("(uid=newmaj)", False, "(objectClass=*)"),
+        ("(uid:caseExactMatch:=newmaj)", False, "(objectClass=*)"),
     ],
 )
 def test_get_ldap_filter(


### PR DESCRIPTION
## Description 

Proposing adding `:caseExactMatch:` option ([docs](https://ldap.com/ldap-filters/)) to the filter condition when searching for `uid` in the LDAP directory using bind user.

Motivations:
- Username/password combination should be usually validated in case-sensitive manner
- Currently, the `processed_username` from [here](https://github.com/pinterest/querybook/blob/2287943ac80575856e08931c646f91da34eae57d/querybook/server/app/auth/ldap_auth.py#L287) can be the username passed by user directly. Propagation such a user name with wrong case can result in new user in DB, because DB `username` is case-sensitive.

I perceive this more as a bug fix than a change.