### PR TITLE
feat: add confirmation before execution if the query drops any tables

### DIFF
--- a/querybook/webapp/__tests__/lib/sql-helper/sql-checker.test.ts
+++ b/querybook/webapp/__tests__/lib/sql-helper/sql-checker.test.ts
@@ -1,0 +1,48 @@
+import { getDroppedTables } from 'lib/sql-helper/sql-checker';
+
+describe('getDroppedTables', () => {
+    test('drops a table', () => {
+        const query = `
+        drop table db.table1;
+        drop table db.table2;
+    `;
+        expect(getDroppedTables(query)).toStrictEqual([
+            'db.table1',
+            'db.table2',
+        ]);
+    });
+
+    test('drops a table and created', () => {
+        const query1 = `
+        drop table db.table1 if exists;
+        create table db.table1 if not exists;
+    `;
+        expect(getDroppedTables(query1)).toStrictEqual([]);
+
+        // with `external`
+        const query2 = `
+        drop table db.table1 if exists;
+        create external table db.table1 if not exists;
+    `;
+        expect(getDroppedTables(query2)).toStrictEqual([]);
+    });
+
+    test('drops more tables than recreated', () => {
+        const query = `
+        drop table db.table1 if exists;
+        drop table db.table2;
+        create table db.table1 if not exists;
+    `;
+        expect(getDroppedTables(query)).toStrictEqual(['db.table2']);
+    });
+
+    test('drops tables with use', () => {
+        const query = `
+        use db;
+        drop table table1 if exists;
+        drop table table2;
+        create table db.table1 if not exists;
+    `;
+        expect(getDroppedTables(query)).toStrictEqual(['db.table2']);
+    });
+});

