### PR TITLE
fix: restrict access to private queries in query search

### DIFF
--- a/docs_website/docs/changelog/breaking_change.md
+++ b/docs_website/docs/changelog/breaking_change.md
@@ -15,7 +15,7 @@ Follow the instructions at [Re-Initialize ElasticSearch](../developer_guide/rein
 
 Alternatively, you can run the following python script to update only the added fields in the query indices:
 
-```
+```py
 from logic.elasticsearch import bulk_update_index_by_fields, update_indices
 
 update_indices("query_executions", "query_cells")

--- a/docs_website/docs/changelog/breaking_change.md
+++ b/docs_website/docs/changelog/breaking_change.md
@@ -7,6 +7,12 @@ slug: /changelog
 
 Here are the list of breaking changes that you should be aware of when updating Querybook:
 
+## v3.5.0
+
+The ElasticSearch index mappings for `query_cells` and `query_executions` were updated to include fields to restrict access to queries based on datadoc access permissions. Query cells and executions on private datadocs will only be shown in query search to users that have access to these datadocs.
+
+Please run `recreate_indices("query_cells", "query_executions")` function in `querybook/server/logic/elasticsearch.py` to recreate the appropriate indices.
+
 ## v3.4.0
 
 There is a new field `feature_params` added to the `query_engine` table to replace `status_checker`.

--- a/docs_website/docs/changelog/breaking_change.md
+++ b/docs_website/docs/changelog/breaking_change.md
@@ -11,7 +11,17 @@ Here are the list of breaking changes that you should be aware of when updating 
 
 The ElasticSearch index mappings for `query_cells` and `query_executions` were updated to include fields to restrict access to queries based on datadoc access permissions. Query cells and executions on private datadocs will only be shown in query search to users that have access to these datadocs.
 
-Please run `recreate_indices("query_cells", "query_executions")` function in `querybook/server/logic/elasticsearch.py` to recreate the appropriate indices.
+Follow the instructions at [Re-Initialize ElasticSearch](../developer_guide/reinitialize_es.md) to recreate ElasticSearch indices.
+
+Alternatively, you can run the following python script to update only the added fields in the query indices:
+
+```
+from logic.elasticsearch import bulk_update_index_by_fields, update_indices
+
+update_indices("query_executions", "query_cells")
+bulk_update_index_by_fields("query_executions", {"id", "public", "readable_user_ids"})
+bulk_update_index_by_fields("query_cells", {"id", "public", "readable_user_ids"})
+```
 
 ## v3.4.0
 

--- a/docs_website/docs/changelog/breaking_change.md
+++ b/docs_website/docs/changelog/breaking_change.md
@@ -13,15 +13,7 @@ The ElasticSearch index mappings for `query_cells` and `query_executions` were u
 
 Follow the instructions at [Re-Initialize ElasticSearch](../developer_guide/reinitialize_es.md) to recreate ElasticSearch indices.
 
-Alternatively, you can run the following python script to update only the added fields in the query indices:
-
-```py
-from logic.elasticsearch import bulk_update_index_by_fields, update_indices
-
-update_indices("query_executions", "query_cells")
-bulk_update_index_by_fields("query_executions", {"id", "public", "readable_user_ids"})
-bulk_update_index_by_fields("query_cells", {"id", "public", "readable_user_ids"})
-```
+Alternatively, you can run the script `querybook/server/scripts/es_3_5_0_upgrade.py` to update only the added fields in the query indices.
 
 ## v3.4.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.4.0",
+    "version": "3.5.0",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/config/elasticsearch.yaml
+++ b/querybook/config/elasticsearch.yaml
@@ -54,6 +54,10 @@ query_executions:
                 query_text:
                     type: text
                     analyzer: query_lowercase
+                public:
+                    type: boolean
+                readable_user_ids:
+                    type: integer
 
 query_cells:
     index_name: search_query_cells_v1
@@ -111,6 +115,11 @@ query_cells:
                 query_text:
                     type: text
                     analyzer: query_lowercase
+                public:
+                    type: boolean
+                readable_user_ids:
+                    type: integer
+
 datadocs:
     index_name: search_datadocs_v1
     type_name: datadocs

--- a/querybook/server/datasources/datadoc.py
+++ b/querybook/server/datasources/datadoc.py
@@ -421,6 +421,10 @@ def add_datadoc_editor(
 
         session.commit()
 
+        # Update queries in elasticsearch to reflect new permissions
+        logic.update_es_query_cells_by_data_doc_id(doc_id, session=session)
+        logic.update_es_query_executions_by_data_doc_id(doc_id, session=session)
+
         if access_request:
             socketio.emit(
                 "data_doc_access_request",
@@ -645,6 +649,10 @@ def update_datadoc_owner(doc_id, next_owner_id, originator=None):
             broadcast=True,
         )
         logic.update_es_data_doc_by_id(doc_id)
+        # Update queries in elasticsearch to reflect new permissions
+        logic.update_es_query_cells_by_data_doc_id(doc_id, session=session)
+        logic.update_es_query_executions_by_data_doc_id(doc_id, session=session)
+
         send_datadoc_transfer_notification(doc_id, next_owner_uid, session)
         return current_owner_editor_dict
 

--- a/querybook/server/datasources/datadoc.py
+++ b/querybook/server/datasources/datadoc.py
@@ -422,8 +422,7 @@ def add_datadoc_editor(
         session.commit()
 
         # Update queries in elasticsearch to reflect new permissions
-        logic.update_es_query_cells_by_data_doc_id(doc_id, session=session)
-        logic.update_es_query_executions_by_data_doc_id(doc_id, session=session)
+        logic.update_es_queries_by_datadoc_id(doc_id, session=session)
 
         if access_request:
             socketio.emit(
@@ -650,8 +649,7 @@ def update_datadoc_owner(doc_id, next_owner_id, originator=None):
         )
         logic.update_es_data_doc_by_id(doc_id)
         # Update queries in elasticsearch to reflect new permissions
-        logic.update_es_query_cells_by_data_doc_id(doc_id, session=session)
-        logic.update_es_query_executions_by_data_doc_id(doc_id, session=session)
+        logic.update_es_queries_by_datadoc_id(doc_id, session=session)
 
         send_datadoc_transfer_notification(doc_id, next_owner_uid, session)
         return current_owner_editor_dict

--- a/querybook/server/datasources/search.py
+++ b/querybook/server/datasources/search.py
@@ -158,8 +158,7 @@ def _construct_query_search_query(
     search_filter = _match_filters(filters)
     if search_filter == {}:
         search_filter["filter"] = {"bool": {}}
-    search_filter["filter"]["bool"].setdefault("must", [])
-    search_filter["filter"]["bool"]["must"].append(
+    search_filter["filter"]["bool"].setdefault("must", []).append(
         {"bool": {"should": _query_access_terms(current_user.id)}}
     )
 
@@ -227,8 +226,7 @@ def _construct_datadoc_query(
     search_filter = _match_filters(filters)
     if search_filter == {}:
         search_filter["filter"] = {"bool": {}}
-    search_filter["filter"]["bool"].setdefault("must", [])
-    search_filter["filter"]["bool"]["must"].append(
+    search_filter["filter"]["bool"].setdefault("must", []).append(
         {"bool": {"should": _data_doc_access_terms(current_user.id)}}
     )
 

--- a/querybook/server/logic/datadoc.py
+++ b/querybook/server/logic/datadoc.py
@@ -76,7 +76,7 @@ def create_data_doc(
     if commit:
         session.commit()
         update_es_data_doc_by_id(data_doc.id)
-        update_es_query_cells_by_data_doc_id(data_doc.id, session=session)
+        update_es_queries_by_datadoc_id(data_doc.id, session=session)
     else:
         session.flush()
 
@@ -152,8 +152,7 @@ def update_data_doc(id, commit=True, session=None, **fields):
 
             # update es queries if doc is switched between public/private
             if "public" in fields:
-                update_es_query_cells_by_data_doc_id(data_doc.id, session=session)
-                update_es_query_executions_by_data_doc_id(data_doc.id, session=session)
+                update_es_queries_by_datadoc_id(data_doc.id, session=session)
             # update es query cells if doc is archived
             elif fields.get("archived") is True:
                 update_es_query_cells_by_data_doc_id(data_doc.id, session=session)
@@ -233,7 +232,7 @@ def clone_data_doc(id, owner_uid, commit=True, session=None):
     if commit:
         session.commit()
         update_es_data_doc_by_id(new_data_doc.id)
-        update_es_query_cells_by_data_doc_id(new_data_doc.id, session=session)
+        update_es_queries_by_datadoc_id(new_data_doc.id, session=session)
     else:
         session.flush()
     session.refresh(new_data_doc)
@@ -821,8 +820,7 @@ def create_data_doc_editor(
     if commit:
         session.commit()
         update_es_data_doc_by_id(editor.data_doc_id)
-        update_es_query_cells_by_data_doc_id(editor.data_doc_id, session=session)
-        update_es_query_executions_by_data_doc_id(editor.data_doc_id, session=session)
+        update_es_queries_by_datadoc_id(editor.data_doc_id, session=session)
     else:
         session.flush()
     session.refresh(editor)
@@ -847,12 +845,7 @@ def update_data_doc_editor(
         if updated:
             if commit:
                 session.commit()
-                update_es_query_cells_by_data_doc_id(
-                    editor.data_doc_id, session=session
-                )
-                update_es_query_executions_by_data_doc_id(
-                    editor.data_doc_id, session=session
-                )
+                update_es_queries_by_datadoc_id(editor.data_doc_id, session=session)
             else:
                 session.flush()
             session.refresh(editor)
@@ -865,8 +858,7 @@ def delete_data_doc_editor(id, doc_id, session=None, commit=True):
     if commit:
         session.commit()
         update_es_data_doc_by_id(doc_id)
-        update_es_query_cells_by_data_doc_id(doc_id, session=session)
-        update_es_query_executions_by_data_doc_id(doc_id, session=session)
+        update_es_queries_by_datadoc_id(doc_id, session=session)
 
 
 """
@@ -1004,6 +996,12 @@ def update_es_query_executions_by_data_doc_id(id, session=None):
     )
     for execution in query_executions:
         update_es_query_execution_by_id(execution.id)
+
+
+@with_session
+def update_es_queries_by_datadoc_id(id, session=None):
+    update_es_query_cells_by_data_doc_id(id, session=session)
+    update_es_query_executions_by_data_doc_id(id, session=session)
 
 
 @with_session

--- a/querybook/server/logic/datadoc.py
+++ b/querybook/server/logic/datadoc.py
@@ -821,6 +821,8 @@ def create_data_doc_editor(
     if commit:
         session.commit()
         update_es_data_doc_by_id(editor.data_doc_id)
+        update_es_query_cells_by_data_doc_id(editor.data_doc_id, session=session)
+        update_es_query_executions_by_data_doc_id(editor.data_doc_id, session=session)
     else:
         session.flush()
     session.refresh(editor)
@@ -845,6 +847,12 @@ def update_data_doc_editor(
         if updated:
             if commit:
                 session.commit()
+                update_es_query_cells_by_data_doc_id(
+                    editor.data_doc_id, session=session
+                )
+                update_es_query_executions_by_data_doc_id(
+                    editor.data_doc_id, session=session
+                )
             else:
                 session.flush()
             session.refresh(editor)
@@ -855,8 +863,10 @@ def update_data_doc_editor(
 def delete_data_doc_editor(id, doc_id, session=None, commit=True):
     session.query(DataDocEditor).filter_by(id=id).delete()
     if commit:
-        update_es_data_doc_by_id(doc_id)
         session.commit()
+        update_es_data_doc_by_id(doc_id)
+        update_es_query_cells_by_data_doc_id(doc_id, session=session)
+        update_es_query_executions_by_data_doc_id(doc_id, session=session)
 
 
 """

--- a/querybook/server/logic/elasticsearch.py
+++ b/querybook/server/logic/elasticsearch.py
@@ -92,10 +92,13 @@ def _get_dict_by_field(
         Dict[str, Any] - subset of the fields passed or the entire generated dict if fields is None
     """
     fields = fields or field_to_getter.keys()
+
+    def get_field_value(field: str):
+        getter = field_to_getter[field]
+        return getter() if callable(getter) else getter
+
     return {
-        field: getter() if callable(getter) else getter
-        for field, getter in field_to_getter.items()
-        if field in fields
+        field: get_field_value(field) for field in fields if field in field_to_getter
     }
 
 

--- a/querybook/server/logic/elasticsearch.py
+++ b/querybook/server/logic/elasticsearch.py
@@ -211,7 +211,7 @@ def query_execution_to_es(query_execution, data_cell=None, fields=None, session=
             else None
         )
 
-    field_to_generator = {
+    field_to_getter = {
         "id": query_execution.id,
         "query_type": "query_execution",
         "title": data_cell.meta.get("title", "Untitled") if data_cell else None,
@@ -229,7 +229,7 @@ def query_execution_to_es(query_execution, data_cell=None, fields=None, session=
         "readable_user_ids": lambda: _get_datadoc_editors(datadoc, session=session),
     }
 
-    return _get_dict_by_field(field_to_generator, fields=fields)
+    return _get_dict_by_field(field_to_getter, fields=fields)
 
 
 @with_exception
@@ -317,7 +317,7 @@ def query_cell_to_es(query_cell, fields=None, session=None):
     engine_id = query_cell_meta.get("engine")
     engine = admin_logic.get_query_engine_by_id(engine_id, session=session)
 
-    field_to_generator = {
+    field_to_getter = {
         "id": query_cell.id,
         "query_type": "query_cell",
         "title": query_cell_meta.get("title", "Untitled"),
@@ -335,7 +335,7 @@ def query_cell_to_es(query_cell, fields=None, session=None):
         "readable_user_ids": lambda: _get_datadoc_editors(datadoc, session=session),
     }
 
-    return _get_dict_by_field(field_to_generator, fields=fields)
+    return _get_dict_by_field(field_to_getter, fields=fields)
 
 
 @with_exception
@@ -426,7 +426,7 @@ def get_joined_cells(datadoc):
 @with_session
 def datadocs_to_es(datadoc, fields=None, session=None):
 
-    field_to_generator = {
+    field_to_getter = {
         "id": datadoc.id,
         "environment_id": datadoc.environment_id,
         "owner_uid": datadoc.owner_uid,
@@ -436,7 +436,7 @@ def datadocs_to_es(datadoc, fields=None, session=None):
         "public": datadoc.public,
         "readable_user_ids": lambda: _get_datadoc_editors(datadoc, session=session),
     }
-    return _get_dict_by_field(field_to_generator, fields=fields)
+    return _get_dict_by_field(field_to_getter, fields=fields)
 
 
 @with_exception
@@ -569,7 +569,7 @@ def table_to_es(table, fields=None, session=None):
             },
         }
 
-    field_to_generator = {
+    field_to_getter = {
         "id": table.id,
         "metastore_id": schema.metastore_id,
         "schema": schema_name,
@@ -584,7 +584,7 @@ def table_to_es(table, fields=None, session=None):
         "importance_score": compute_weight,
         "tags": [tag.tag_name for tag in table.tags],
     }
-    return _get_dict_by_field(field_to_generator, fields=fields)
+    return _get_dict_by_field(field_to_getter, fields=fields)
 
 
 def _bulk_insert_tables():
@@ -665,13 +665,13 @@ def user_to_es(user, fields=None, session=None):
             "input": process_names_for_suggestion(username, fullname),
         }
 
-    field_to_generator = {
+    field_to_getter = {
         "id": user.id,
         "username": username,
         "fullname": fullname,
         "suggest": get_suggestion_field,
     }
-    return _get_dict_by_field(field_to_generator, fields=fields)
+    return _get_dict_by_field(field_to_getter, fields=fields)
 
 
 @with_session

--- a/querybook/server/logic/elasticsearch.py
+++ b/querybook/server/logic/elasticsearch.py
@@ -2,12 +2,14 @@ from html import escape
 from itertools import chain
 import math
 import re
+from typing import Set
 
 from const.impression import ImpressionItemType
 from const.query_execution import QueryExecutionStatus
 from env import QuerybookSettings
 from elasticsearch import Elasticsearch, RequestsHttpConnection
-from lib.query_analysis.lineage import get_table_statement_type, process_query
+from lib.query_analysis import lineage as lineage_lib
+from lib.query_analysis.lineage import get_table_statement_type
 
 from lib.utils.utils import (
     DATETIME_TO_UTC,
@@ -18,13 +20,13 @@ from lib.logger import get_logger
 from lib.config import get_config_value
 from lib.richtext import richtext_to_plaintext
 from app.db import with_session
-from logic.admin import get_query_engine_by_id
+from logic import admin as admin_logic
+from logic import datadoc as datadoc_logic
 from logic.datadoc import (
     get_all_data_docs,
     get_all_query_cells,
     get_data_cell_by_query_execution_id,
     get_data_doc_by_id,
-    get_data_doc_editors_by_doc_id,
     get_unarchived_query_cell_by_id,
 )
 from logic.metastore import (
@@ -78,13 +80,19 @@ def get_hosted_es():
     return hosted_es
 
 
+def _get_partial_dict(field_to_generator, fields=None):
+    if fields is None:
+        return {key: func() for key, func in field_to_generator.items()}
+    return {key: func() for key, func in field_to_generator.items() if key in fields}
+
+
 """
     QUERY EXECUTIONS
 """
 
 
 @with_session
-def _get_query_cell_executions_iter(batch_size=1000, session=None):
+def _get_query_cell_executions_iter(batch_size=1000, fields=None, session=None):
     offset = 0
     while True:
         query_cells = get_all_query_cells(
@@ -106,6 +114,7 @@ def _get_query_cell_executions_iter(batch_size=1000, session=None):
                     expand_query_execution = query_execution_to_es(
                         query_execution,
                         data_cell=query_cell,
+                        fields=fields,
                         session=session,
                     )
                     yield expand_query_execution
@@ -124,7 +133,7 @@ def _get_query_cell_executions_iter(batch_size=1000, session=None):
 
 
 @with_session
-def _get_adhoc_query_executions_iter(batch_size=1000, session=None):
+def _get_adhoc_query_executions_iter(batch_size=1000, fields=None, session=None):
     offset = 0
     while True:
         query_executions = get_successful_adhoc_query_executions(
@@ -140,7 +149,7 @@ def _get_adhoc_query_executions_iter(batch_size=1000, session=None):
 
         for query_execution in query_executions:
             expand_query_execution = query_execution_to_es(
-                query_execution, session=session
+                query_execution, fields=fields, session=session
             )
             yield expand_query_execution
 
@@ -150,9 +159,13 @@ def _get_adhoc_query_executions_iter(batch_size=1000, session=None):
 
 
 @with_session
-def get_query_executions_iter(batch_size=1000, session=None):
-    yield from _get_query_cell_executions_iter(batch_size=batch_size, session=session)
-    yield from _get_adhoc_query_executions_iter(batch_size=batch_size, session=session)
+def get_query_executions_iter(batch_size=1000, fields=None, session=None):
+    yield from _get_query_cell_executions_iter(
+        batch_size=batch_size, fields=fields, session=session
+    )
+    yield from _get_adhoc_query_executions_iter(
+        batch_size=batch_size, fields=fields, session=session
+    )
 
 
 @with_session
@@ -161,55 +174,51 @@ def _get_datadoc_editors(datadoc, session=None):
     since there is no need to compute list of editors if everyone is able to access the data"""
     if datadoc is None or datadoc.public:
         return []
-    editors = get_data_doc_editors_by_doc_id(data_doc_id=datadoc.id, session=session)
+    editors = datadoc_logic.get_data_doc_editors_by_doc_id(
+        data_doc_id=datadoc.id, session=session
+    )
     return [editor.uid for editor in editors]
 
 
 @with_session
-def query_execution_to_es(query_execution, data_cell=None, session=None):
+def query_execution_to_es(query_execution, data_cell=None, fields=None, session=None):
     """data_cell is added as a parameter so that bulk insert of query executions won't require
     re-retrieval of data_cell"""
-    query_execution_id = query_execution.id
-
     engine_id = query_execution.engine_id
-    engine = get_query_engine_by_id(engine_id, session=session)
-
-    table_names, _ = process_query(
-        query_execution.query, language=(engine and engine.language)
-    )
-    table_names = list(chain.from_iterable(table_names))
-
-    duration = (
-        DATETIME_TO_UTC(query_execution.completed_at)
-        - DATETIME_TO_UTC(query_execution.created_at)
-        if query_execution.completed_at is not None
-        else None
-    )
-
-    environments = engine.environments
-    environment_ids = [env.id for env in environments]
-
-    title = data_cell.meta.get("title", "Untitled") if data_cell else None
-
+    engine = admin_logic.get_query_engine_by_id(engine_id, session=session)
     datadoc = data_cell.doc if data_cell else None
-    editors = _get_datadoc_editors(datadoc, session=session)
 
-    expand_query_execution = {
-        "id": query_execution_id,
-        "query_type": "query_execution",
-        "title": title,
-        "environment_id": environment_ids,
-        "author_uid": query_execution.uid,
-        "engine_id": engine_id,
-        "statement_type": get_table_statement_type(query_execution.query),
-        "created_at": DATETIME_TO_UTC(query_execution.created_at),
-        "duration": duration,
-        "full_table_name": table_names,
-        "query_text": query_execution.query,
-        "public": datadoc is None or datadoc.public,
-        "readable_user_ids": editors,
+    def get_duration():
+        return (
+            DATETIME_TO_UTC(query_execution.completed_at)
+            - DATETIME_TO_UTC(query_execution.created_at)
+            if query_execution.completed_at is not None
+            else None
+        )
+
+    def get_table_names():
+        table_names, _ = lineage_lib.process_query(
+            query_execution.query, language=(engine and engine.language)
+        )
+        return list(chain.from_iterable(table_names))
+
+    field_to_generator = {
+        "id": lambda: query_execution.id,
+        "query_type": lambda: "query_execution",
+        "title": lambda: data_cell.meta.get("title", "Untitled") if data_cell else None,
+        "environment_id": lambda: [env.id for env in engine.environments],
+        "author_uid": lambda: query_execution.uid,
+        "engine_id": lambda: engine_id,
+        "statement_type": lambda: get_table_statement_type(query_execution.query),
+        "created_at": lambda: DATETIME_TO_UTC(query_execution.created_at),
+        "duration": get_duration,
+        "full_table_name": get_table_names,
+        "query_text": lambda: query_execution.query,
+        "public": lambda: datadoc is None or datadoc.public,
+        "readable_user_ids": lambda: _get_datadoc_editors(datadoc, session=session),
     }
-    return expand_query_execution
+
+    return _get_partial_dict(field_to_generator, fields=fields)
 
 
 @with_exception
@@ -218,6 +227,15 @@ def _bulk_insert_query_executions():
 
     for query_execution in get_query_executions_iter():
         _insert(index_name, query_execution["id"], query_execution)
+
+
+@with_exception
+def _bulk_update_query_executions(fields: Set[str] = None):
+    index_name = ES_CONFIG["query_executions"]["index_name"]
+
+    for query_execution in get_query_executions_iter(fields=fields):
+        updated_body = {"doc": query_execution, "doc_as_upsert": True}
+        _update(index_name, query_execution["id"], updated_body)
 
 
 @with_exception
@@ -255,7 +273,7 @@ def update_query_execution_by_id(query_execution_id, session=None):
 
 
 @with_session
-def get_query_cells_iter(batch_size=1000, session=None):
+def get_query_cells_iter(batch_size=1000, fields=None, session=None):
     offset = 0
 
     while True:
@@ -269,7 +287,9 @@ def get_query_cells_iter(batch_size=1000, session=None):
         )
 
         for query_cell in query_cells:
-            expand_query_cell = query_cell_to_es(query_cell, session=session)
+            expand_query_cell = query_cell_to_es(
+                query_cell, fields=fields, session=session
+            )
             yield expand_query_cell
 
         if len(query_cells) < batch_size:
@@ -278,36 +298,37 @@ def get_query_cells_iter(batch_size=1000, session=None):
 
 
 @with_session
-def query_cell_to_es(query_cell, session=None):
-    query_cell_id = query_cell.id
+def query_cell_to_es(query_cell, fields=None, session=None):
     query_cell_meta = query_cell.meta
+    query = query_cell.context
+    datadoc = query_cell.doc
 
     engine_id = query_cell_meta.get("engine")
-    engine = get_query_engine_by_id(engine_id, session=session)
+    engine = admin_logic.get_query_engine_by_id(engine_id, session=session)
 
-    query = query_cell.context
-    table_names, _ = process_query(query, language=(engine and engine.language))
-    table_names = list(chain.from_iterable(table_names))
+    def get_table_names():
+        table_names, _ = lineage_lib.process_query(
+            query, language=(engine and engine.language)
+        )
+        return list(chain.from_iterable(table_names))
 
-    datadoc = query_cell.doc
-    editors = _get_datadoc_editors(datadoc, session=session)
-
-    expand_query = {
-        "id": query_cell_id,
-        "query_type": "query_cell",
-        "title": query_cell_meta.get("title", "Untitled"),
-        "data_doc_id": datadoc and datadoc.id,
-        "environment_id": datadoc and datadoc.environment_id,
-        "author_uid": datadoc and datadoc.owner_uid,
-        "engine_id": engine_id,
-        "statement_type": get_table_statement_type(query),
-        "created_at": DATETIME_TO_UTC(query_cell.created_at),
-        "full_table_name": table_names,
-        "query_text": query,
-        "public": datadoc.public,
-        "readable_user_ids": editors,
+    field_to_generator = {
+        "id": lambda: query_cell.id,
+        "query_type": lambda: "query_cell",
+        "title": lambda: query_cell_meta.get("title", "Untitled"),
+        "data_doc_id": lambda: datadoc and datadoc.id,
+        "environment_id": lambda: datadoc and datadoc.environment_id,
+        "author_uid": lambda: datadoc and datadoc.owner_uid,
+        "engine_id": lambda: engine_id,
+        "statement_type": lambda: get_table_statement_type(query),
+        "created_at": lambda: DATETIME_TO_UTC(query_cell.created_at),
+        "full_table_name": get_table_names,
+        "query_text": lambda: query,
+        "public": lambda: datadoc is not None and datadoc.public,
+        "readable_user_ids": lambda: _get_datadoc_editors(datadoc, session=session),
     }
-    return expand_query
+
+    return _get_partial_dict(field_to_generator, fields=fields)
 
 
 @with_exception
@@ -316,6 +337,15 @@ def _bulk_insert_query_cells():
 
     for query_cell in get_query_cells_iter():
         _insert(index_name, query_cell["id"], query_cell)
+
+
+@with_exception
+def _bulk_update_query_cells(fields: Set[str] = None):
+    index_name = ES_CONFIG["query_cells"]["index_name"]
+
+    for query_cell in get_query_cells_iter(fields=fields):
+        updated_body = {"doc": query_cell, "doc_as_upsert": True}
+        _update(index_name, query_cell["id"], updated_body)
 
 
 @with_exception
@@ -348,7 +378,7 @@ def update_query_cell_by_id(query_cell_id, session=None):
 
 
 @with_session
-def get_datadocs_iter(batch_size=5000, session=None):
+def get_datadocs_iter(batch_size=5000, fields=None, session=None):
     offset = 0
 
     while True:
@@ -360,7 +390,7 @@ def get_datadocs_iter(batch_size=5000, session=None):
         LOG.info("\n--Datadocs count: {}, offset: {}".format(len(data_docs), offset))
 
         for data_doc in data_docs:
-            expand_datadoc = datadocs_to_es(data_doc, session=session)
+            expand_datadoc = datadocs_to_es(data_doc, fields=fields, session=session)
             yield expand_datadoc
 
         if len(data_docs) < batch_size:
@@ -368,10 +398,7 @@ def get_datadocs_iter(batch_size=5000, session=None):
         offset += batch_size
 
 
-@with_session
-def datadocs_to_es(datadoc, session=None):
-    title = datadoc.title
-
+def get_joined_cells(datadoc):
     cells_as_text = []
     for cell in datadoc.cells:
         if cell.cell_type == DataCellType.text:
@@ -386,19 +413,23 @@ def datadocs_to_es(datadoc, session=None):
             cells_as_text.append("[... additional unparsable content ...]")
 
     joined_cells = escape("\n".join(cells_as_text))
+    return joined_cells
 
-    editors = _get_datadoc_editors(datadoc, session=session)
-    expand_datadoc = {
-        "id": datadoc.id,
-        "environment_id": datadoc.environment_id,
-        "owner_uid": datadoc.owner_uid,
-        "created_at": DATETIME_TO_UTC(datadoc.created_at),
-        "cells": joined_cells,
-        "title": title,
-        "public": datadoc.public,
-        "readable_user_ids": editors,
+
+@with_session
+def datadocs_to_es(datadoc, fields=None, session=None):
+
+    field_to_generator = {
+        "id": lambda: datadoc.id,
+        "environment_id": lambda: datadoc.environment_id,
+        "owner_uid": lambda: datadoc.owner_uid,
+        "created_at": lambda: DATETIME_TO_UTC(datadoc.created_at),
+        "cells": lambda: get_joined_cells(datadoc),
+        "title": lambda: datadoc.title,
+        "public": lambda: datadoc.public,
+        "readable_user_ids": lambda: _get_datadoc_editors(datadoc, session=session),
     }
-    return expand_datadoc
+    return _get_partial_dict(field_to_generator, fields=fields)
 
 
 @with_exception
@@ -407,6 +438,15 @@ def _bulk_insert_datadocs():
 
     for datadoc in get_datadocs_iter():
         _insert(index_name, datadoc["id"], datadoc)
+
+
+@with_exception
+def _bulk_update_datadocs(fields: Set[str] = None):
+    index_name = ES_CONFIG["datadocs"]["index_name"]
+
+    for datadoc in get_datadocs_iter(fields=fields):
+        updated_body = {"doc": datadoc, "doc_as_upsert": True}
+        _update(index_name, datadoc["id"], updated_body)
 
 
 @with_exception
@@ -439,7 +479,7 @@ def update_data_doc_by_id(doc_id, session=None):
 
 
 @with_session
-def get_tables_iter(batch_size=5000, session=None):
+def get_tables_iter(batch_size=5000, fields=None, session=None):
     offset = 0
 
     while True:
@@ -451,7 +491,7 @@ def get_tables_iter(batch_size=5000, session=None):
         LOG.info("\n--Table count: {}, offset: {}".format(len(tables), offset))
 
         for table in tables:
-            expand_table = table_to_es(table, session=session)
+            expand_table = table_to_es(table, fields=fields, session=session)
             yield expand_table
 
         if len(tables) < batch_size:
@@ -489,46 +529,55 @@ def get_table_weight(table_id: int, session=None) -> int:
 
 
 @with_session
-def table_to_es(table, session=None):
+def table_to_es(table, fields=None, session=None):
     schema = table.data_schema
-
-    column_names = [c.name for c in table.columns]
     schema_name = schema.name
     table_name = table.name
-    description = (
-        richtext_to_plaintext(table.information.description, escape=True)
-        if table.information
-        else ""
-    )
-
     full_name = "{}.{}".format(schema_name, table_name)
-    weight = get_table_weight(table.id, session=session)
 
-    expand_table = {
-        "id": table.id,
-        "metastore_id": schema.metastore_id,
-        "schema": schema_name,
-        "name": table_name,
-        "full_name": full_name,
-        "full_name_ngram": full_name,
-        "completion_name": {
+    def get_table_description():
+        return (
+            richtext_to_plaintext(table.information.description, escape=True)
+            if table.information
+            else ""
+        )
+
+    weight = None
+
+    def compute_weight():
+        nonlocal weight
+        if weight is None:
+            weight = get_table_weight(table.id, session=session)
+        return weight
+
+    def get_completion_name():
+        return {
             "input": [
                 full_name,
                 table_name,
             ],
-            "weight": weight,
+            "weight": compute_weight(),
             "contexts": {
                 "metastore_id": schema.metastore_id,
             },
-        },
-        "description": description,
-        "created_at": DATETIME_TO_UTC(table.created_at),
-        "columns": column_names,
-        "golden": table.golden,
-        "importance_score": weight,
-        "tags": [tag.tag_name for tag in table.tags],
+        }
+
+    field_to_generator = {
+        "id": lambda: table.id,
+        "metastore_id": lambda: schema.metastore_id,
+        "schema": lambda: schema_name,
+        "name": lambda: table_name,
+        "full_name": lambda: full_name,
+        "full_name_ngram": lambda: full_name,
+        "completion_name": get_completion_name,
+        "description": get_table_description,
+        "created_at": lambda: DATETIME_TO_UTC(table.created_at),
+        "columns": lambda: [c.name for c in table.columns],
+        "golden": lambda: table.golden,
+        "importance_score": compute_weight,
+        "tags": lambda: [tag.tag_name for tag in table.tags],
     }
-    return expand_table
+    return _get_partial_dict(field_to_generator, fields=fields)
 
 
 def _bulk_insert_tables():
@@ -536,6 +585,14 @@ def _bulk_insert_tables():
 
     for table in get_tables_iter():
         _insert(index_name, table["id"], table)
+
+
+def _bulk_update_tables(fields: Set[str] = None):
+    index_name = ES_CONFIG["tables"]["index_name"]
+
+    for table in get_tables_iter(fields=fields):
+        updated_body = {"doc": table, "doc_as_upsert": True}
+        _update(index_name, table["id"], updated_body)
 
 
 @with_exception
@@ -592,22 +649,25 @@ def process_names_for_suggestion(*args):
 
 
 @with_session
-def user_to_es(user, session=None):
+def user_to_es(user, fields=None, session=None):
     username = user.username or ""
     fullname = user.fullname or ""
 
-    return {
-        "id": user.id,
-        "username": username,
-        "fullname": fullname,
-        "suggest": {
-            "input": process_names_for_suggestion(username, fullname),
-        },
+    field_to_generator = {
+        "id": lambda: user.id,
+        "username": lambda: username,
+        "fullname": lambda: fullname,
+        "suggest": lambda: (
+            {
+                "input": process_names_for_suggestion(username, fullname),
+            }
+        ),
     }
+    return _get_partial_dict(field_to_generator, fields=fields)
 
 
 @with_session
-def get_users_iter(batch_size=5000, session=None):
+def get_users_iter(batch_size=5000, fields=None, session=None):
     offset = 0
 
     while True:
@@ -619,7 +679,7 @@ def get_users_iter(batch_size=5000, session=None):
         LOG.info("\n--User count: {}, offset: {}".format(len(users), offset))
 
         for user in users:
-            expanded_user = user_to_es(user, session=session)
+            expanded_user = user_to_es(user, fields=fields, session=session)
             yield expanded_user
 
         if len(users) < batch_size:
@@ -632,6 +692,14 @@ def _bulk_insert_users():
 
     for user in get_users_iter():
         _insert(index_name, user["id"], user)
+
+
+def _bulk_update_users(fields: Set[str] = None):
+    index_name = ES_CONFIG["users"]["index_name"]
+
+    for user in get_users_iter(fields=fields):
+        updated_body = {"doc": user, "doc_as_upsert": True}
+        _update(index_name, user["id"], updated_body)
 
 
 @with_exception
@@ -735,3 +803,31 @@ def get_es_config_by_name(*config_names):
 def recreate_indices(*config_names):
     delete_indices(*config_names)
     create_indices_if_not_exist(*config_names)
+
+
+def update_indices(*config_names):
+    es_configs = get_es_config_by_name(*config_names)
+    for config in es_configs:
+        index_name = config["index_name"]
+        mapping = config["mappings"]["mappings"]
+        get_hosted_es().indices.put_mapping(mapping, index=index_name)
+
+
+def bulk_update_index_by_fields(config_name, fields):
+    es_config = ES_CONFIG[config_name]
+    type_name = es_config["type_name"]
+    if type_name == "query_executions":
+        LOG.info("Updating query executions")
+        _bulk_update_query_executions(fields=fields)
+    elif type_name == "query_cells":
+        LOG.info("Updating query cells")
+        _bulk_update_query_cells(fields=fields)
+    elif type_name == "datadocs":
+        LOG.info("Updating datadocs")
+        _bulk_update_datadocs(fields=fields)
+    elif type_name == "tables":
+        LOG.info("Updating tables")
+        _bulk_update_tables(fields=fields)
+    elif type_name == "users":
+        LOG.info("Updating users")
+        _bulk_update_users(fields=fields)

--- a/querybook/server/scripts/es_3_5_0_upgrade.py
+++ b/querybook/server/scripts/es_3_5_0_upgrade.py
@@ -1,0 +1,5 @@
+from logic.elasticsearch import bulk_update_index_by_fields, update_indices
+
+update_indices("query_executions", "query_cells")
+bulk_update_index_by_fields("query_executions", ["id", "public", "readable_user_ids"])
+bulk_update_index_by_fields("query_cells", ["id", "public", "readable_user_ids"])

--- a/querybook/tests/test_lib/test_elasticsearch/test_elasticsearch.py
+++ b/querybook/tests/test_lib/test_elasticsearch/test_elasticsearch.py
@@ -1,0 +1,478 @@
+import datetime
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+from const.data_doc import DataCellType
+
+from logic.elasticsearch import (
+    datadocs_to_es,
+    query_cell_to_es,
+    query_execution_to_es,
+    table_to_es,
+    user_to_es,
+)
+
+CREATED_AT_DT = datetime.datetime(2020, 5, 5, 12, 8, 30)
+CREATED_AT_EPOCH = 1588680510
+COMPLETED_AT_DT = datetime.datetime(
+    2020, 5, 5, 12, 8, 45
+)  # 15 seconds after created at
+
+
+class BaseQueryTestCase(TestCase):
+    QUERY_TEXT = "SELECT id, val1 from test_table inner join test_table_2 on test_table_2.val1 = test_table_1.val1 limit 10;"
+    ENGINE_ID = 7
+    AUTHOR_UID = "bob"
+    ENVIRONMENT_ID = 2
+
+    QUERY_CELL_ID = 32
+    QUERY_CELL_TITLE = "Test Query Cell"
+    DATADOC_ID = 198
+
+    def _patch_get_query_engine_by_id(self):
+        get_query_engine_by_id_patch = patch("logic.admin.get_query_engine_by_id")
+        self.get_query_engine_by_id_mock = get_query_engine_by_id_patch.start()
+        self.addCleanup(get_query_engine_by_id_patch.stop)
+        self.get_query_engine_by_id_mock.return_value = MagicMock(
+            id=self.ENGINE_ID,
+            language="sqlite",
+            environments=[MagicMock(id=self.ENVIRONMENT_ID)],
+        )
+
+    def _patch_get_datadoc_editors_by_doc_id(self):
+        get_data_doc_editors_by_doc_id_patch = patch(
+            "logic.datadoc.get_data_doc_editors_by_doc_id"
+        )
+        self.get_data_doc_editors_by_doc_id_mock = (
+            get_data_doc_editors_by_doc_id_patch.start()
+        )
+        self.addCleanup(get_data_doc_editors_by_doc_id_patch.stop)
+
+    def _create_private_shared_datadoc_mock(self):
+        mock_doc = MagicMock(
+            id=self.DATADOC_ID,
+            environment_id=self.ENVIRONMENT_ID,
+            owner_uid=self.AUTHOR_UID,
+            public=False,
+        )
+        self.get_data_doc_editors_by_doc_id_mock.return_value = [
+            MagicMock(uid="alice"),
+            MagicMock(uid="charlie"),
+        ]
+        return mock_doc
+
+    def _create_private_datadoc_mock(self):
+        mock_doc = MagicMock(
+            id=self.DATADOC_ID,
+            environment_id=self.ENVIRONMENT_ID,
+            owner_uid=self.AUTHOR_UID,
+            public=False,
+        )
+        self.get_data_doc_editors_by_doc_id_mock.return_value = []
+        return mock_doc
+
+    def _create_public_datadoc_mock(self):
+        mock_doc = MagicMock(
+            id=self.DATADOC_ID,
+            environment_id=self.ENVIRONMENT_ID,
+            owner_uid=self.AUTHOR_UID,
+            public=True,
+        )
+        return mock_doc
+
+    def _get_mock_query_cell(self):
+        return MagicMock(
+            id=self.QUERY_CELL_ID,
+            context=self.QUERY_TEXT,
+            created_at=CREATED_AT_DT,
+            doc=self._create_private_shared_datadoc_mock(),
+            meta={
+                "engine": self.ENGINE_ID,
+                "title": self.QUERY_CELL_TITLE,
+            },
+        )
+
+    def _assert_equals_query_item(self, result, expected_result):
+        for key, expected_value in expected_result.items():
+            if key != "full_table_name":
+                self.assertEqual(result[key], expected_value)
+            else:  # full_table_name array order can change
+                self.assertEqual(set(result[key]), set(expected_value))
+
+        self.assertEqual(len(result.items()), len(expected_result.items()))
+
+    def setUp(self):
+        self._patch_get_query_engine_by_id()
+        self._patch_get_datadoc_editors_by_doc_id()
+
+
+class QueryCellTestCase(BaseQueryTestCase):
+    def setUp(self):
+        super(QueryCellTestCase, self).setUp()
+        self.mock_cell = self._get_mock_query_cell()
+
+    def test_query_cell_to_es(self):
+        result = query_cell_to_es(self.mock_cell, session=MagicMock())
+        expected_result = {
+            "id": self.QUERY_CELL_ID,
+            "query_type": "query_cell",
+            "title": self.QUERY_CELL_TITLE,
+            "data_doc_id": self.DATADOC_ID,
+            "environment_id": self.ENVIRONMENT_ID,
+            "author_uid": self.AUTHOR_UID,
+            "engine_id": self.ENGINE_ID,
+            "statement_type": ["SELECT"],
+            "created_at": CREATED_AT_EPOCH,
+            "full_table_name": ["main.test_table", "main.test_table_2"],
+            "query_text": self.QUERY_TEXT,
+            "public": False,
+            "readable_user_ids": ["alice", "charlie"],
+        }
+        self._assert_equals_query_item(result, expected_result)
+
+    def test_private_datadoc(self):
+        self.mock_cell.doc = self._create_private_datadoc_mock()
+        expected_result = {
+            "id": self.QUERY_CELL_ID,
+            "query_type": "query_cell",
+            "title": self.QUERY_CELL_TITLE,
+            "data_doc_id": self.DATADOC_ID,
+            "environment_id": self.ENVIRONMENT_ID,
+            "author_uid": self.AUTHOR_UID,
+            "engine_id": self.ENGINE_ID,
+            "statement_type": ["SELECT"],
+            "created_at": CREATED_AT_EPOCH,
+            "full_table_name": ["main.test_table", "main.test_table_2"],
+            "query_text": self.QUERY_TEXT,
+            "public": False,
+            "readable_user_ids": [],
+        }
+        result = query_cell_to_es(self.mock_cell, session=MagicMock())
+        self._assert_equals_query_item(result, expected_result)
+
+    def test_public_datadoc(self):
+        self.mock_cell.doc = self._create_public_datadoc_mock()
+        expected_result = {
+            "id": self.QUERY_CELL_ID,
+            "query_type": "query_cell",
+            "title": self.QUERY_CELL_TITLE,
+            "data_doc_id": self.DATADOC_ID,
+            "environment_id": self.ENVIRONMENT_ID,
+            "author_uid": self.AUTHOR_UID,
+            "engine_id": self.ENGINE_ID,
+            "statement_type": ["SELECT"],
+            "created_at": CREATED_AT_EPOCH,
+            "full_table_name": ["main.test_table", "main.test_table_2"],
+            "query_text": self.QUERY_TEXT,
+            "public": True,
+            "readable_user_ids": [],
+        }
+        result = query_cell_to_es(self.mock_cell, session=MagicMock())
+        self._assert_equals_query_item(result, expected_result)
+
+    def test_partial_dict(self):
+        # Test that heavy process_query function isn't run when we select specific dict fields
+        with patch("lib.query_analysis.lineage.process_query") as mock_process_query:
+            result = query_cell_to_es(
+                self.mock_cell,
+                fields=["id", "query_type", "statement_type"],
+                session=MagicMock(),
+            )
+            self.assertEquals(
+                result,
+                {
+                    "id": self.QUERY_CELL_ID,
+                    "query_type": "query_cell",
+                    "statement_type": ["SELECT"],
+                },
+            )
+            self.assertEquals(mock_process_query.call_count, 0)
+
+
+class QueryExecutionTestCase(BaseQueryTestCase):
+    EXECUTION_ID = 2837
+    QUERY_DURATION = 15  # COMPLETED_AT_DT - CREATED_AT_DT seconds
+
+    def setUp(self):
+        super(QueryExecutionTestCase, self).setUp()
+
+        # mock query_execution
+        self.mock_execution = MagicMock(
+            id=self.EXECUTION_ID,
+            uid=self.AUTHOR_UID,
+            engine_id=self.ENGINE_ID,
+            query=self.QUERY_TEXT,
+            created_at=CREATED_AT_DT,
+            completed_at=COMPLETED_AT_DT,
+        )
+
+    def test_no_data_cell(self):
+        result = query_execution_to_es(self.mock_execution, session=MagicMock())
+        expected_result = {
+            "id": self.EXECUTION_ID,
+            "query_type": "query_execution",
+            "title": None,
+            "environment_id": [self.ENVIRONMENT_ID],
+            "author_uid": self.AUTHOR_UID,
+            "engine_id": self.ENGINE_ID,
+            "statement_type": ["SELECT"],
+            "created_at": CREATED_AT_EPOCH,
+            "duration": self.QUERY_DURATION,
+            "full_table_name": ["main.test_table", "main.test_table_2"],
+            "query_text": self.QUERY_TEXT,
+            "public": True,
+            "readable_user_ids": [],
+        }
+        self._assert_equals_query_item(result, expected_result)
+
+    def test_with_data_cell(self):
+        mock_cell = self._get_mock_query_cell()
+        expected_result = {
+            "id": self.EXECUTION_ID,
+            "query_type": "query_execution",
+            "title": self.QUERY_CELL_TITLE,
+            "environment_id": [self.ENVIRONMENT_ID],
+            "author_uid": self.AUTHOR_UID,
+            "engine_id": self.ENGINE_ID,
+            "statement_type": ["SELECT"],
+            "created_at": CREATED_AT_EPOCH,
+            "duration": self.QUERY_DURATION,
+            "full_table_name": ["main.test_table", "main.test_table_2"],
+            "query_text": self.QUERY_TEXT,
+            "public": False,
+            "readable_user_ids": ["alice", "charlie"],
+        }
+        result = query_execution_to_es(
+            self.mock_execution, data_cell=mock_cell, session=MagicMock()
+        )
+        self._assert_equals_query_item(result, expected_result)
+
+    def test_partial_dict(self):
+        # Test that heavy process_query function isn't run when we select specific dict fields
+        with patch("lib.query_analysis.lineage.process_query") as mock_process_query:
+            result = query_execution_to_es(
+                self.mock_execution,
+                fields=["id", "query_type", "readable_user_ids"],
+                session=MagicMock(),
+            )
+            self.assertEquals(
+                result,
+                {
+                    "id": self.EXECUTION_ID,
+                    "query_type": "query_execution",
+                    "readable_user_ids": [],
+                },
+            )
+            self.assertEquals(mock_process_query.call_count, 0)
+
+
+class DataDocTestCase(TestCase):
+    DATADOC_ID = 112
+    ENVIRONMENT_ID = 7
+    OWNER_UID = "bob"
+    DATADOC_TITLE = "Test DataDoc"
+
+    def _get_datadoc_cells_mock(self):
+        return [
+            MagicMock(
+                cell_type=DataCellType.query,
+                context="SELECT * FROM table;",
+                meta={"title": "test cell"},
+            ),
+            MagicMock(
+                cell_type=DataCellType.query,
+                context="SELECT * FROM table_2;",
+                meta={},
+            ),
+            MagicMock(cell_type=DataCellType.text, context="test text"),
+            MagicMock(
+                cell_type=DataCellType.chart,
+            ),
+        ]
+
+    def _get_datadoc_mock(self):
+        mock_doc = MagicMock(
+            id=self.DATADOC_ID,
+            environment_id=self.ENVIRONMENT_ID,
+            owner_uid=self.OWNER_UID,
+            created_at=CREATED_AT_DT,
+            title=self.DATADOC_TITLE,
+            public=False,
+            cells=self._get_datadoc_cells_mock(),
+        )
+        return mock_doc
+
+    def _patch_get_data_doc_editors_by_doc_id(self):
+        get_data_doc_editors_by_doc_id_patch = patch(
+            "logic.datadoc.get_data_doc_editors_by_doc_id"
+        )
+        self.get_data_doc_editors_by_doc_id_mock = (
+            get_data_doc_editors_by_doc_id_patch.start()
+        )
+        self.addCleanup(get_data_doc_editors_by_doc_id_patch.stop)
+        self.get_data_doc_editors_by_doc_id_mock.return_value = [
+            MagicMock(uid="alice"),
+            MagicMock(uid="charlie"),
+        ]
+
+    def setUp(self):
+        self.mock_doc = self._get_datadoc_mock()
+        self._patch_get_data_doc_editors_by_doc_id()
+
+    def test_data_doc_to_es(self):
+        result = datadocs_to_es(self.mock_doc, session=MagicMock())
+        expected_result = {
+            "id": self.DATADOC_ID,
+            "environment_id": self.ENVIRONMENT_ID,
+            "owner_uid": self.OWNER_UID,
+            "created_at": CREATED_AT_EPOCH,
+            "cells": "test cell\nSELECT * FROM table;\nSELECT * FROM table_2;\ntest text\n[... additional unparsable content ...]",
+            "title": self.DATADOC_TITLE,
+            "public": False,
+            "readable_user_ids": ["alice", "charlie"],
+        }
+        self.assertEquals(result, expected_result)
+
+    def test_partial_dict(self):
+        with patch("logic.elasticsearch.get_joined_cells") as mock_get_joined_cells:
+            result = datadocs_to_es(
+                self.mock_doc,
+                fields=["id", "environment_id", "created_at"],
+                session=MagicMock(),
+            )
+            self.assertEquals(mock_get_joined_cells.call_count, 0)
+            self.assertEquals(
+                result,
+                {
+                    "id": self.DATADOC_ID,
+                    "environment_id": self.ENVIRONMENT_ID,
+                    "created_at": CREATED_AT_EPOCH,
+                },
+            )
+
+
+class TableTestCase(TestCase):
+    TABLE_ID = 2
+    TABLE_DESCRIPTION = "this is a test table"
+    TABLE_WEIGHT = 8
+    TABLE_NAME = "test_table"
+    SCHEMA_NAME = "test_schema"
+    FULL_NAME = "test_schema.test_table"
+    METASTORE_ID = 17
+
+    def _get_data_schema_mock(self):
+        mock_data_schema = MagicMock(metastore_id=self.METASTORE_ID)
+        mock_data_schema.name = self.SCHEMA_NAME
+        return mock_data_schema
+
+    def _get_columns_mock(self):
+        mock_col_a = MagicMock()
+        mock_col_a.name = "col_a"
+        mock_col_b = MagicMock()
+        mock_col_b.name = "col_b"
+        return [mock_col_a, mock_col_b]
+
+    def _get_table_mock(self):
+        table_mock = MagicMock(
+            id=self.TABLE_ID,
+            created_at=CREATED_AT_DT,
+            golden=False,
+            information=MagicMock(description=self.TABLE_DESCRIPTION),
+            tags=[
+                MagicMock(tag_name="tag_1"),
+                MagicMock(tag_name="tag_2"),
+            ],
+        )
+        table_mock.name = self.TABLE_NAME
+        table_mock.data_schema = self._get_data_schema_mock()
+        table_mock.columns = self._get_columns_mock()
+        return table_mock
+
+    def _patch_get_table_weight(self):
+        get_table_weight_patch = patch("logic.elasticsearch.get_table_weight")
+        self.get_table_weight_mock = get_table_weight_patch.start()
+        self.addCleanup(get_table_weight_patch.stop)
+        self.get_table_weight_mock.return_value = self.TABLE_WEIGHT
+
+    def setUp(self):
+        self.table_mock = self._get_table_mock()
+        self._patch_get_table_weight()
+
+    def test_table_to_es(self):
+        expected_result = {
+            "id": self.TABLE_ID,
+            "metastore_id": self.METASTORE_ID,
+            "schema": self.SCHEMA_NAME,
+            "name": self.TABLE_NAME,
+            "full_name": self.FULL_NAME,
+            "full_name_ngram": self.FULL_NAME,
+            "completion_name": {
+                "input": [
+                    self.FULL_NAME,
+                    self.TABLE_NAME,
+                ],
+                "weight": self.TABLE_WEIGHT,
+                "contexts": {
+                    "metastore_id": self.METASTORE_ID,
+                },
+            },
+            "description": self.TABLE_DESCRIPTION,
+            "created_at": CREATED_AT_EPOCH,
+            "columns": ["col_a", "col_b"],
+            "golden": False,
+            "importance_score": self.TABLE_WEIGHT,
+            "tags": ["tag_1", "tag_2"],
+        }
+
+        self.assertEquals(
+            table_to_es(self.table_mock, session=MagicMock()),
+            expected_result,
+        )
+        self.assertEquals(
+            self.get_table_weight_mock.call_count, 1
+        )  # ensure table weight isn't computed twice
+
+    def test_partial_dict(self):
+        self.assertEquals(
+            table_to_es(
+                self.table_mock, fields=["id", "description"], session=MagicMock()
+            ),
+            {
+                "id": self.TABLE_ID,
+                "description": self.TABLE_DESCRIPTION,
+            },
+        )
+        self.assertEquals(self.get_table_weight_mock.call_count, 0)
+
+
+class UserTestCase(TestCase):
+    def setUp(self):
+        self.user_mock = MagicMock(username="john", fullname="John Smith 123", id=7)
+
+    def test_user_to_es(self):
+        self.assertEquals(
+            user_to_es(self.user_mock, session=MagicMock()),
+            {
+                "id": 7,
+                "username": "john",
+                "fullname": "John Smith 123",
+                "suggest": {"input": ["john", "john", "john smith", "john", "smith"]},
+            },
+        )
+
+    def test_partial_dict(self):
+        with patch(
+            "logic.elasticsearch.process_names_for_suggestion"
+        ) as mock_process_names:
+            self.assertEquals(
+                user_to_es(
+                    self.user_mock,
+                    fields=["id", "username", "fullname"],
+                    session=MagicMock(),
+                ),
+                {
+                    "id": 7,
+                    "username": "john",
+                    "fullname": "John Smith 123",
+                },
+            )
+            self.assertEquals(mock_process_names.call_count, 0)


### PR DESCRIPTION
fixes #865

- add `public` and `readable_user_ids` fields to query_cell and query_execution elasticsearch indices to restrict access to queries on private datadocs
- change elasticsearch item creation functions to allow option to generate/update specific fields
- update `querybook/server/datasources/search.py` to use "must" query to ensure user has access to datadocs & queries that are returned
