### PR TITLE
feat: dont show stack trace is exception is recognitizable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.7.3",
+    "version": "3.7.4",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/lib/query_executor/base_executor.py
+++ b/querybook/server/lib/query_executor/base_executor.py
@@ -591,7 +591,7 @@ class QueryExecutorBaseClass(metaclass=ABCMeta):
         else:
             self._on_query_completion()
 
-    def _handle_exception(self, e, stack_trace: str):
+    def _handle_exception(self, exc: Exception, stack_trace: str):
         try:
             # Try our best to fetch logs again
             if self._cursor:
@@ -601,11 +601,11 @@ class QueryExecutorBaseClass(metaclass=ABCMeta):
             pass
         finally:
             # Update logger
-            error_type, error_str, error_extracted = self._parse_exception(e)
+            error_type, error_str, error_extracted = self._parse_exception(exc)
             self._logger.on_exception(
                 error_type,
                 format_if_internal_error_with_stack_trace(
-                    error_type, error_str, stack_trace
+                    exc, error_type, error_str, stack_trace
                 ),
                 error_extracted,
             )

--- a/querybook/server/lib/query_executor/utils.py
+++ b/querybook/server/lib/query_executor/utils.py
@@ -1,5 +1,6 @@
 import json
 from const.query_execution import QueryExecutionErrorType
+from lib.query_executor.exc import QueryExecutorException
 
 
 def merge_str(str1: str, str2: str, separator: str = "\n") -> str:
@@ -31,10 +32,15 @@ def parse_exception(e):
 
 
 def format_if_internal_error_with_stack_trace(
-    error_type: QueryExecutionErrorType, error_str: str, stack_trace: str
+    exc: Exception,
+    error_type: QueryExecutionErrorType,
+    error_str: str,
+    stack_trace: str,
 ):
     """If the error is internal (which means its either unknown or caused by Querybook).
-       Then include the stack trace for better debugging
+       Then include the stack trace for better debugging.
+       Note if the error is instance of QueryExecutorException, then we know where
+       and why it is thrown. So it is ignored even tho it is internal.
 
     Args:
         error_type (QueryExecutionErrorType): The type of Querybook runtime error
@@ -44,7 +50,9 @@ def format_if_internal_error_with_stack_trace(
     Returns:
         str: The combined error trace string
     """
-    if error_type == QueryExecutionErrorType.INTERNAL.value:
+    if error_type == QueryExecutionErrorType.INTERNAL.value and not isinstance(
+        exc, QueryExecutorException
+    ):
         return (error_str or "") + "\nStack trace:\n" + stack_trace
     return error_str
 

--- a/querybook/server/lib/richtext.py
+++ b/querybook/server/lib/richtext.py
@@ -1,5 +1,6 @@
 from html import escape as htmlescape
 import json
+from typing import Tuple
 from bs4 import BeautifulSoup
 
 
@@ -14,7 +15,7 @@ def richtext_to_plaintext(text, default="", escape=False) -> str:
     return text
 
 
-def try_parse_draftjs(text) -> str:
+def try_parse_draftjs(text) -> Tuple[bool, str]:
     """With Richtext serialized as HTML, this will be deprecated in v4"""
     try:
         content_state = json.loads(text)

--- a/querybook/tests/test_lib/test_query_executor/test_utils.py
+++ b/querybook/tests/test_lib/test_query_executor/test_utils.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from const.query_execution import QueryExecutionErrorType
+from lib.query_executor.exc import QueryExecutorException
 from lib.query_executor.utils import (
     merge_str,
     format_if_internal_error_with_stack_trace,
@@ -22,14 +23,14 @@ class FormatIfInternalErrorWithStackTraceTestCase(TestCase):
     def test_is_internal_error(self):
         self.assertEqual(
             format_if_internal_error_with_stack_trace(
-                QueryExecutionErrorType.INTERNAL.value, "Hello", "World"
+                Exception(), QueryExecutionErrorType.INTERNAL.value, "Hello", "World"
             ),
             "Hello\nStack trace:\nWorld",
         )
 
         self.assertEqual(
             format_if_internal_error_with_stack_trace(
-                QueryExecutionErrorType.INTERNAL.value, None, "World"
+                Exception(), QueryExecutionErrorType.INTERNAL.value, None, "World"
             ),
             "\nStack trace:\nWorld",
         )
@@ -37,7 +38,18 @@ class FormatIfInternalErrorWithStackTraceTestCase(TestCase):
     def test_is_not_internal_error(self):
         self.assertEqual(
             format_if_internal_error_with_stack_trace(
-                QueryExecutionErrorType.ENGINE.value, "Hello", "World"
+                Exception(), QueryExecutionErrorType.ENGINE.value, "Hello", "World"
+            ),
+            "Hello",
+        )
+
+    def test_is_internal_but_recognizable_error(self):
+        self.assertEqual(
+            format_if_internal_error_with_stack_trace(
+                QueryExecutorException(),
+                QueryExecutionErrorType.INTERNAL.value,
+                "Hello",
+                "World",
             ),
             "Hello",
         )


### PR DESCRIPTION
There is no need for stack trace of QueryExecutionError since they are thrown by Querybook for runtime verification and can be traced