### PR TITLE
fix: adhoc template query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.6.2",
+    "version": "3.6.3",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/components/QueryComposer/QueryComposer.tsx
+++ b/querybook/webapp/components/QueryComposer/QueryComposer.tsx
@@ -12,7 +12,6 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { DataDocTemplateInfoButton } from 'components/DataDocTemplateButton/DataDocTemplateInfoButton';
 import { DataDocTemplateVarForm } from 'components/DataDocTemplateButton/DataDocTemplateVarForm';
-import { TTemplateVariableDict } from 'components/DataDocTemplateButton/helpers';
 import { BoundQueryEditor } from 'components/QueryEditor/BoundQueryEditor';
 import { QueryEditor } from 'components/QueryEditor/QueryEditor';
 import {
@@ -136,7 +135,7 @@ const useQuery = (dispatch: Dispatch, environmentId: number) => {
 const useTemplatedVariables = (dispatch: Dispatch, environmentId: number) => {
     const templatedVariables = useSelector(
         (state: IStoreState) =>
-            state.adhocQuery[environmentId]?.templatedVariables
+            state.adhocQuery[environmentId]?.templatedVariables ?? {}
     );
     const setTemplatedVariables = useCallback(
         (newVariables: Record<string, any>) =>


### PR DESCRIPTION
Seeing below errors on adhoc queries. 
```
Failed to templatize query.
get_templated_query() missing 1 required positional argument: 'variables'
```
Cause:
In https://github.com/pinterest/querybook/pull/939, we added templating support for adhoc queries, while forgot to provide a default value when getting the `templatedVariables` from Redux store if there is no variables added, which will be undefined, while the render template API requires this argument.