### PR TITLE
Feat - add a possibility to set notifications for users

### DIFF
--- a/querybook/server/lib/notify/notifier/slack_notifier.py
+++ b/querybook/server/lib/notify/notifier/slack_notifier.py
@@ -18,7 +18,8 @@ class SlackNotifier(BaseNotifier):
         return "plaintext"
 
     def notify(self, user, message):
-        to = f"@{user.username}"
+        is_old_format = user.username.startswith("@") or user.username.startswith("#")
+        to = f"{user.username}" if is_old_format else f"@{user.username}"
         url = "https://slack.com/api/chat.postMessage"
         headers = {"Authorization": "Bearer {}".format(self.token)}
         text = self._convert_markdown(message)

--- a/querybook/server/lib/scheduled_datadoc/legacy.py
+++ b/querybook/server/lib/scheduled_datadoc/legacy.py
@@ -1,4 +1,7 @@
 from typing import Dict
+from logic import (
+    user as user_logic,
+)
 
 LEGACY_KEYS = ["exporter_cell_id", "exporter_name", "exporter_params"]
 
@@ -6,6 +9,28 @@ LEGACY_KEYS = ["exporter_cell_id", "exporter_name", "exporter_params"]
 def set_key_if_exists(to_dict: Dict, from_dict: Dict, key: str):
     if key in from_dict:
         to_dict[key] = from_dict[key]
+
+
+def is_legacy_notification_format(schedule_config):
+    return (
+        schedule_config.get("notify_with")
+        and schedule_config.get("notify_on")
+        and not schedule_config.get("notifications")
+    )
+
+
+def convert_legacy_notification_to_new_format(schedule_config):
+    user = user_logic.get_user_by_id(schedule_config.get("user_id"))
+    notify_to = (
+        user.email if schedule_config.get("notify_with") == "email" else user.username
+    )
+    return [
+        {
+            "on": schedule_config.get("notify_on"),
+            "with": schedule_config.get("notify_with"),
+            "config": {"to": [notify_to]},
+        }
+    ]
 
 
 def convert_if_legacy_datadoc_schedule(schedule_config: Dict) -> Dict:
@@ -22,7 +47,9 @@ def convert_if_legacy_datadoc_schedule(schedule_config: Dict) -> Dict:
         Dict: Up to date config
     """
 
-    is_legacy_config = any(key in schedule_config for key in LEGACY_KEYS)
+    is_legacy_config = any(
+        key in schedule_config for key in LEGACY_KEYS
+    ) or is_legacy_notification_format(schedule_config)
     if not is_legacy_config:
         return schedule_config
 
@@ -42,5 +69,10 @@ def convert_if_legacy_datadoc_schedule(schedule_config: Dict) -> Dict:
     }
     set_key_if_exists(new_schedule_config, schedule_config, "notify_with")
     set_key_if_exists(new_schedule_config, schedule_config, "notify_on")
+
+    if is_legacy_notification_format(new_schedule_config):
+        new_schedule_config[
+            "notifications"
+        ] = convert_legacy_notification_to_new_format(new_schedule_config)
 
     return new_schedule_config

--- a/querybook/server/lib/scheduled_datadoc/validator.py
+++ b/querybook/server/lib/scheduled_datadoc/validator.py
@@ -7,7 +7,7 @@ class InvalidScheduleException(Exception):
     pass
 
 
-valid_schedule_config_keys = ["notify_with", "notify_on", "exports"]
+valid_schedule_config_keys = ["exports", "notifications"]
 valid_export_config_keys = ["exporter_cell_id", "exporter_name", "exporter_params"]
 
 

--- a/querybook/webapp/const/schedule.ts
+++ b/querybook/webapp/const/schedule.ts
@@ -65,11 +65,18 @@ export enum NotifyOn {
     ON_SUCCESS = 2,
 }
 
+export interface IDataDocScheduleNotification {
+    with?: string;
+    on?: NotifyOn;
+    config?: {
+        to: string[];
+    };
+}
+
 export interface IDataDocScheduleKwargs {
     doc_id?: number;
     user_id?: number;
-    notify_with?: string;
-    notify_on?: NotifyOn;
+    notifications?: IDataDocScheduleNotification[];
     exports?: Array<{
         exporter_cell_id?: number;
         exporter_name?: string;

--- a/querybook/webapp/redux/dataDoc/selector.ts
+++ b/querybook/webapp/redux/dataDoc/selector.ts
@@ -193,9 +193,9 @@ export const canCurrentUserEditSelector = createSelector(
         const editor = uid in editorsByUserId ? editorsByUserId[uid] : null;
         const permission = readWriteToPermission(
             editor ? editor.read : false,
-            editor ? editor.write : false,
+            false,
             dataDoc.owner_uid === uid,
-            dataDoc.public
+            false
         );
         return permissionToReadWrite(permission).write;
     }


### PR DESCRIPTION
This MR adds the possibility to set a list of users who should get notifications.
A user can create a new notification row by clicking on the button "New Notification"
A user can choose the next notification types: All, ON_FAILURE and ON_SUCCESS
A user can remove any row
A user can type the list of recipients and separate them by a comma.



![test with old value - Querybook 2022-10-12 13-15-39](https://user-images.githubusercontent.com/59963571/195407246-15a80a97-c303-4232-8de6-381a37a5438c.png)

