### PR TITLE
fix: revert back to python 3.9

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -24,7 +24,7 @@ jobs:
                   libldap2-dev
             - uses: actions/setup-python@v2
               with:
-                  python-version: '3.10'
+                  python-version: '3.9'
             - uses: actions/cache@v2
               id: pip-cache
               with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# Cannot upgrade to Python 3.10 until the following uWSGI release a new version:
+# https://github.com/unbit/uwsgi/pull/2363
+# This caused websocket to fail
 FROM python:3.9
 
 ARG PRODUCTION=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.9
 
 ARG PRODUCTION=true
 ARG EXTRA_PIP_INSTALLS=""

--- a/docs_website/docs/developer_guide/developer_setup.md
+++ b/docs_website/docs/developer_guide/developer_setup.md
@@ -12,7 +12,7 @@ To enable autocomplete and type checking, it is recommended to install all Query
 
 If you do decide to develop locally, please make sure you have the following python and node versions available locally:
 
--   Python: ~3.10
+-   Python: ~3.9
 -   Node: >=12
 
 If you do not have the compatible version, we recommend the following methods to install the compatible versions required by Querybook.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.7.2",
+    "version": "3.7.3",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/app/flask_app.py
+++ b/querybook/server/app/flask_app.py
@@ -131,8 +131,6 @@ def make_socketio(app):
         message_queue=QuerybookSettings.REDIS_URL,
         json=flask_json,
         cors_allowed_origins="*",
-        logger=True,
-        engineio_logger=True,
     )
     return socketio
 


### PR DESCRIPTION
Unfortunately, uWSGI is not Python 3.10 ready for websockets. 
We will need https://github.com/unbit/uwsgi/pull/2363 fix to be released.

Downgrade to 3.9 instead, tested both dev docker and prod docker
Also removed websocket logging