### PR TITLE
Bump MySQL to a M1 compatible version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
             retries: 3
     mysql:
         container_name: querybook_mysql
-        image: mysql:5.7
+        image: mysql:8.0
         restart: always
         ports:
             # <Port exposed> : < MySQL Port running inside container>


### PR DESCRIPTION
From MySQL 8.0 it is also built for arm64:
https://hub.docker.com/layers/mysql/library/mysql/5.7.37/images/sha256-1520c2db1591b37fc7f2c0bc72b4e0a002afed6fcc2397f7bcd2bbdff490c930?context=explore

5.7 is amd64 only:
https://hub.docker.com/layers/mysql/library/mysql/5.7.37/images/sha256-1520c2db1591b37fc7f2c0bc72b4e0a002afed6fcc2397f7bcd2bbdff490c930?context=explore

I tested locally and seems to work fine 👍🏻 