### PR TITLE
feat: add auto url transform to querybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.5.3",
+    "version": "3.5.4",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/lib/query-result/detector.ts
+++ b/querybook/webapp/lib/query-result/detector.ts
@@ -1,5 +1,6 @@
 import { sampleSize } from 'lodash';
 
+import { isValidUrl } from 'lib/utils';
 import { isNumeric } from 'lib/utils/number';
 
 import { IColumnDetector } from './types';
@@ -22,6 +23,12 @@ const columnDetectors: IColumnDetector[] = [
                     return false;
                 }
             }),
+    },
+    {
+        type: 'url',
+        priority: 0.2,
+        checker: (colName: string, values: any[]) =>
+            detectTypeForValues(values, isValidUrl),
     },
     {
         type: 'number',

--- a/querybook/webapp/lib/query-result/transformer.tsx
+++ b/querybook/webapp/lib/query-result/transformer.tsx
@@ -7,6 +7,7 @@ import {
     isNumeric,
     roundNumberToDecimal,
 } from 'lib/utils/number';
+import { Link } from 'ui/Link/Link';
 
 import { IColumnTransformer } from './types';
 
@@ -69,6 +70,18 @@ const queryResultTransformers: IColumnTransformer[] = [
                 return v;
             }
         },
+    },
+    {
+        key: 'url',
+        name: 'Url Links',
+        appliesToType: ['url'],
+        priority: 0,
+        auto: true,
+        transform: (v: string): React.ReactNode => (
+            <Link to={v} naturalLink>
+                {v}
+            </Link>
+        ),
     },
 ]
     .concat(window.CUSTOM_COLUMN_TRANSFORMERS ?? [])

--- a/querybook/webapp/lib/utils/index.ts
+++ b/querybook/webapp/lib/utils/index.ts
@@ -295,3 +295,10 @@ export function getChangedObject(
 
     return ret;
 }
+
+// Source: https://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url/45567717#45567717
+const urlPattern =
+    /(?:https?):\/\/(\w+:?\w*)?(\S+)(:\d+)?(\/|\/([\w#!:.?+=&%!\-\/]))?/;
+export function isValidUrl(url: string): boolean {
+    return !!urlPattern.test(url);
+}


### PR DESCRIPTION
Query results that is a valid url will automatically be transformed into <a> tags