### PR TITLE
feat: strip white space when rendering templated queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.5.4",
+    "version": "3.5.5",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/lib/query_analysis/templating.py
+++ b/querybook/server/lib/query_analysis/templating.py
@@ -164,7 +164,14 @@ def create_get_latest_partition(engine_id: int) -> Callable[[str, str], str]:
 
 def get_templated_query_env(engine_id: int):
     jinja_env = SandboxedEnvironment()
+
+    # Inject helper functions
     jinja_env.globals.update(latest_partition=create_get_latest_partition(engine_id))
+
+    # Template rendering config
+    jinja_env.trim_blocks = True
+    jinja_env.lstrip_blocks = True
+
     return jinja_env
 
 


### PR DESCRIPTION
Before:
```


  
  


SELECT
  *
FROM(
    SELECT
      '2019' AS Year,
      Country,
      Score
    FROM
      world_happiness_2019
    ORDER BY
      Rank
    LIMIT
      10
  )

  
    UNION
  
  


SELECT
  *
FROM(
    SELECT
      '2018' AS Year,
      Country,
      Score
    FROM
      world_happiness_2018
    ORDER BY
      Rank
    LIMIT
      10
  )

  
    UNION
  
  

```

After
```
  SELECT
  *
FROM(
    SELECT
      '2019' AS Year,
      Country,
      Score
    FROM
      world_happiness_2019
    ORDER BY
      Rank
    LIMIT
      10
  )
    UNION
  SELECT
  *
```