### PR TITLE
Fix SQLAlchemy API change to return RMKeyView for columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.6.3",
+    "version": "3.6.4",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/lib/query_executor/clients/sqlalchemy.py
+++ b/querybook/server/lib/query_executor/clients/sqlalchemy.py
@@ -51,4 +51,4 @@ class SqlAlchemyCursor(CursorBaseClass):
         return [list(row) for row in self._cursor.fetchmany(size=n)]
 
     def get_columns(self):
-        return self._cursor.keys()
+        return list(self._cursor.keys())


### PR DESCRIPTION
Instead of a list of string, the cursor.keys() now return RMKeyView. Apply list() to convert it back to a list of strings.
We definitely need to add some unit test in future to prevent things like this from happening