### PR TITLE
fix: query result limit value

### DIFF
--- a/querybook/config/query_result_limit.yaml
+++ b/querybook/config/query_result_limit.yaml
@@ -1,0 +1,6 @@
+default_query_result_size: 1000
+query_result_size_options: # Make sure this is in increasing order
+    - 1000
+    - 5000
+    - 10000
+    - 50000

--- a/querybook/server/lib/table_upload/exporter/s3_exporter.py
+++ b/querybook/server/lib/table_upload/exporter/s3_exporter.py
@@ -17,7 +17,7 @@ from lib.query_analysis.create_table.create_table import (
     get_external_create_table_statement,
 )
 from lib.table_upload.exporter.utils import update_pandas_df_column_name_type
-from querybook.server.env import QuerybookSettings
+from env import QuerybookSettings
 from .base_exporter import BaseTableUploadExporter
 
 S3_OBJECT_KEY_NOT_ALLOWED_CHAR = r"[^\w-]+"

--- a/querybook/webapp/const/queryExecution.ts
+++ b/querybook/webapp/const/queryExecution.ts
@@ -137,4 +137,5 @@ export interface IQueryExecutionNotification {
 }
 
 // Make sure this is in increasing order
-export const StatementExecutionResultSizes = [1000, 5000, 10000, 50000];
+export const StatementExecutionResultSizes: number[] = require('config/query_result_limit.yaml')
+    .query_result_size_options;


### PR DESCRIPTION
although we allow 50k rows max to be fetched, the backend has an assert of 5k rows. Unified both limits via yaml config