### PR TITLE
fix: list drag and drop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.6.0",
+    "version": "3.6.1",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/models/board.py
+++ b/querybook/server/models/board.py
@@ -64,7 +64,7 @@ class Board(CRUDMixin, Base):
             next(
                 iter(
                     session.query(sql.func.max(BoardItem.item_order))
-                    .filter_by(board_id=self.id)
+                    .filter_by(parent_board_id=self.id)
                     .first()
                 ),
                 None,

--- a/querybook/webapp/components/Board/BoardItem.scss
+++ b/querybook/webapp/components/Board/BoardItem.scss
@@ -4,9 +4,8 @@
     margin-right: auto;
     border-radius: var(--border-radius-sm);
     background-color: var(--bg-lightest);
-    margin-bottom: 24px;
 
-    .BoardItem-controls .Icon {
+    .BoardItem-controls .IconButton {
         margin-right: 16px;
     }
 

--- a/querybook/webapp/components/Board/BoardItem.tsx
+++ b/querybook/webapp/components/Board/BoardItem.tsx
@@ -128,14 +128,8 @@ export const BoardItem: React.FunctionComponent<IBoardItemProps> = ({
                 icon="X"
                 noPadding
                 onClick={onDeleteBoardItem.bind(null, itemId, itemType)}
-                tooltip="Remove from board"
             />
-            <IconButton
-                size={18}
-                icon="MoveVertical"
-                noPadding
-                tooltip="Drag to reorder"
-            />
+            <IconButton size={18} icon="MoveVertical" noPadding />
         </>
     ) : (
         <>


### PR DESCRIPTION
- fixed board item order miscalculation
- Removed tooltip for buttons during drag and drop phase. The tooltip would make board item more bloated than what it actually looks like. In future, we should move to React based Tooltip solutions instead
- Removed duplicated CSS