### PR TITLE
feat: Allow metastore loaders to provide table/column descriptions

### DIFF
--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -55,6 +55,9 @@ class DataTable(NamedTuple):
     # Json arrays of partitions
     partitions: List = []
 
+    # Metadata
+    description: str = None
+
     # Store the raw info here
     raw_description: str = None
 
@@ -63,6 +66,9 @@ class DataColumn(NamedTuple):
     name: str
     type: str
     comment: str = None
+
+    # Metadata
+    description: str = None
 
 
 class BaseMetastoreLoader(metaclass=ABCMeta):
@@ -155,6 +161,7 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
                 schema_tables += [
                     (schema_id, schema_name, table_name) for table_name in table_names
                 ]
+
         self._create_tables_batched(schema_tables)
 
     def get_latest_partition(
@@ -221,6 +228,7 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
                 data_table_id=table_id,
                 latest_partitions=json.dumps((table.partitions or [])[-10:]),
                 earliest_partitions=json.dumps((table.partitions or [])[:10]),
+                description=table.description,
                 hive_metastore_description=table.raw_description,
                 session=session,
             )
@@ -233,6 +241,7 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
                     name=column.name,
                     type=column.type,
                     comment=column.comment,
+                    description=column.description,
                     table_id=table_id,
                     commit=False,
                     session=session,

--- a/querybook/server/logic/metastore.py
+++ b/querybook/server/logic/metastore.py
@@ -255,6 +255,7 @@ def create_table_information(
     data_table_id=None,
     latest_partitions=None,
     earliest_partitions=None,
+    description=None,
     hive_metastore_description=None,
     commit=False,
     session=None,
@@ -269,6 +270,9 @@ def create_table_information(
         earliest_partitions=earliest_partitions,
         hive_metastore_description=hive_metastore_description,
     )
+
+    if description:
+        new_table_information.description = description
 
     if not table_information:
         session.add(new_table_information)
@@ -419,7 +423,13 @@ def get_all_column_name_by_table_id(table_id, session=None):
 
 @with_session
 def create_column(
-    name=None, type=None, comment=None, table_id=None, commit=True, session=None
+    name=None,
+    type=None,
+    comment=None,
+    description=None,
+    table_id=None,
+    commit=True,
+    session=None,
 ):
     old_table_column = get_column_by_name(name, table_id, session=session)
     if old_table_column:
@@ -431,6 +441,9 @@ def create_column(
         comment=comment,
         table_id=table_id,
     )
+
+    if description:
+        new_table_column.description = description
 
     if not old_table_column:
         session.add(new_table_column)


### PR DESCRIPTION
This change adds description properties to `DataTable` and `DataColumn`, and persists these to the database (if not `None`).

This allows a metastore loader implementation to source the table and column descriptions from a separate system and sync them into Querybook.

Here's an example implementation that hardcodes the same descriptions for every table & column:

```python
from typing import List, Tuple
from lib.logger import get_logger
from lib.metastore.base_metastore_loader import DataColumn, DataTable
from lib.metastore.loaders.sqlalchemy_metastore_loader import SqlAlchemyMetastoreLoader

LOG = get_logger(__name__)

class ExternalMetadataLoader(SqlAlchemyMetastoreLoader):
    def get_table_and_columns(
        self, schema_name, table_name
    ) -> Tuple[DataTable, List[DataColumn]]:
        table, columns = super().get_table_and_columns(schema_name, table_name)

        table = table._replace(description="test table description")

        columns = list(
            map(
                lambda column: column._replace(description="test column description"),
                columns,
            )
        )
        
        return table, columns
```

Fixes #871.