### PR TITLE
chore: Upgrade to Python 3.10

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -24,7 +24,7 @@ jobs:
                   libldap2-dev
             - uses: actions/setup-python@v2
               with:
-                  python-version: 3.7.9
+                  python-version: 3.10
             - uses: actions/cache@v2
               id: pip-cache
               with:

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -24,7 +24,7 @@ jobs:
                   libldap2-dev
             - uses: actions/setup-python@v2
               with:
-                  python-version: 3.10
+                  python-version: '3.10'
             - uses: actions/cache@v2
               id: pip-cache
               with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.7.9
+FROM python:3.10
+
 ARG PRODUCTION=true
 ARG EXTRA_PIP_INSTALLS=""
 

--- a/docs_website/docs/developer_guide/developer_setup.md
+++ b/docs_website/docs/developer_guide/developer_setup.md
@@ -12,7 +12,7 @@ To enable autocomplete and type checking, it is recommended to install all Query
 
 If you do decide to develop locally, please make sure you have the following python and node versions available locally:
 
--   Python: ~3.7
+-   Python: ~3.10
 -   Node: >=12
 
 If you do not have the compatible version, we recommend the following methods to install the compatible versions required by Querybook.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.6.4",
+    "version": "3.7.0",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "reselect": "4.0.0",
         "sass": "^1.50.0",
         "smooth-scroll-into-view-if-needed": "^1.1.27",
-        "socket.io-client": "3.1.2",
+        "socket.io-client": "4.5.1",
         "sql-formatter": "2.3.4",
         "styled-components": "5.2.1",
         "typescript": "4.4.4",

--- a/querybook/server/app/auth/utils.py
+++ b/querybook/server/app/auth/utils.py
@@ -43,10 +43,8 @@ class QuerybookLoginManager(LoginManager):
     def __init__(self, *args, **kwargs):
         super(QuerybookLoginManager, self).__init__(*args, **kwargs)
 
-        # Note: This code only applies to the current version of Flask-Login(0.4.1)
-        # When upgrade, please use _request_callback and _user_callback
-        self.request_callback = load_user_with_api_access_token
-        self.user_callback = load_user
+        self.request_loader(load_user_with_api_access_token)
+        self.user_loader(load_user)
         self.needs_refresh_message = (
             "To protect your account, please reauthenticate to access this page."
         )

--- a/querybook/server/app/db.py
+++ b/querybook/server/app/db.py
@@ -2,11 +2,17 @@ import os
 from contextlib import contextmanager
 import functools
 
-from flask import has_request_context, g, _app_ctx_stack
+from flask import has_request_context, g
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.exc import SQLAlchemyError, DisconnectionError
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker, scoped_session
+
+try:
+    from greenlet import getcurrent as _get_ident
+except ImportError:
+    from threading import get_ident as _get_ident
+
 
 from env import QuerybookSettings
 from lib.logger import get_logger
@@ -87,7 +93,7 @@ def get_session(scopefunc=None):
 
 def get_flask_db_session():
     if "database_session" not in g:
-        g.database_session = get_session(scopefunc=_app_ctx_stack.__ident_func__)()
+        g.database_session = get_session(scopefunc=_get_ident)()
     return g.database_session
 
 

--- a/querybook/server/app/flask_app.py
+++ b/querybook/server/app/flask_app.py
@@ -131,6 +131,8 @@ def make_socketio(app):
         message_queue=QuerybookSettings.REDIS_URL,
         json=flask_json,
         cors_allowed_origins="*",
+        logger=True,
+        engineio_logger=True,
     )
     return socketio
 

--- a/querybook/server/datasources_socketio/connect.py
+++ b/querybook/server/datasources_socketio/connect.py
@@ -11,5 +11,5 @@ def connect():
         raise ConnectionRefusedError("User is not logged in, please refresh the page.")
 
 
-socketio.on("connect", namespace=DATA_DOC_NAMESPACE)(connect)
-socketio.on("connect", namespace=QUERY_EXECUTION_NAMESPACE)(connect)
+socketio.on_event("connect", connect, namespace=DATA_DOC_NAMESPACE)
+socketio.on_event("connect", connect, namespace=QUERY_EXECUTION_NAMESPACE)

--- a/querybook/server/datasources_socketio/query_execution.py
+++ b/querybook/server/datasources_socketio/query_execution.py
@@ -1,5 +1,5 @@
-from flask_socketio import join_room, leave_room, emit
-
+from flask_socketio import join_room, leave_room, emit, rooms
+from flask import request
 
 from app.auth.permission import verify_query_engine_permission
 from app.db import DBSession
