### PR TITLE
fix: DELETE http does not work without params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.7.0",
+    "version": "3.7.1",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/app/datasource.py
+++ b/querybook/server/app/datasource.py
@@ -48,10 +48,11 @@ def register(url, methods=None, require_auth=True, custom_response=False):
             if require_auth and not current_user.is_authenticated:
                 flask.abort(401, description="Login required.")
 
+            params = {}
             if flask.request.method == "GET":
                 params = json.loads(flask.request.args.get("params", "{}"))
-            else:
-                params = flask.request.json or {}
+            elif flask.request.is_json:
+                params = flask.request.json
 
             status = 200
             try:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 
 # Server requirements
 Werkzeug==2.2.0
-flask==2.1.3
+flask==2.2.0
 Flask-Caching==1.10.1
 Flask-Compress==1.10.1
 Flask-Login==0.6.2


### PR DESCRIPTION
with the recent update, it looks like flask.request.json would throw an error unless "Content-Type: application/json" is specified.
However, the axios library in the frontend requires data to be specified to add that header: https://github.com/axios/axios/issues/86

Updated flask to 2.2.0 and also make the backend check if the request is `is_json` before getting the parameters.
