### PR TITLE
feat: add reverse mapping for lists - list UI in table & datadocs pages

### DIFF
--- a/querybook/server/datasources/board.py
+++ b/querybook/server/datasources/board.py
@@ -90,7 +90,7 @@ def delete_board(board_id, **fields):
         Board.delete(board.id, session=session)
 
 
-@register("/board_item/<item_type>/<int:item_id>/board/", methods=["GET"])
+@register("/board_item/<item_type>/<int:item_id>/board_id/", methods=["GET"])
 def get_board_ids_from_board_item(item_type: str, item_id: int, environment_id: int):
     """Given an potential item, find all possible board ids it can
        be related to
@@ -101,6 +101,21 @@ def get_board_ids_from_board_item(item_type: str, item_id: int, environment_id: 
         environment_id {[int]} - [id of board environment]
     """
     return logic.get_board_ids_from_board_item(item_type, item_id, environment_id)
+
+
+@register("/board_item/<item_type>/<int:item_id>/board/", methods=["GET"])
+def get_boards_from_board_item(item_type: str, item_id: int, environment_id: int):
+    """Given an potential item, find all boards containing the list
+       that the current user has access to
+
+    Arguments:
+        item_type {[str]} -- [data_doc or table]
+        item_id {[int]} -- [Doc id or table id]
+        environment_id {[int]} - [id of board environment]
+    """
+    return logic.get_accessible_boards_from_board_item(
+        item_type, item_id, environment_id, current_user.id
+    )
 
 
 @register(

--- a/querybook/server/logic/board.py
+++ b/querybook/server/logic/board.py
@@ -1,4 +1,6 @@
 import datetime
+
+from sqlalchemy import or_
 from app.db import with_session
 from models.board import Board, BoardItem
 from models.user import User
@@ -149,6 +151,25 @@ def get_board_ids_from_board_item(item_type, item_id, environment_id, session=No
             .filter(Board.environment_id == environment_id)
             .all(),
         )
+    )
+
+
+@with_session
+def get_accessible_boards_from_board_item(
+    item_type, item_id, environment_id, current_user_id, session=None
+):
+    return (
+        session.query(Board)
+        .join(BoardItem, Board.id == BoardItem.parent_board_id)
+        .filter(getattr(BoardItem, item_type_to_id_type(item_type)) == item_id)
+        .filter(Board.environment_id == environment_id)
+        .filter(
+            or_(
+                Board.public.is_(True),
+                Board.owner_uid == current_user_id,
+            )
+        )
+        .all()
     )
 
 

--- a/querybook/webapp/components/BoardDetailedList/BoardDetailedList.scss
+++ b/querybook/webapp/components/BoardDetailedList/BoardDetailedList.scss
@@ -1,0 +1,34 @@
+.BoardDetailedList {
+    .Board {
+        display: flex;
+        flex-direction: column;
+        border-radius: var(--border-radius);
+        padding: 8px 16px;
+        background-color: var(--bg-lightest);
+        margin-bottom: var(--margin);
+        min-width: max-content;
+
+        &:hover {
+            background-color: var(--bg-hover);
+        }
+
+        .Board-description {
+            color: var(--text-light);
+        }
+
+        .Board-bottom {
+            align-items: baseline;
+            color: var(--text-light);
+        }
+
+        .Board-owner-info {
+            display: flex;
+            align-items: center;
+            align-self: flex-end;
+        }
+
+        .UserAvatar {
+            margin-right: 4px;
+        }
+    }
+}

--- a/querybook/webapp/components/BoardDetailedList/BoardDetailedList.tsx
+++ b/querybook/webapp/components/BoardDetailedList/BoardDetailedList.tsx
@@ -2,7 +2,7 @@ import { stateFromHTML } from 'draft-js-import-html';
 import React from 'react';
 
 import { AccentText, StyledText } from 'ui/StyledText/StyledText';
-import { IBoard } from 'const/board';
+import { IBoardBase } from 'const/board';
 import { UserAvatar } from 'components/UserBadge/UserAvatar';
 import { useUser } from 'hooks/redux/useUser';
 import { LoadingRow } from 'ui/Loading/Loading';
