### PR TITLE
chore: Upgrade flask and sqlalchemy versions

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 
 # Server requirements
 Werkzeug==2.0.1
-flask==2.0.1
+flask==2.1.3
 Flask-Caching==1.10.1
 Flask-Compress==1.10.1
 Flask-Login==0.4.1
@@ -12,7 +12,7 @@ redis==3.5.3
 gevent==21.8.0
 greenlet==1.1.1
 
-alembic==1.4.3
+alembic==1.8.1
 
 gevent-websocket==0.10.1
 flask-socketio==5.1.1
@@ -21,16 +21,16 @@ flask-socketio==5.1.1
 python-socketio==5.2.1
 
 # Query templating
-Jinja2==3.0.1  # From Flask
+Jinja2==3.1.2  # From Flask
 
 # Celery
 celery==5.2.3
 
 # Ops
 pyyaml==5.4.1
-sqlalchemy==1.3.17
-pymysql==0.9.3
-requests==2.22.0
+sqlalchemy==1.4.39
+pymysql==1.0.2
+requests==2.28.1
 elasticsearch==7.13.4
 
 # Query meta


### PR DESCRIPTION
Updating flask and sqlalchemy (and related packages) to the latest version.
Tested locally with default docker-compose MySQL 8