### PR TITLE
fix: various board related bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.6.1",
+    "version": "3.6.2",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/logic/elasticsearch.py
+++ b/querybook/server/logic/elasticsearch.py
@@ -828,7 +828,7 @@ def update_board_by_id(board_id, session=None):
                 "doc": formatted_object,
                 "doc_as_upsert": True,
             }  # ES requires this format for updates
-            _update(index_name, board, updated_body)
+            _update(index_name, board_id, updated_body)
         except Exception:
             LOG.error("failed to upsert board {}. Will pass.".format(board))
 

--- a/querybook/webapp/components/Board/Board.tsx
+++ b/querybook/webapp/components/Board/Board.tsx
@@ -8,11 +8,7 @@ import { BoardPageContext, IBoardPageContextType } from 'context/BoardPage';
 import { useBoardItemActions } from 'hooks/board/useBoardItemActions';
 import { useBrowserTitle } from 'hooks/useBrowserTitle';
 import { isAxiosError } from 'lib/utils/error';
-import {
-    fetchBoardIfNeeded,
-    getBoardEditors,
-    setCurrentBoardId,
-} from 'redux/board/action';
+import { fetchBoardIfNeeded, getBoardEditors } from 'redux/board/action';
 import * as boardSelectors from 'redux/board/selector';
 import { Dispatch, IStoreState } from 'redux/store/types';
 import { DraggableList } from 'ui/DraggableList/DraggableList';
@@ -38,10 +34,11 @@ const BoardDOM: React.FunctionComponent<IBoardDOMProps> = ({
     boardItemById,
 }) => {
     useBrowserTitle(board.name);
-    const isEditable = useSelector(boardSelectors.canCurrentUserEditSelector);
+    const isEditable = useSelector((state: IStoreState) =>
+        boardSelectors.canCurrentUserEditSelector(state, board.id)
+    );
 
     const [defaultCollapse, setDefaulCollapse] = React.useState(false);
-    // TODO - meowcodes: implement isEditable + board 0
     const [isEditMode, setIsEditMode] = React.useState(false);
 
     const { handleDeleteBoardItem, handleMoveBoardItem } =
@@ -52,8 +49,9 @@ const BoardDOM: React.FunctionComponent<IBoardDOMProps> = ({
             onDeleteBoardItem: handleDeleteBoardItem,
             isEditMode,
             isCollapsed: defaultCollapse,
+            boardId: board.id,
         }),
-        [handleDeleteBoardItem, isEditMode, defaultCollapse]
+        [handleDeleteBoardItem, isEditMode, defaultCollapse, board.id]
     );
 
     let boardItemDOM: React.ReactNode;
@@ -145,7 +143,6 @@ export const Board: React.FunctionComponent<IBoardProps> = ({ boardId }) => {
                 setError(e);
             }
         });
-        dispatch(setCurrentBoardId(boardId));
         dispatch(getBoardEditors(boardId));
     }, [boardId]);
 

--- a/querybook/webapp/components/Board/BoardHeader.tsx
+++ b/querybook/webapp/components/Board/BoardHeader.tsx
@@ -1,3 +1,4 @@
+import { ContentState } from 'draft-js';
 import * as React from 'react';
 import { useDispatch } from 'react-redux';
 
@@ -6,7 +7,7 @@ import { BoardViewersBadge } from 'components/BoardViewersBadge/BoardViewersBadg
 import { IBoardWithItemIds } from 'const/board';
 import { generateFormattedDate } from 'lib/utils/datetime';
 import { navigateWithinEnv } from 'lib/utils/query-string';
-import { setCurrentBoardId, updateBoard } from 'redux/board/action';
+import { updateBoard } from 'redux/board/action';
 import { updateSearchFilter, updateSearchType } from 'redux/search/action';
 import { SearchType } from 'redux/search/types';
 import { Dispatch } from 'redux/store/types';
