### PR TITLE
Feat: add 'All' button in the 'Hide columns' menu

### DIFF
--- a/querybook/webapp/components/DataDocStatementExecution/StatementResult.tsx
+++ b/querybook/webapp/components/DataDocStatementExecution/StatementResult.tsx
@@ -342,9 +342,28 @@ const ColumnToggleMenuButton: React.FC<{
 }> = ({ columnNames, columnVisibility, toggleVisibility }) => {
     const buttonRef = React.useRef<HTMLAnchorElement>();
     const [showPopover, _, toggleShowPopover] = useToggleState(false);
+    const isAllSelected = useMemo(
+        () => columnNames.every((columnName) => columnVisibility[columnName]),
+        [columnNames, columnVisibility]
+    );
 
     const getPopoverContent = () => (
         <div className="StatementResult-column-toggle-menu">
+            <div key="all">
+                <Checkbox
+                    title={isAllSelected ? 'Hide All' : 'Select All'}
+                    value={isAllSelected}
+                    onChange={() => {
+                        if (isAllSelected) {
+                            columnNames.map((col) => toggleVisibility(col));
+                        } else {
+                            columnNames
+                                .filter((col) => !columnVisibility[col])
+                                .map((column) => toggleVisibility(column));
+                        }
+                    }}
+                />
+            </div>
             {columnNames.map((columnName) => (
                 <div key={columnName}>
                     <Checkbox


### PR DESCRIPTION
This change adds a possibility to hide/show all columns in 'Hide columns' menu just using one checkbox.
![1-hide:show](https://user-images.githubusercontent.com/59963571/181517355-d8358fde-a1c9-479c-9ac0-78704bb6c0fa.png)
![2-hide:show](https://user-images.githubusercontent.com/59963571/181517367-2004a4b4-b53f-4343-be1a-e4087b986d5d.png)