@@ -62,3 +62,10 @@ def on_join_room(query_execution_id):
 @register_socket("unsubscribe", namespace=QUERY_EXECUTION_NAMESPACE)
 def on_leave_room(query_execution_id):
     leave_room(query_execution_id)
+
+
+@register_socket("disconnect", namespace=QUERY_EXECUTION_NAMESPACE)
+def disconnect():
+    query_execution_ids = rooms(request.sid, namespace=QUERY_EXECUTION_NAMESPACE)
+    for query_execution_id in query_execution_ids:
+        leave_room(query_execution_id)

--- a/querybook/server/lib/query_executor/base_executor.py
+++ b/querybook/server/lib/query_executor/base_executor.py
@@ -18,7 +18,6 @@ from lib.form import AllFormField
 from lib.logger import get_logger
 from lib.query_executor.base_client import ClientBaseClass
 from lib.query_executor.utils import (
-    spread_dict,
     merge_str,
     parse_exception,
     format_if_internal_error_with_stack_trace,
@@ -81,12 +80,10 @@ class QueryExecutorLogger(object):
                 session=session,
             ).to_dict()
 
-        query_execution = spread_dict(
-            query_execution,
-            {
-                "total": len(self._statement_ranges),
-            },
-        )
+        query_execution = query_execution | {
+            "total": len(self._statement_ranges),
+        }
+
         socketio.emit(
             "query_start",
             query_execution,
@@ -309,12 +306,9 @@ class QueryExecutorLogger(object):
             )
 
     def update_progress(self):
-        progress = spread_dict(
-            self._statement_progress,
-            {
-                "total": len(self._statement_ranges),
-            },
-        )
+        progress = self._statement_progress | {
+            "total": len(self._statement_ranges),
+        }
 
         self._celery_task.update_state(state="PROGRESS", meta=progress)
 

--- a/querybook/server/lib/query_executor/utils.py
+++ b/querybook/server/lib/query_executor/utils.py
@@ -2,22 +2,6 @@ import json
 from const.query_execution import QueryExecutionErrorType
 
 