@@ -34,25 +35,24 @@ export const BoardHeader: React.FunctionComponent<IProps> = ({
             if (searchType === SearchType.Query) {
                 dispatch(updateSearchFilter('query_type', 'query_execution'));
             }
-            dispatch(setCurrentBoardId(board.id));
-            navigateWithinEnv('/search/', { isModal: true, from: 'board' });
+            navigateWithinEnv('/search/', { isModal: true, boardId: board.id });
         },
-        [board.id]
+        [dispatch, board.id]
     );
 
     const handleDescriptionUpdate = React.useCallback(
-        (description) =>
+        (description: ContentState) =>
             dispatch(
                 updateBoard(board.id, board.name, board.public, description)
             ),
-        [board.id]
+        [dispatch, board.id, board.name, board.public]
     );
 
     const handleTitleChange = React.useCallback(
-        (updatedTitle) => {
+        (updatedTitle: string) => {
             dispatch(updateBoard(board.id, updatedTitle));
         },
-        [board.id]
+        [dispatch, board.id]
     );
 
     return (

--- a/querybook/webapp/components/Board/BoardItem.tsx
+++ b/querybook/webapp/components/Board/BoardItem.tsx
@@ -25,7 +25,14 @@ import { Title } from 'ui/Title/Title';
 import './BoardItem.scss';
 
 export interface IBoardItemProps {
+    /**
+     * Id of the boardItem in DB
+     */
     boardItemId: number;
+
+    /**
+     * Id of the item, i.e tableId or docId
+     */
     itemId: number;
     itemType: BoardItemType;
     title: string;
@@ -52,8 +59,11 @@ export const BoardItem: React.FunctionComponent<IBoardItemProps> = ({
         isCollapsed: defaultCollapsed,
         isEditMode,
         onDeleteBoardItem,
+        boardId,
     } = React.useContext(BoardPageContext);
-    const isEditable = useSelector(boardSelectors.canCurrentUserEditSelector);
+    const isEditable = useSelector((state: IStoreState) =>
+        boardSelectors.canCurrentUserEditSelector(state, boardId)
+    );
 
     const dispatch: Dispatch = useDispatch();
     const [collapsed, setCollapsed] = React.useState(defaultCollapsed);

--- a/querybook/webapp/components/BoardViewersBadge/BoardViewersBadge.tsx
+++ b/querybook/webapp/components/BoardViewersBadge/BoardViewersBadge.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { BoardViewersList } from 'components/BoardViewersList/BoardViewersList';
 import { fetchBoardAccessRequests } from 'redux/board/action';
 import { currentBoardAccessRequestsByUidSelector } from 'redux/board/selector';
-import { Dispatch } from 'redux/store/types';
+import { Dispatch, IStoreState } from 'redux/store/types';
 import { Button } from 'ui/Button/Button';
 import { Popover } from 'ui/Popover/Popover';
 
@@ -25,14 +25,14 @@ export const BoardViewersBadge: React.FunctionComponent<IProps> = ({
     const [showViewsList, setShowViewsList] = React.useState(false);
     const selfRef = React.useRef<HTMLDivElement>();
 
-    const accessRequestsByUid = useSelector(
-        currentBoardAccessRequestsByUidSelector
+    const accessRequestsByUid = useSelector((state: IStoreState) =>
+        currentBoardAccessRequestsByUidSelector(state, boardId)
     );
     const accessRequestsByUidLength = Object.keys(accessRequestsByUid).length;
 
     React.useEffect(() => {
         dispatch(fetchBoardAccessRequests(boardId));
-    }, [boardId]);
+    }, [dispatch, boardId]);
 
     return (
         <div className="BoardViewersBadge" ref={selfRef}>

--- a/querybook/webapp/components/BoardViewersList/BoardViewersList.tsx
+++ b/querybook/webapp/components/BoardViewersList/BoardViewersList.tsx
@@ -43,9 +43,12 @@ export const BoardViewersList: React.FunctionComponent<IProps> = ({
     } = useShallowSelector((state: IStoreState) => ({
         board: state.board.boardById[boardId],
         editorsByUid: state.board.editorsByBoardIdUserId[boardId],
-        editorInfos: boardEditorInfosSelector(state),
+        editorInfos: boardEditorInfosSelector(state, boardId),
         currentUserId: state.user.myUserInfo.uid,
-        accessRequestsByUid: currentBoardAccessRequestsByUidSelector(state),
+        accessRequestsByUid: currentBoardAccessRequestsByUidSelector(
+            state,
+            boardId
+        ),
     }));
 
     const isOwner = board.owner_uid === currentUserId;

--- a/querybook/webapp/components/EnvironmentAppRouter/EnvironmentModalSwitchRouter.tsx
+++ b/querybook/webapp/components/EnvironmentAppRouter/EnvironmentModalSwitchRouter.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Route, Switch, useHistory, useLocation } from 'react-router-dom';
+import { Route, Switch, useLocation } from 'react-router-dom';
 
 import { useModalRoute } from 'hooks/useModalRoute';
-import { usePrevious } from 'hooks/usePrevious';
 import { FourOhFour } from 'ui/ErrorPage/FourOhFour';
 import { Loading } from 'ui/Loading/Loading';
 import { Modal } from 'ui/Modal/Modal';
@@ -42,15 +41,12 @@ const UserSettingsMenuRoute = React.lazy(
 
 export const EnvironmentModalSwitchRouter: React.FC = () => {
     const location = useLocation();
-    const history = useHistory();
-
-    const lastLocation = usePrevious(location);
     const [lastNotModalLocation, setLastNotModalLocation] =
         React.useState(null);
 
     React.useEffect(() => {
-        if (history.action !== 'POP' && !lastLocation?.state?.isModal) {
-            setLastNotModalLocation(lastLocation);
+        if (!location?.state?.isModal) {
+            setLastNotModalLocation(location);
         }
     }, [location]);
 

--- a/querybook/webapp/components/EnvironmentAppRouter/modalRoute/SearchRoute.tsx
+++ b/querybook/webapp/components/EnvironmentAppRouter/modalRoute/SearchRoute.tsx
@@ -6,7 +6,6 @@ import { SearchOverview } from 'components/Search/SearchOverview';
 import { useBrowserTitle } from 'hooks/useBrowserTitle';
 import { useModalRoute } from 'hooks/useModalRoute';
 import history from 'lib/router-history';
-import { setCurrentBoardId } from 'redux/board/action';
 import { mapQueryParamToState as mapQueryParamToStateAction } from 'redux/search/action';
 import { Modal } from 'ui/Modal/Modal';
 
@@ -27,14 +26,9 @@ const SearchRoute: React.FunctionComponent<RouteComponentProps> = ({
         }
     }, [isModal, mapQueryParamToState]);
 
-    React.useEffect(() => {
-        const isFromBoard = location?.state?.from === 'board';
-        if (!isFromBoard) {
-            dispatch(setCurrentBoardId(null));
-        }
-    }, [location.state]);
+    const fromBoardId = location?.state?.boardId;
 
-    const contentDOM = <SearchOverview />;
+    const contentDOM = <SearchOverview fromBoardId={fromBoardId} />;
 
     return isModal ? (
         <Modal

--- a/querybook/webapp/components/PublicBoardPage/PublicBoardPage.tsx
+++ b/querybook/webapp/components/PublicBoardPage/PublicBoardPage.tsx
@@ -24,6 +24,7 @@ export const PublicBoardPage: React.FunctionComponent = () => {
             onDeleteBoardItem: () => null,
             isEditMode: false,
             isCollapsed: false,
+            boardId: 0,
         }),
         []
     );

--- a/querybook/webapp/components/Search/SearchOverview.tsx
+++ b/querybook/webapp/components/Search/SearchOverview.tsx
@@ -63,7 +63,14 @@ const userReactSelectStyle = makeReactSelectStyle(
     true,
     miniAsyncReactSelectStyles
 );
-export const SearchOverview: React.FunctionComponent = () => {
+
+interface ISearchOverviewProps {
+    fromBoardId?: number;
+}
+
+export const SearchOverview: React.FC<ISearchOverviewProps> = ({
+    fromBoardId,
+}) => {
     const {
         resultByPage,
         currentPage,
@@ -337,6 +344,7 @@ export const SearchOverview: React.FunctionComponent = () => {
                       key={`${result.query_type}-${result.id}`}
                       preview={result}
                       environmentName={environment.name}
+                      fromBoardId={fromBoardId}
                   />
               ))
             : searchType === SearchType.DataDoc
@@ -346,6 +354,7 @@ export const SearchOverview: React.FunctionComponent = () => {
                       key={result.id}
                       preview={result}
                       url={`/${environment.name}/datadoc/${result.id}/`}
+                      fromBoardId={fromBoardId}
                   />
               ))
             : searchType === SearchType.Table
@@ -355,6 +364,7 @@ export const SearchOverview: React.FunctionComponent = () => {
                       preview={result}
                       url={`/${environment.name}/table/${result.id}/`}
                       searchString={searchString}
+                      fromBoardId={fromBoardId}
                   />
               ))
             : (results as IBoardPreview[]).map((result) => (
@@ -363,6 +373,7 @@ export const SearchOverview: React.FunctionComponent = () => {
                       preview={result}
                       url={`/${environment.name}/list/${result.id}/`}
                       searchString={searchString}
+                      fromBoardId={fromBoardId}
                   />
               ));
 

--- a/querybook/webapp/components/Search/SearchResultItem.tsx
+++ b/querybook/webapp/components/Search/SearchResultItem.tsx
@@ -15,7 +15,6 @@ import history from 'lib/router-history';
 import { generateFormattedDate } from 'lib/utils/datetime';
 import { stopPropagation } from 'lib/utils/noop';
 import { queryEngineByIdEnvSelector } from 'redux/queryEngine/selector';
-import { IStoreState } from 'redux/store/types';
 import { Button } from 'ui/Button/Button';
 import { IconButton } from 'ui/Button/IconButton';
 import { ThemedCodeHighlight } from 'ui/CodeHighlight/ThemedCodeHighlight';
@@ -86,12 +85,14 @@ interface IQueryItemProps {
     preview: IQueryPreview;
     searchString: string;
     environmentName: string;
+    fromBoardId: number | undefined;
 }
 
 export const QueryItem: React.FunctionComponent<IQueryItemProps> = ({
     preview,
     environmentName,
     searchString,
+    fromBoardId,
 }) => {
     const {
         author_uid: authorUid,
@@ -112,10 +113,6 @@ export const QueryItem: React.FunctionComponent<IQueryItemProps> = ({
     const handleClick = React.useMemo(() => openClick.bind(null, url), [url]);
     const queryEngineById = useSelector(queryEngineByIdEnvSelector);
     const selfRef = useRef<HTMLDivElement>();
-
-    const currentBoardId = useSelector(
-        (state: IStoreState) => state.board.currentBoardId
-    );
 
     if (loading) {
         return (
@@ -214,10 +211,11 @@ export const QueryItem: React.FunctionComponent<IQueryItemProps> = ({
             <UrlContextMenu anchorRef={selfRef} url={url} />
             {queryType === 'execution' && (
                 <Button className="SearchResultItemBoardItemAddButton flex-center">
-                    {currentBoardId ? (
+                    {fromBoardId ? (
                         <SearchResultItemBoardItemAddButton
                             itemType="query"
                             itemId={id}
+                            fromBoardId={fromBoardId}
                         />
                     ) : (
                         <BoardItemAddButton
@@ -238,17 +236,17 @@ interface IDataDocItemProps {
     preview: IDataDocPreview;
     searchString: string;
     url: string;
+    fromBoardId: number | undefined;
 }
 
 export const DataDocItem: React.FunctionComponent<IDataDocItemProps> = ({
     preview,
     url,
     searchString,
+    fromBoardId,
 }) => {
     const selfRef = useRef<HTMLDivElement>();
-    const currentBoardId = useSelector(
-        (state: IStoreState) => state.board.currentBoardId
-    );
+
     const { owner_uid: ownerUid, created_at: createdAt, id } = preview;
     const { userInfo: ownerInfo, loading } = useUser({ uid: ownerUid });
     const handleClick = React.useMemo(() => openClick.bind(null, url), [url]);
@@ -302,10 +300,11 @@ export const DataDocItem: React.FunctionComponent<IDataDocItemProps> = ({
             </div>
             <UrlContextMenu anchorRef={selfRef} url={url} />
             <Button className="SearchResultItemBoardItemAddButton flex-center">
-                {currentBoardId ? (
+                {fromBoardId ? (
                     <SearchResultItemBoardItemAddButton
                         itemType="data_doc"
                         itemId={id}
+                        fromBoardId={fromBoardId}
                     />
                 ) : (
                     <BoardItemAddButton
@@ -325,12 +324,14 @@ interface IDataTableItemProps {
     preview: ITablePreview;
     searchString: string;
     url: string;
+    fromBoardId: number | undefined;
 }
 
 export const DataTableItem: React.FunctionComponent<IDataTableItemProps> = ({
     preview,
     searchString,
     url,
+    fromBoardId,
 }) => {
     const selfRef = useRef<HTMLDivElement>();
     const {
@@ -343,9 +344,6 @@ export const DataTableItem: React.FunctionComponent<IDataTableItemProps> = ({
         id,
     } = preview;
     const handleClick = React.useMemo(() => openClick.bind(null, url), [url]);
-    const currentBoardId = useSelector(
-        (state: IStoreState) => state.board.currentBoardId
-    );
 
     const goldenIcon = golden ? (
         <div className="result-item-golden ml4">
@@ -404,10 +402,11 @@ export const DataTableItem: React.FunctionComponent<IDataTableItemProps> = ({
             </div>
             <UrlContextMenu url={url} anchorRef={selfRef} />
             <Button className="SearchResultItemBoardItemAddButton flex-center">
-                {currentBoardId ? (
+                {fromBoardId ? (
                     <SearchResultItemBoardItemAddButton
                         itemType="table"
                         itemId={id}
+                        fromBoardId={fromBoardId}
                     />
                 ) : (
                     <BoardItemAddButton
@@ -427,14 +426,12 @@ export const BoardItem: React.FunctionComponent<{
     preview: IBoardPreview;
     url: string;
     searchString: string;
-}> = ({ preview, url, searchString }) => {
+    fromBoardId: number | undefined;
+}> = ({ preview, url, searchString, fromBoardId }) => {
     const selfRef = useRef<HTMLDivElement>();
     const { owner_uid: ownerUid, description, id } = preview;
     const { userInfo: ownerInfo, loading } = useUser({ uid: ownerUid });
     const handleClick = React.useMemo(() => openClick.bind(null, url), [url]);
-    const currentBoardId = useSelector(
-        (state: IStoreState) => state.board.currentBoardId
-    );
 
     if (loading) {
         return (
@@ -483,12 +480,13 @@ export const BoardItem: React.FunctionComponent<{
                 </div>
             </div>
             <UrlContextMenu anchorRef={selfRef} url={url} />
-            {currentBoardId === id ? null : (
+            {fromBoardId === id ? null : (
                 <Button className="SearchResultItemBoardItemAddButton flex-center">
-                    {currentBoardId ? (
+                    {fromBoardId ? (
                         <SearchResultItemBoardItemAddButton
                             itemType="board"
                             itemId={id}
+                            fromBoardId={fromBoardId}
                         />
                     ) : (
                         <BoardItemAddButton

--- a/querybook/webapp/components/Search/SearchResultItemBoardItemAddButton.tsx
+++ b/querybook/webapp/components/Search/SearchResultItemBoardItemAddButton.tsx
@@ -11,20 +11,20 @@ import { AccentText } from 'ui/StyledText/StyledText';
 interface IProps {
     itemType: BoardItemType;
     itemId: number;
+    fromBoardId: number;
 }
 
 export const SearchResultItemBoardItemAddButton: React.FunctionComponent<
     IProps
-> = ({ itemType, itemId }) => {
+> = ({ itemType, itemId, fromBoardId }) => {
     const dispatch: Dispatch = useDispatch();
-    const { currentBoardId, boardById } = useSelector((state: IStoreState) => ({
-        currentBoardId: state.board.currentBoardId,
-        boardById: state.board.boardById,
-    }));
+    const boardById = useSelector(
+        (state: IStoreState) => state.board.boardById
+    );
 
     const currentBoard = React.useMemo(
-        () => currentBoardId && boardById[currentBoardId],
-        [boardById, currentBoardId]
+        () => fromBoardId && boardById[fromBoardId],
+        [boardById, fromBoardId]
     );
 
     const itemInBoard = React.useMemo(
@@ -35,14 +35,14 @@ export const SearchResultItemBoardItemAddButton: React.FunctionComponent<
     const handleAddItem = React.useCallback(async () => {
         if (!itemInBoard) {
             // Add item
-            await dispatch(addBoardItem(currentBoardId, itemType, itemId));
+            await dispatch(addBoardItem(fromBoardId, itemType, itemId));
             toast.success(`Item added to the list "${currentBoard.name}"!`);
         } else {
             // remove item
-            await dispatch(deleteBoardItem(currentBoardId, itemType, itemId));
+            await dispatch(deleteBoardItem(fromBoardId, itemType, itemId));
             toast.success(`Item removed from the list "${currentBoard.name}"!`);
         }
-    }, [currentBoard, currentBoardId, itemId, itemType, itemInBoard]);
+    }, [dispatch, currentBoard, fromBoardId, itemId, itemType, itemInBoard]);
 
     return (
         <div className="flex-row" onClick={handleAddItem}>

--- a/querybook/webapp/context/BoardPage.ts
+++ b/querybook/webapp/context/BoardPage.ts
@@ -3,6 +3,7 @@ import React from 'react';
 import { BoardItemType } from 'const/board';
 
 export interface IBoardPageContextType {
+    boardId: number;
     isEditMode: boolean;
     isCollapsed: boolean;
 

--- a/querybook/webapp/redux/board/action.ts
+++ b/querybook/webapp/redux/board/action.ts
@@ -317,17 +317,6 @@ export function updateBoardItemMeta(
     };
 }
 
-export function setCurrentBoardId(boardId: number): ThunkResult<Promise<void>> {
-    return async (dispatch) => {
-        dispatch({
-            type: '@@board/SET_CURRENT_BOARD_ID',
-            payload: {
-                boardId,
-            },
-        });
-    };
-}
-
 export function getBoardEditors(
     boardId: number
 ): ThunkResult<Promise<IBoardEditor[]>> {

--- a/querybook/webapp/redux/board/reducer.ts
+++ b/querybook/webapp/redux/board/reducer.ts
@@ -9,7 +9,6 @@ import { BoardAction, IBoardState } from './types';
 const initialState: Readonly<IBoardState> = {
     boardById: {},
     boardItemById: {},
-    currentBoardId: null,
     editorsByBoardIdUserId: {},
     accessRequestsByBoardIdUserId: {},
 };
@@ -114,11 +113,6 @@ export default function (state = initialState, action: BoardAction) {
             case '@@board/UPDATE_BOARD_ITEM_DESCRIPTION': {
                 const { boardItem } = action.payload;
                 draft.boardItemById[boardItem.id] = boardItem;
-                return;
-            }
-            case '@@board/SET_CURRENT_BOARD_ID': {
-                const { boardId } = action.payload;
-                draft.currentBoardId = boardId;
                 return;
             }
             case '@@board/RECEIVE_BOARD_EDITORS': {

--- a/querybook/webapp/redux/board/selector.ts
+++ b/querybook/webapp/redux/board/selector.ts
@@ -35,11 +35,8 @@ export const myBoardsSelector = createSelector(
             .sort((a, b) => b.updated_at - a.updated_at)
 );
 
-export const currentBoardSelector = createSelector(
-    (state: IStoreState) => state.board.currentBoardId,
-    boardByIdSelector,
-    (currentBoardId, boardById) => boardById[currentBoardId]
-);
+export const currentBoardSelector = (state: IStoreState, boardId: number) =>
+    state.board.boardById[boardId];
 
 const rawBoardItemsSelector = createSelector(
     boardSelector,

--- a/querybook/webapp/redux/board/types.ts
+++ b/querybook/webapp/redux/board/types.ts
@@ -72,13 +72,6 @@ export interface IUpdateBoardItemDescriptionAction extends Action {
     };
 }
 
-export interface ISetCurrentBoardIdAction extends Action {
-    type: '@@board/SET_CURRENT_BOARD_ID';
-    payload: {
-        boardId: number;
-    };
-}
-
 export interface IReceiveBoardEditorsAction extends Action {
     type: '@@board/RECEIVE_BOARD_EDITORS';
     payload: {
@@ -144,7 +137,6 @@ export type BoardAction =
     | IRemoveBoardItemAction
     | IMoveBoardItemAction
     | IUpdateBoardItemDescriptionAction
-    | ISetCurrentBoardIdAction
     | IReceiveBoardEditorsAction
     | IReceiveBoardEditorAction
     | IRemoveBoardEditorAction
@@ -156,7 +148,6 @@ export type BoardAction =
 export interface IBoardState {
     boardById: Record<number, IBoardWithItemIds>;
     boardItemById: Record<number, IBoardItem>;
-    currentBoardId: number;
     editorsByBoardIdUserId: Record<number, Record<number, IBoardEditor>>;
     accessRequestsByBoardIdUserId: Record<
         number,


### PR DESCRIPTION
- Fixed route computation that would take the previous non-modal route instead of the current non-modal route
- Fixed currentBoardId logic impacting ownership calculation
- Fixed board elasticsearch update, board['id'] needs to be passed in instead of board