--- a/querybook/webapp/__tests__/lib/sql-helper/sql-checker.test.ts
+++ b/querybook/webapp/__tests__/lib/sql-helper/sql-checker.test.ts
@@ -1,7 +1,7 @@
 import { getDroppedTables } from 'lib/sql-helper/sql-checker';
 
 describe('getDroppedTables', () => {
-    test('drops a table', () => {
+    test('drops tables', () => {
         const query = `
         drop table db.table1;
         drop table db.table2;
@@ -12,16 +12,27 @@ describe('getDroppedTables', () => {
         ]);
     });
 
-    test('drops a table and created', () => {
+    test('drops tables with if exists', () => {
+        const query = `
+        drop table if exists db.table1;
+        drop table if exists db.table2;
+    `;
+        expect(getDroppedTables(query)).toStrictEqual([
+            'db.table1',
+            'db.table2',
+        ]);
+    });
+
+    test('drops a table and recreated', () => {
         const query1 = `
-        drop table db.table1 if exists;
+        drop table if exists db.table1;
         create table db.table1 if not exists;
     `;
         expect(getDroppedTables(query1)).toStrictEqual([]);
 
         // with `external`
         const query2 = `
-        drop table db.table1 if exists;
+        drop table if exists db.table1;
         create external table db.table1 if not exists;
     `;
         expect(getDroppedTables(query2)).toStrictEqual([]);
@@ -29,7 +40,7 @@ describe('getDroppedTables', () => {
 
     test('drops more tables than recreated', () => {
         const query = `
-        drop table db.table1 if exists;
+        drop table if exists db.table1;
         drop table db.table2;
         create table db.table1 if not exists;
     `;
@@ -39,7 +50,7 @@ describe('getDroppedTables', () => {
     test('drops tables with use', () => {
         const query = `
         use db;
-        drop table table1 if exists;
+        drop table if exists table1;
         drop table table2;
         create table db.table1 if not exists;
     `;

--- a/querybook/webapp/__tests__/lib/sql-helper/sql-checker.test.ts
+++ b/querybook/webapp/__tests__/lib/sql-helper/sql-checker.test.ts
@@ -26,23 +26,30 @@ describe('getDroppedTables', () => {
     test('drops a table and recreated', () => {
         const query1 = `
         drop table if exists db.table1;
-        create table db.table1 if not exists;
+        create table db.table1;
     `;
         expect(getDroppedTables(query1)).toStrictEqual([]);
 
-        // with `external`
+        // with `if not exists`
         const query2 = `
         drop table if exists db.table1;
-        create external table db.table1 if not exists;
+        create table if not exists db.table1;
     `;
         expect(getDroppedTables(query2)).toStrictEqual([]);
+
+        // with `external`
+        const query3 = `
+        drop table if exists db.table1;
+        create external table if not exists db.table1;
+    `;
+        expect(getDroppedTables(query3)).toStrictEqual([]);
     });
 
     test('drops more tables than recreated', () => {
         const query = `
         drop table if exists db.table1;
         drop table db.table2;
-        create table db.table1 if not exists;
+        create table if not exists db.table1;
     `;
         expect(getDroppedTables(query)).toStrictEqual(['db.table2']);
     });
@@ -52,7 +59,7 @@ describe('getDroppedTables', () => {
         use db;
         drop table if exists table1;
         drop table table2;
-        create table db.table1 if not exists;
+        create table if not exists db.table1;
     `;
         expect(getDroppedTables(query)).toStrictEqual(['db.table2']);
     });

--- a/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
+++ b/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
@@ -359,37 +359,36 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
     public async onRunButtonClick() {
         await sleep(ON_CHANGE_DEBOUNCE_MS);
         const renderedQuery = await this.getCurrentSelectedQuery();
+        const runQuery = () =>
+            this.props.createQueryExecution(
+                renderedQuery,
+                this.engineId,
+                this.props.cellId
+            );
 
         if (renderedQuery) {
             const droppedTables = getDroppedTables(renderedQuery);
             if (droppedTables.length > 0) {
-                sendConfirm({
-                    header: 'Dropping Tables?',
-                    message: (
-                        <Content>
-                            <div>Your query is going to drop</div>
-                            <ul>
-                                {droppedTables.map((t) => (
-                                    <li key={t}>{t}</li>
-                                ))}
-                            </ul>
-                        </Content>
-                    ),
-                    onConfirm: () => {
-                        this.props.createQueryExecution(
-                            renderedQuery,
-                            this.engineId,
-                            this.props.cellId
-                        );
-                    },
-                    confirmText: 'Continue Execution',
+                return new Promise((resolve, reject) => {
+                    sendConfirm({
+                        header: 'Dropping Tables?',
+                        message: (
+                            <Content>
+                                <div>Your query is going to drop</div>
+                                <ul>
+                                    {droppedTables.map((t) => (
+                                        <li key={t}>{t}</li>
+                                    ))}
+                                </ul>
+                            </Content>
+                        ),
+                        onConfirm: () => runQuery().then(resolve, reject),
+                        onDismiss: () => resolve(null),
+                        confirmText: 'Continue Execution',
+                    });
                 });
             } else {
-                return this.props.createQueryExecution(
-                    renderedQuery,
-                    this.engineId,
-                    this.props.cellId
-                );
+                return runQuery();
             }
         }
     }

--- a/querybook/webapp/lib/sql-helper/sql-checker.ts
+++ b/querybook/webapp/lib/sql-helper/sql-checker.ts
@@ -2,7 +2,6 @@ import {
     findTableReferenceAndAlias,
     getStatementType,
     simpleParse,
-    TableToken,
     tokenize,
 } from './sql-lexer';
 import { isEmpty } from 'lodash';

--- a/querybook/webapp/lib/sql-helper/sql-checker.ts
+++ b/querybook/webapp/lib/sql-helper/sql-checker.ts
@@ -1,0 +1,40 @@
+import {
+    findTableReferenceAndAlias,
+    getStatementType,
+    simpleParse,
+    TableToken,
+    tokenize,
+} from './sql-lexer';
+import { isEmpty } from 'lodash';
+
+/**
+ * Check if a query will drop any tables, e.g. containing any `DROP TABLE <table_name>;` statements.
+ * Will also check if the same table gets recreated in the query. If so, it will not be counted.
+ *
+ * @param {string} query - Query to be executed.
+ * @return {string[]} - A list of table names to be dropped.
+ */
+export const getDroppedTables = (query: string): string[] => {
+    const tokens = tokenize(query);
+    const statements = simpleParse(tokens);
+    const { references: tablesByStatement } =
+        findTableReferenceAndAlias(statements);
+
+    const tablesToBeDropped = new Set<string>();
+
+    statements.forEach((statement, statementNum) => {
+        const statementType = getStatementType(statement);
+        const tables = tablesByStatement[statementNum];
+        if (isEmpty(tables)) {
+            return;
+        }
+        const tableName = `${tables[0].schema}.${tables[0].name}`;
+        if (statementType === 'drop') {
+            tablesToBeDropped.add(tableName);
+        } else if (statementType === 'create') {
+            tablesToBeDropped.delete(tableName);
+        }
+    });
+
+    return Array.from(tablesToBeDropped);
+};


### PR DESCRIPTION
**Context**
Recently one of our P0 prod tables were accidentally dropped by a user through querybook. At best we would like to prevent such cases from happening. At a minimum we will like an option to warn the user that they are about to drop a critical prod table and they need to confirm before the statement execution goes through.

This PR will ask user to confirm before the query execution if it will drop any tables.
![Snip20220724_26](https://user-images.githubusercontent.com/8308723/180831103-288833c0-d96f-47b5-87a1-4abe69c2597d.png)