-def spread_dict(x, y):
-    """Combines two dictionaries x, y into a new dict z.
-       After we update to python 3.9, we can replace this with x | y
-
-    Args:
-        x (Dict): the first dictionary
-        y (Dict): keys from y will overwrite x
-
-    Returns:
-        Dict: The merged dictionary
-    """
-    z = x.copy()
-    z.update(y)
-    return z
-
-
 def merge_str(str1: str, str2: str, separator: str = "\n") -> str:
     """Join two strings together if by the separator. If either is empty
        then separator will not be used

--- a/querybook/webapp/lib/data-doc/datadoc-socketio.ts
+++ b/querybook/webapp/lib/data-doc/datadoc-socketio.ts
@@ -133,7 +133,7 @@ export class DataDocSocket {
             this.promiseMap = {};
             if (removeSocket) {
                 // If we are not running any query any more, break off the socketio connection
-                SocketIOManager.removeSocket(this.socket);
+                SocketIOManager.removeSocket(DataDocSocket.NAME_SPACE);
                 this.socket = null;
                 this.socketPromise = null;
             }

--- a/querybook/webapp/lib/socketio-manager.ts
+++ b/querybook/webapp/lib/socketio-manager.ts
@@ -1,6 +1,6 @@
 import { debounce } from 'lodash';
 import toast from 'react-hot-toast';
-import { Manager, Socket } from 'socket.io-client';
+import { io, Socket } from 'socket.io-client';
 
 /*
 This module manages all incoming websocket connections using socketIO,
@@ -8,17 +8,34 @@ please do not use socketio individually and only use this to avoid repeated
 socket creation
 */
 
-const socketIOPath = `${location.protocol}//${location.host}`;
-const socketIOManager = new Manager(socketIOPath, {
+class OpenSocketManager {
+    private _openSocket: {
+        [nameSpace: string]: Promise<Socket>;
+    } = {};
+
+    public hasSocket(nameSpace: string) {
+        return nameSpace in this._openSocket;
+    }
+
+    public async getSocket(nameSpace: string) {
+        return this._openSocket[nameSpace];
+    }
+
+    public async addSocket(nameSpace: string, socketPromise: Promise<Socket>) {
+        this._openSocket[nameSpace] = socketPromise;
+    }
+
+    public removeSocket(nameSpace: string) {
+        delete this._openSocket[nameSpace];
+    }
+}
+const openSocketManager = new OpenSocketManager();
+
+const socketIOConfig = {
     secure: true,
     path: '/-/socket.io',
     transports: ['websocket'],
-    autoConnect: false,
-});
-
-function getSocketFromManager(nameSpace: string) {
-    return socketIOManager.socket(nameSpace);
-}
+};
 
 const sendErrorToastDebounced = debounce(
     (error) => {
@@ -33,49 +50,62 @@ export default {
         nameSpace = '/',
         onConnection: (socket: Socket) => void = null
     ) => {
-        const socket = getSocketFromManager(nameSpace);
-
-        if (!socket.connected) {
-            socket.connect();
-            // wait for connection
-            await new Promise<void>((resolve) => {
-                socket.on('connect', () => {
-                    sendErrorToastDebounced.cancel();
-                    if (onConnection) {
-                        onConnection(socket);
-                    }
-                    resolve();
-                });
-
-                socket.on('connect_error', (error: Error) => {
-                    sendErrorToastDebounced(error.toString());
-                });
-
-                socket.on('connect_timeout', (timeout) => {
-                    sendErrorToastDebounced(timeout);
-                });
-
-                socket.on('disconnect', (reason: string) => {
-                    if (reason === 'io server disconnect') {
-                        sendErrorToastDebounced(
-                            'Websocket was disconnected due to authentication issue. Please try to refresh the page.'
-                        );
-                    } else if (reason !== 'io client disconnect') {
-                        sendErrorToastDebounced(
-                            `Websocket was disconnected due to: ${reason}`
-                        );
-                    }
-                });
-            });
+        if (openSocketManager.hasSocket(nameSpace)) {
+            return openSocketManager.getSocket(nameSpace);
         }
+
+        const socket = io(nameSpace, socketIOConfig);
+
+        // wait for connection
+        const socketCreationPromise = new Promise<Socket>((resolve) => {
+            socket.on('connect', () => {
+                sendErrorToastDebounced.cancel();
+                if (onConnection) {
+                    onConnection(socket);
+                }
+                resolve(socket);
+            });
+
+            socket.on('connect_error', (error: Error) => {
+                sendErrorToastDebounced(
+                    'Connection Error: ' + error.toString()
+                );
+                openSocketManager.removeSocket(nameSpace);
+            });
+
+            socket.on('connect_timeout', (timeout) => {
+                sendErrorToastDebounced(
+                    'Connection Timeout: ' + String(timeout)
+                );
+            });
+
+            socket.on('disconnect', (reason: string) => {
+                if (reason === 'io server disconnect') {
+                    sendErrorToastDebounced(
+                        'Websocket was disconnected due to authentication issue. Please try to refresh the page.'
+                    );
+                } else if (reason !== 'io client disconnect') {
+                    sendErrorToastDebounced(
+                        `Websocket was disconnected due to: ${reason}`
+                    );
+                }
+                openSocketManager.removeSocket(nameSpace);
+            });
+        });
+
+        openSocketManager.addSocket(nameSpace, socketCreationPromise);
+        await socketCreationPromise;
+
         return socket;
     },
-    removeSocket: (socket: Socket) => {
-        if (socket) {
+    removeSocket: async (nameSpace: string) => {
+        if (openSocketManager.hasSocket(nameSpace)) {
+            const socket = await openSocketManager.getSocket(nameSpace);
             if (socket.connected) {
-                socket.close();
+                socket.disconnect();
             }
             socket.offAny();
+            openSocketManager.removeSocket(nameSpace);
         }
     },
 };

--- a/querybook/webapp/redux/queryExecutions/action.ts
+++ b/querybook/webapp/redux/queryExecutions/action.ts
@@ -628,7 +628,7 @@ class QueryExecutionSocket {
 
             // If we are not running any query any more, break off the socketio connection
             if (Object.keys(this.activeQueryExecutions).length === 0) {
-                SocketIOManager.removeSocket(this.socket);
+                SocketIOManager.removeSocket(QueryExecutionSocket.NAME_SPACE);
                 this.socket = null;
                 this.socketPromise = null;
             }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,30 +1,27 @@
 
 # Server requirements
-Werkzeug==2.0.1
+Werkzeug==2.2.0
 flask==2.1.3
 Flask-Caching==1.10.1
 Flask-Compress==1.10.1
-Flask-Login==0.4.1
+Flask-Login==0.6.2
 Flask-Limiter==2.2.0
 python-memcached==1.59
-redis==3.5.3
+redis==4.3.4
 
-gevent==21.8.0
-greenlet==1.1.1
+gevent==21.12.0
+greenlet==1.1.2
 
 alembic==1.8.1
 
 gevent-websocket==0.10.1
-flask-socketio==5.1.1
-
-# Fixing the version of python-socketio due to change in 5.3.0
-python-socketio==5.2.1
+flask-socketio==5.2.0
 
 # Query templating
 Jinja2==3.1.2  # From Flask
 
 # Celery
-celery==5.2.3
+celery==5.2.7
 
 # Ops
 pyyaml==5.4.1

--- a/requirements/engine/hive.txt
+++ b/requirements/engine/hive.txt
@@ -1,3 +1,3 @@
 -r ../shared/thrift.txt
 -r ../shared/zk.txt
-PyHive[hive]==0.6.3
+PyHive[hive]==0.6.5

--- a/requirements/engine/presto.txt
+++ b/requirements/engine/presto.txt
@@ -1,1 +1,1 @@
-PyHive[presto]==0.6.3
+PyHive[presto]==0.6.5

--- a/requirements/shared/thrift.txt
+++ b/requirements/shared/thrift.txt
@@ -1,3 +1,3 @@
-sasl==0.2.1
+sasl==0.3.1
 thrift==0.11.0
 thrift-sasl==0.3.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-pytest==5.2.2
+pytest==7.1.2
 coverage==5.4
 moto==2.2.4
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3622,6 +3622,11 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@socket.io/component-emitter@~3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
+  integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
+
 "@storybook/addon-actions@6.3.1":
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-6.3.1.tgz#b483e1c2cf5c77b8b750fb8d03a3f7defc4adc98"
@@ -4642,11 +4647,6 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
-
-"@types/component-emitter@^1.2.10":
-  version "1.2.10"
-  resolved "https://registry.yarnpkg.com/@types/component-emitter/-/component-emitter-1.2.10.tgz#ef5b1589b9f16544642e473db5ea5639107ef3ea"
-  integrity sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg==
 
 "@types/d3-array@^1":
   version "1.2.7"
@@ -6793,11 +6793,6 @@ babel-runtime@6.x, babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-backo2@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
-  integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
-
 bail@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.5.tgz#b6fa133404a392cbc1f8c4bf63f5953351e7a776"
@@ -6807,11 +6802,6 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
-
-base64-arraybuffer@0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz#9818c79e059b1355f97e0428a017c838e90ba812"
-  integrity sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=
 
 base64-js@^1.0.2:
   version "1.3.0"
@@ -7802,11 +7792,6 @@ component-emitter@^1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
   integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
 
-component-emitter@~1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
-  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
-
 component-indexof@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/component-indexof/-/component-indexof-0.0.3.tgz#11d091312239eb8f32c8f25ae9cb002ffe8d3c24"
@@ -8437,7 +8422,7 @@ debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.3.2, debug@^4.3.4:
+debug@^4.3.2, debug@^4.3.4, debug@~4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -9080,28 +9065,21 @@ endent@^2.0.1:
     fast-json-parse "^1.0.3"
     objectorarray "^1.0.4"
 
-engine.io-client@~4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-4.1.1.tgz#109942705079f15a4fcf1090bc86d3a1341c0a61"
-  integrity sha512-iYasV/EttP/2pLrdowe9G3zwlNIFhwny8VSIh+vPlMnYZqSzLsTzSLa9hFy015OrH1s4fzoYxeHjVkO8hSFKwg==
+engine.io-client@~6.2.1:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-6.2.2.tgz#c6c5243167f5943dcd9c4abee1bfc634aa2cbdd0"
+  integrity sha512-8ZQmx0LQGRTYkHuogVZuGSpDqYZtCM/nv8zQ68VZ+JkOpazJ7ICdsSpaO6iXwvaU30oFg5QJOJWj8zWqhbKjkQ==
   dependencies:
-    base64-arraybuffer "0.1.4"
-    component-emitter "~1.3.0"
+    "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.1"
-    engine.io-parser "~4.0.1"
-    has-cors "1.1.0"
-    parseqs "0.0.6"
-    parseuri "0.0.6"
-    ws "~7.4.2"
-    xmlhttprequest-ssl "~1.5.4"
-    yeast "0.1.2"
+    engine.io-parser "~5.0.3"
+    ws "~8.2.3"
+    xmlhttprequest-ssl "~2.0.0"
 
-engine.io-parser@~4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-4.0.2.tgz#e41d0b3fb66f7bf4a3671d2038a154024edb501e"
-  integrity sha512-sHfEQv6nmtJrq6TKuIz5kyEKH/qSdK56H/A+7DnAuUPWosnIZAS2NHNcPLmyjtY3cGS/MqJdZbUjW97JU72iYg==
-  dependencies:
-    base64-arraybuffer "0.1.4"
+engine.io-parser@~5.0.3:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.4.tgz#0b13f704fa9271b3ec4f33112410d8f3f41d0fc0"
+  integrity sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==
 
 enhanced-resolve@^4.5.0:
   version "4.5.0"
@@ -10711,11 +10689,6 @@ has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
   integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
-
-has-cors@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
-  integrity sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -14227,16 +14200,6 @@ parse5@^6.0.0, parse5@^6.0.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
-parseqs@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.6.tgz#8e4bb5a19d1cdc844a08ac974d34e273afa670d5"
-  integrity sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==
-
-parseuri@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/parseuri/-/parseuri-0.0.6.tgz#e1496e829e3ac2ff47f39a4dd044b32823c4a25a"
-  integrity sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==
-
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -16824,26 +16787,22 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-socket.io-client@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-3.1.2.tgz#77be8c180cef29121970856e8f48e5463631020a"
-  integrity sha512-fXhF8plHrd7U14A7K0JPOmZzpmGkLpIS6623DzrBZqYzI/yvlP4fA3LnxwthEVgiHmn2uJ4KjdnQD8A03PuBWQ==
+socket.io-client@4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.5.1.tgz#cab8da71976a300d3090414e28c2203a47884d84"
+  integrity sha512-e6nLVgiRYatS+AHXnOnGi4ocOpubvOUCGhyWw8v+/FxW8saHkinG6Dfhi9TU0Kt/8mwJIAASxvw6eujQmjdZVA==
   dependencies:
-    "@types/component-emitter" "^1.2.10"
-    backo2 "~1.0.2"
-    component-emitter "~1.3.0"
-    debug "~4.3.1"
-    engine.io-client "~4.1.0"
-    parseuri "0.0.6"
-    socket.io-parser "~4.0.4"
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.2"
+    engine.io-client "~6.2.1"
+    socket.io-parser "~4.2.0"
 
-socket.io-parser@~4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.0.4.tgz#9ea21b0d61508d18196ef04a2c6b9ab630f4c2b0"
-  integrity sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==
+socket.io-parser@~4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.1.tgz#01c96efa11ded938dcb21cbe590c26af5eff65e5"
+  integrity sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==
   dependencies:
-    "@types/component-emitter" "^1.2.10"
-    component-emitter "~1.3.0"
+    "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.1"
 
 sockjs-client@^1.5.0:
@@ -18894,10 +18853,10 @@ ws@^7.2.3:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.2.tgz#782100048e54eb36fe9843363ab1c68672b261dd"
   integrity sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==
 
-ws@~7.4.2:
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.3.tgz#1f9643de34a543b8edb124bdcbc457ae55a6e5cd"
-  integrity sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==
+ws@~8.2.3:
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz#63a56456db1b04367d0b721a0b80cae6d8becbba"
+  integrity sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"
@@ -18909,10 +18868,10 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmlhttprequest-ssl@~1.5.4:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
-  integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
+xmlhttprequest-ssl@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz#91360c86b914e67f44dce769180027c0da618c67"
+  integrity sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
@@ -19000,11 +18959,6 @@ yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
-
-yeast@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
-  integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Change list:
- Update to docker, python tests, etc
- Updated following packages: Werkzeug, Flask-Login, Redis, SocketIO, Celery, Greenlet, Pyhive, sasl, Pytest
- Updated SocketIO logic since it breaks after 3.10 update. I noticed once updated, I cannot reuse a namespace if it is disconnected before and I would need to create a new websocket connection. Now Querybook client would have at most 2 connections to server.
- Updated scopefunc for sqlalchemy db session due to werkzeug update
- Disconnect query execution would make it leave all the room
- Removed spread dict and use `|` operator instead