@@ -15,11 +15,11 @@ import { RichTextEditor } from 'ui/RichTextEditor/RichTextEditor';
 import './BoardDetailedList.scss';
 
 export interface IBoardDetailedListProps {
-    boards: IBoard[];
+    boards: IBoardBase[];
 }
 
 const BoardListItem: React.FunctionComponent<{
-    board: IBoard;
+    board: IBoardBase;
 }> = ({ board }) => {
     const {
         created_at: createdAt,
@@ -57,7 +57,7 @@ const BoardListItem: React.FunctionComponent<{
             </div>
             <Level className="Board-bottom">
                 <span className="Board-owner-info">
-                    <UserAvatar className="mr4" uid={ownerUid} tiny />
+                    <UserAvatar uid={ownerUid} tiny />
                     {ownerInfo.username}
                 </span>
                 <StyledText size="small" color="lightest">

--- a/querybook/webapp/components/BoardDetailedList/BoardDetailedList.tsx
+++ b/querybook/webapp/components/BoardDetailedList/BoardDetailedList.tsx
@@ -1,0 +1,81 @@
+import { stateFromHTML } from 'draft-js-import-html';
+import React from 'react';
+
+import { AccentText, StyledText } from 'ui/StyledText/StyledText';
+import { IBoard } from 'const/board';
+import { UserAvatar } from 'components/UserBadge/UserAvatar';
+import { useUser } from 'hooks/redux/useUser';
+import { LoadingRow } from 'ui/Loading/Loading';
+import { Level } from 'ui/Level/Level';
+import { generateFormattedDate } from 'lib/utils/datetime';
+import { getWithinEnvUrl } from 'lib/utils/query-string';
+import { Link } from 'ui/Link/Link';
+import { RichTextEditor } from 'ui/RichTextEditor/RichTextEditor';
+
+import './BoardDetailedList.scss';
+
+export interface IBoardDetailedListProps {
+    boards: IBoard[];
+}
+
+const BoardListItem: React.FunctionComponent<{
+    board: IBoard;
+}> = ({ board }) => {
+    const {
+        created_at: createdAt,
+        description,
+        id,
+        name,
+        owner_uid: ownerUid,
+    } = board;
+    const { userInfo: ownerInfo, loading } = useUser({ uid: ownerUid });
+
+    if (loading) {
+        return (
+            <div className="Board flex-center">
+                <LoadingRow />
+            </div>
+        );
+    }
+
+    return (
+        <div className="Board">
+            <Link to={getWithinEnvUrl(`/list/${id}`)}>
+                <AccentText size="smedium" weight="bold" color="text" hover>
+                    {name}
+                </AccentText>
+            </Link>
+            <div className="Board-description mv8">
+                {stateFromHTML(description).getPlainText().length ? (
+                    <RichTextEditor
+                        value={stateFromHTML(description)}
+                        readOnly
+                    />
+                ) : (
+                    'no description'
+                )}
+            </div>
+            <Level className="Board-bottom">
+                <span className="Board-owner-info">
+                    <UserAvatar className="mr4" uid={ownerUid} tiny />
+                    {ownerInfo.username}
+                </span>
+                <StyledText size="small" color="lightest">
+                    {generateFormattedDate(createdAt, 'X')}
+                </StyledText>
+            </Level>
+        </div>
+    );
+};
+
+export const BoardDetailedList: React.FunctionComponent<
+    IBoardDetailedListProps
+> = ({ boards }) => {
+    return (
+        <div className="BoardDetailedList">
+            {boards.map((board) => (
+                <BoardListItem board={board} key={board.id} />
+            ))}
+        </div>
+    );
+};

--- a/querybook/webapp/components/DataDocListsButton/DataDocListsButton.tsx
+++ b/querybook/webapp/components/DataDocListsButton/DataDocListsButton.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { IDataDoc } from 'const/datadoc';
+import { IconButton } from 'ui/Button/IconButton';
+import { DataDocListsModal } from 'components/DataDocListsModal/DataDocListsModal';
+
+interface IProps {
+    dataDoc: IDataDoc;
+}
+
+export const DataDocListsButton: React.FunctionComponent<IProps> = ({
+    dataDoc,
+}) => {
+    const [showLists, setShowLists] = React.useState(false);
+
+    return (
+        <div>
+            <IconButton
+                icon="List"
+                onClick={() => setShowLists(true)}
+                tooltip="View Lists"
+                tooltipPos="left"
+                title="Lists"
+            />
+            {showLists ? (
+                <DataDocListsModal
+                    dataDoc={dataDoc}
+                    onHide={() => setShowLists(false)}
+                />
+            ) : null}
+        </div>
+    );
+};

--- a/querybook/webapp/components/DataDocListsModal/DataDocListsModal.tsx
+++ b/querybook/webapp/components/DataDocListsModal/DataDocListsModal.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import { EmptyText } from 'ui/StyledText/StyledText';
+import { Modal } from 'ui/Modal/Modal';
+import { BoardDetailedList } from 'components/BoardDetailedList/BoardDetailedList';
+import { currentEnvironmentSelector } from 'redux/environment/selector';
+import { Loading } from 'ui/Loading/Loading';
+import { BoardResource } from 'resource/board';
+import { IDataDoc } from 'const/datadoc';
+import { useResource } from 'hooks/useResource';
+
+interface IProps {
+    dataDoc: IDataDoc;
+    onHide: () => void;
+}
+
+export const DataDocListsModal: React.FunctionComponent<IProps> = ({
+    dataDoc,
+    onHide,
+}) => {
+    const environment = useSelector(currentEnvironmentSelector);
+
+    const { data: boards, isLoading } = useResource(
+        React.useCallback(
+            () =>
+                BoardResource.getItemBoards(
+                    environment.id,
+                    'data_doc',
+                    dataDoc.id
+                ),
+            [environment.id, dataDoc.id]
+        )
+    );
+
+    if (isLoading) {
+        return <Loading />;
+    }
+
+    const dataDocName = dataDoc.title ? `"${dataDoc.title}"` : 'DataDoc';
+
+    const noListsDOM = (
+        <EmptyText className="m24">No lists available.</EmptyText>
+    );
+
+    return (
+        <Modal onHide={onHide} title={`Lists Containing ${dataDocName}`}>
+            {isLoading ? (
+                <Loading />
+            ) : boards.length ? (
+                <BoardDetailedList boards={boards} />
+            ) : (
+                noListsDOM
+            )}
+        </Modal>
+    );
+};

--- a/querybook/webapp/components/DataDocRightSidebar/DataDocRightSidebar.tsx
+++ b/querybook/webapp/components/DataDocRightSidebar/DataDocRightSidebar.tsx
@@ -14,6 +14,7 @@ import { DataDocScheduleButton } from './DataDocScheduleButton';
 import { DeleteDataDocButton } from './DeleteDataDocButton';
 
 import './DataDocRightSidebar.scss';
+import { DataDocListsButton } from 'components/DataDocListsButton/DataDocListsButton';
 
 interface IProps {
     dataDoc: IDataDoc;
@@ -60,6 +61,9 @@ export const DataDocRightSidebar: React.FunctionComponent<IProps> = ({
             title="Delete"
         />
     );
+
+    const listsButtonDOM = <DataDocListsButton dataDoc={dataDoc} />;
+
     const templateButtonDOM = (
         <DataDocTemplateButton
             dataDoc={dataDoc}
@@ -108,6 +112,7 @@ export const DataDocRightSidebar: React.FunctionComponent<IProps> = ({
                 {isEditable && exporterExists && (
                     <DataDocDAGExporterButton docId={dataDoc.id} />
                 )}
+                {listsButtonDOM}
                 {templateButtonDOM}
                 {scheduleButtonDOM}
                 <IconButton

--- a/querybook/webapp/components/DataTableView/DataTableView.tsx
+++ b/querybook/webapp/components/DataTableView/DataTableView.tsx
@@ -12,6 +12,7 @@ import { DataTableViewOverview } from 'components/DataTableViewOverview/DataTabl
 import { DataTableViewQueryExamples } from 'components/DataTableViewQueryExample/DataTableViewQueryExamples';
 import { DataTableViewSamples } from 'components/DataTableViewSamples/DataTableViewSamples';
 import { DataTableViewSourceQuery } from 'components/DataTableViewSourceQuery/DataTableViewSourceQuery';
+import { DataTableViewLists } from 'components/DataTableViewLists/DataTableViewLists';
 import { DataTableViewWarnings } from 'components/DataTableViewWarnings/DataTableViewWarnings';
 import { IPaginatedQuerySampleFilters } from 'const/metastore';
 import { setBrowserTitle } from 'lib/querybookUI';
@@ -57,6 +58,10 @@ const tabDefinitions = [
     {
         name: 'Query Examples',
         key: 'query_examples',
+    },
+    {
+        name: 'Lists',
+        key: 'lists',
     },
     {
         name: 'Warnings',
@@ -180,6 +185,16 @@ class DataTableViewComponent extends React.PureComponent<
     }
 
     @bind
+    public makeListsDOM() {
+        const { table } = this.props;
+        return (
+            <Loader item={table} itemLoader={NOOP}>
+                <DataTableViewLists table={table} />
+            </Loader>
+        );
+    }
+
+    @bind
     public makeWarningsDOM() {
         const { tableWarnings, table } = this.props;
         return (
@@ -297,6 +312,7 @@ class DataTableViewComponent extends React.PureComponent<
             lineage: this.makeLineageDOM,
             source_query: this.makeQueryDOM,
             query_examples: this.makeQueryExamplesDOM,
+            lists: this.makeListsDOM,
             warnings: this.makeWarningsDOM,
         };
 

--- a/querybook/webapp/components/DataTableViewLists/DataTableViewLists.tsx
+++ b/querybook/webapp/components/DataTableViewLists/DataTableViewLists.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import { IDataTable } from 'const/metastore';
+import { EmptyText } from 'ui/StyledText/StyledText';
+import { BoardResource } from 'resource/board';
+import { currentEnvironmentSelector } from 'redux/environment/selector';
+import { Loading } from 'ui/Loading/Loading';
+import { BoardDetailedList } from 'components/BoardDetailedList/BoardDetailedList';
+import { useResource } from 'hooks/useResource';
+
+export interface IDataTableViewListsProps {
+    table: IDataTable;
+}
+
+export const DataTableViewLists: React.FunctionComponent<
+    IDataTableViewListsProps
+> = ({ table }) => {
+    const environment = useSelector(currentEnvironmentSelector);
+
+    const { data: boards, isLoading } = useResource(
+        React.useCallback(
+            () =>
+                BoardResource.getItemBoards(environment.id, 'table', table.id),
+            [environment.id, table.id]
+        )
+    );
+
+    const noListsDOM = (
+        <EmptyText className="m24">No lists available.</EmptyText>
+    );
+
+    if (isLoading) {
+        return <Loading />;
+    }
+
+    return (
+        <div className="DataTableViewLists">
+            {boards.length ? <BoardDetailedList boards={boards} /> : noListsDOM}
+        </div>
+    );
+};

--- a/querybook/webapp/resource/board.ts
+++ b/querybook/webapp/resource/board.ts
@@ -47,6 +47,11 @@ export const BoardResource = {
         ds.delete(`/board/${boardId}/${itemType}/${itemId}/`),
 
     getItemBoardIds: (envId: number, itemType: BoardItemType, itemId: number) =>
+        ds.fetch<number[]>(`/board_item/${itemType}/${itemId}/board_id/`, {
+            environment_id: envId,
+        }),
+
+    getItemBoards: (envId: number, itemType: BoardItemType, itemId: number) =>
         ds.fetch<number[]>(`/board_item/${itemType}/${itemId}/board/`, {
             environment_id: envId,
         }),

--- a/querybook/webapp/resource/board.ts
+++ b/querybook/webapp/resource/board.ts
@@ -52,7 +52,7 @@ export const BoardResource = {
         }),
 
     getItemBoards: (envId: number, itemType: BoardItemType, itemId: number) =>
-        ds.fetch<number[]>(`/board_item/${itemType}/${itemId}/board/`, {
+        ds.fetch<IBoardBase[]>(`/board_item/${itemType}/${itemId}/board/`, {
             environment_id: envId,
         }),
 };


### PR DESCRIPTION
* Add tab to table page to display lists containing the table
<img width="911" alt="Screen Shot 2022-06-28 at 9 43 27 AM" src="https://user-images.githubusercontent.com/23270317/176235496-75c5205e-3864-4cdd-a45c-6c5efd3188c1.png">

* Add button to datadoc displaying lists containing the doc
<img width="154" alt="Screen Shot 2022-06-28 at 9 44 24 AM" src="https://user-images.githubusercontent.com/23270317/176235540-00c73077-177b-40fb-b388-0024d2ef0b12.png">
<img width="1236" alt="Screen Shot 2022-06-28 at 9 47 07 AM" src="https://user-images.githubusercontent.com/23270317/176235605-0d65b9e4-b39f-49b4-9d6c-f1373f82e1e7.png">

