### PR TITLE
feat: Add templating support for Adhoc query

### DIFF
--- a/querybook/server/datasources/datadoc.py
+++ b/querybook/server/datasources/datadoc.py
@@ -81,7 +81,7 @@ def get_data_docs(
 
 
 @register("/datadoc/", methods=["POST"])
-def create_data_doc(environment_id, cells=[], title=None):
+def create_data_doc(environment_id, cells=[], title=None, meta={}):
     with DBSession() as session:
         verify_environment_permission([environment_id])
         environment = Environment.get(id=environment_id, session=session)
@@ -93,18 +93,14 @@ def create_data_doc(environment_id, cells=[], title=None):
             public=environment.shareable,
             archived=False,
             title=title,
-            meta={},
+            meta=meta,
             session=session,
         )
 
 
 @register("/datadoc/from_execution/", methods=["POST"])
 def create_data_doc_from_execution(
-    environment_id,
-    execution_id,
-    engine_id,
-    query_string,
-    title=None,
+    environment_id, execution_id, engine_id, query_string, title=None, meta={}
 ):
     with DBSession() as session:
         verify_environment_permission([environment_id])
@@ -124,7 +120,7 @@ def create_data_doc_from_execution(
             public=environment.shareable,
             archived=False,
             title=title,
-            meta={},
+            meta=meta,
             session=session,
         )
 

--- a/querybook/webapp/components/DataDocTemplateButton/DataDocTemplateButton.tsx
+++ b/querybook/webapp/components/DataDocTemplateButton/DataDocTemplateButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import toast from 'react-hot-toast';
 
 import { DataDocTemplateVarForm } from 'components/DataDocTemplateButton/DataDocTemplateVarForm';
 import { IDataDoc } from 'const/datadoc';
@@ -34,6 +35,7 @@ export const DataDocTemplateButton: React.FunctionComponent<IProps> = ({
                 onSave={(meta) => {
                     changeDataDocMeta(dataDoc.id, meta);
                     setShowTemplateForm(false);
+                    toast.success('Variables saved');
                 }}
             />
         </Modal>

--- a/querybook/webapp/components/DataDocTemplateButton/DataDocTemplateCell.tsx
+++ b/querybook/webapp/components/DataDocTemplateButton/DataDocTemplateCell.tsx
@@ -1,5 +1,6 @@
 import { isEmpty } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
 
 import { DataDocTemplateVarForm } from 'components/DataDocTemplateButton/DataDocTemplateVarForm';
 import { IDataDoc } from 'const/datadoc';
@@ -68,6 +69,7 @@ export const DataDocTemplateCell: React.FunctionComponent<IProps> = ({
                         if (isEmpty(meta)) {
                             setShowFacde(true);
                         }
+                        toast.success('Variables saved');
                     }}
                 />
             </>

--- a/querybook/webapp/const/adhocQuery.ts
+++ b/querybook/webapp/const/adhocQuery.ts
@@ -1,5 +1,6 @@
 export interface IAdhocQuery {
     query?: string;
+    templatedVariables?: Record<string, any>;
     engineId?: number;
     executionId?: number;
 }

--- a/querybook/webapp/redux/dataDoc/action.ts
+++ b/querybook/webapp/redux/dataDoc/action.ts
@@ -221,12 +221,14 @@ export function cloneDataDoc(docId: number): ThunkResult<Promise<IRawDataDoc>> {
 }
 
 export function createDataDoc(
-    cells: Array<Partial<IDataCell>> = []
+    cells: Array<Partial<IDataCell>> = [],
+    meta: Record<string, any> = {}
 ): ThunkResult<Promise<IDataDoc>> {
     return async (dispatch, getState) => {
         const { data: rawDataDoc } = await DataDocResource.create(
             cells,
-            getState().environment.currentEnvironmentId
+            getState().environment.currentEnvironmentId,
+            meta
         );
         const { dataDoc, dataDocCellById } = normalizeRawDataDoc(rawDataDoc);
         dispatch(receiveDataDoc(dataDoc, dataDocCellById));
@@ -238,7 +240,8 @@ export function createDataDoc(
 export function createDataDocFromAdhoc(
     queryExecutionId: number,
     engineId: number,
-    queryString: string = ''
+    queryString: string = '',
+    meta: Record<string, any> = {}
 ): ThunkResult<Promise<IDataDoc>> {
     return async (dispatch, getState) => {
         const state = getState();
@@ -247,7 +250,8 @@ export function createDataDocFromAdhoc(
             state.environment.currentEnvironmentId,
             queryExecutionId,
             engineId,
-            queryString
+            queryString,
+            meta
         );
         const { dataDoc, dataDocCellById } = normalizeRawDataDoc(rawDataDoc);
         dispatch(receiveDataDoc(dataDoc, dataDocCellById));

--- a/querybook/webapp/resource/dataDoc.ts
+++ b/querybook/webapp/resource/dataDoc.ts
@@ -36,9 +36,14 @@ export const DataDocResource = {
             originator: dataDocSocket.socketId,
         }),
 
-    create: (cells: Array<Partial<IDataCell>>, environmentId: number) =>
+    create: (
+        cells: Array<Partial<IDataCell>>,
+        environmentId: number,
+        meta?: Record<string, any>
+    ) =>
         ds.save<IRawDataDoc>('/datadoc/', {
             title: '',
+            meta,
             environment_id: environmentId,
             cells,
         }),
@@ -47,10 +52,12 @@ export const DataDocResource = {
         environmentId: number,
         queryExecutionId: number,
         engineId: number,
-        queryString: string
+        queryString: string,
+        meta?: Record<string, any>
     ) =>
         ds.save<IRawDataDoc>('/datadoc/from_execution/', {
             title: '',
+            meta: meta,
             environment_id: environmentId,
             execution_id: queryExecutionId,
             engine_id: engineId,


### PR DESCRIPTION
This PR is to add templating support for Adhoc query, like the datadocs. Changes include

- Add a dropdown menu to add template variables and preview template rendered query. 
- Also moved the "create datadoc" and "add udf" to the dropdown menu
- When creating datadoc from the adhoc query, it will pass the template variables over as well

![image](https://user-images.githubusercontent.com/8308723/180325148-30803f64-ebf6-4fb1-afc0-2011b140b026.png)
![image](https://user-images.githubusercontent.com/8308723/180325388-6cd0ef63-f194-4d1b-86fc-da46c960d932.png)
![image](https://user-images.githubusercontent.com/8308723/180325433-04918f0b-f155-4016-b13b-06d7aded0f66.png)
![image](https://user-images.githubusercontent.com/8308723/180325981-4fa39761-e904-401a-90b0-8656a06e6d53.png)
