### PR TITLE
feat: Ignore null values when detecting types

### DIFF
--- a/querybook/webapp/components/DataDocChartCell/DataDocChart.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChart.tsx
@@ -14,6 +14,7 @@ import {
     getAutoDetectedScaleType,
     getDefaultScaleType,
 } from 'lib/chart/chart-utils';
+import { isCellValNull } from 'lib/query-result/helper';
 import { IStoreState } from 'redux/store/types';
 
 import { DataDocChartWrapper } from './DataDocChartWrapper';
@@ -26,12 +27,6 @@ interface IDataDocChartProps {
 }
 
 Chart.registry.remove(ChartDataLabels);
-
-function isChartValNull(val: any): boolean {
-    // checks if chart value is null or "null"
-    // only applies to query results in querybook
-    return val === 'null' || val == null;
-}
 
 const useChartScale = (meta: IDataChartCellMeta, data?: any[][]) => {
     const xScale = meta?.chart?.x_axis?.scale;
@@ -52,7 +47,7 @@ const useChartScale = (meta: IDataChartCellMeta, data?: any[][]) => {
         let defaultScale: ChartScaleType = null;
         for (let i = 1; i < data.length; i++) {
             const row = data[i];
-            if (!isChartValNull(row?.[xIndex])) {
+            if (!isCellValNull(row?.[xIndex])) {
                 defaultScale = getDefaultScaleType(row?.[xIndex]);
                 break;
             }
@@ -87,7 +82,7 @@ const useChartScale = (meta: IDataChartCellMeta, data?: any[][]) => {
                 if (
                     !ySeries[j]?.hidden &&
                     j !== xIndex &&
-                    !isChartValNull(val)
+                    !isCellValNull(val)
                 ) {
                     return getAutoDetectedScaleType(
                         allowedYAxisType,

--- a/querybook/webapp/components/StatementResultTable/StatementResultTable.tsx
+++ b/querybook/webapp/components/StatementResultTable/StatementResultTable.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { UserSettingsFontSizeToCSSFontSize } from 'const/font';
 import { useImmer } from 'hooks/useImmer';
 import { findColumnType } from 'lib/query-result/detector';
+import { isCellValNull } from 'lib/query-result/helper';
 import { getTransformersForType } from 'lib/query-result/transformer';
 import { IColumnTransformer } from 'lib/query-result/types';
 import { IStoreState } from 'redux/store/types';
@@ -186,10 +187,11 @@ export const StatementResultTable = React.forwardRef<
                 cols={columns}
                 showPagination={showPagination}
                 formatCell={(index, column, row) => {
+                    const value = row[index];
                     const transformer = getTransformerForColumn(index);
-                    return transformer
-                        ? transformer.transform(row[index])
-                        : row[index];
+                    return transformer && !isCellValNull(value)
+                        ? transformer.transform(value)
+                        : value;
                 }}
                 sortCell={useSortCell(rows)}
             />

--- a/querybook/webapp/components/StatementResultTable/StatementResultTable.tsx
+++ b/querybook/webapp/components/StatementResultTable/StatementResultTable.tsx
@@ -182,10 +182,12 @@ export const StatementResultTable = React.forwardRef<
                 showPagination={showPagination}
                 formatCell={(index, column, row) => {
                     const value = row[index];
+                    if (isCellValNull(value)) {
+                        return value;
+                    }
+
                     const transformer = getTransformerForColumn(index);
-                    return transformer && !isCellValNull(value)
-                        ? transformer.transform(value)
-                        : value;
+                    return transformer ? transformer.transform(value) : value;
                 }}
                 sortCell={useSortCell(rows)}
             />

--- a/querybook/webapp/components/StatementResultTable/StatementResultTable.tsx
+++ b/querybook/webapp/components/StatementResultTable/StatementResultTable.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { UserSettingsFontSizeToCSSFontSize } from 'const/font';
 import { useImmer } from 'hooks/useImmer';
-import { findColumnType } from 'lib/query-result/detector';
+import { getColumnTypesForTable } from 'lib/query-result/detector';
 import { isCellValNull } from 'lib/query-result/helper';
 import { getTransformersForType } from 'lib/query-result/transformer';
 import { IColumnTransformer } from 'lib/query-result/types';
@@ -97,13 +97,7 @@ export const StatementResultTable = React.forwardRef<
 
     const rows = useMemo(() => data.slice(1), [data]);
     const columnTypes = useMemo(
-        () =>
-            data[0].map((col, index) =>
-                findColumnType(
-                    col,
-                    rows.map((row) => row[index])
-                )
-            ),
+        () => getColumnTypesForTable(data[0], rows),
         [data, rows]
     );
 

--- a/querybook/webapp/components/StatementResultTable/common.ts
+++ b/querybook/webapp/components/StatementResultTable/common.ts
@@ -1,3 +1,0 @@
-export function isCellNull(cell: any) {
-    return cell === 'null' || cell == null;
-}

--- a/querybook/webapp/components/StatementResultTable/useSortCell.ts
+++ b/querybook/webapp/components/StatementResultTable/useSortCell.ts
@@ -1,8 +1,7 @@
 import { useCallback, useMemo } from 'react';
 
+import { isCellValNull } from 'lib/query-result/helper';
 import { isNumeric } from 'lib/utils/number';
-
-import { isCellNull } from './common';
 
 export type ColumnSortType = 'string' | 'number';
 
@@ -14,9 +13,9 @@ export function useSortCell(rows: string[][]) {
 
     const sortCell = useCallback(
         (colIdx: number, a: any, b: any) => {
-            if (isCellNull(a)) {
+            if (isCellValNull(a)) {
                 return -1;
-            } else if (isCellNull(b)) {
+            } else if (isCellValNull(b)) {
                 return 1;
             }
 
@@ -39,7 +38,7 @@ export function useSortCell(rows: string[][]) {
 function getColumnType(rows: any[][], colIdx: number): ColumnSortType {
     for (const row of rows) {
         const cell = row[colIdx];
-        if (isCellNull(cell)) {
+        if (isCellValNull(cell)) {
             continue;
         } else if (!isNumeric(cell)) {
             return 'string';

--- a/querybook/webapp/lib/query-result/detector.ts
+++ b/querybook/webapp/lib/query-result/detector.ts
@@ -61,13 +61,9 @@ export function getColumnTypesForTable(columns: string[], rows: any[][]) {
         Math.floor(rows.length / 100)
     );
     return columns.map((colName, index) => {
-        const notNullRowValues = rows.reduce((arr, row) => {
-            const value = row[index];
-            if (!isCellValNull(value)) {
-                arr.push(value);
-            }
-            return arr;
-        }, []);
+        const notNullRowValues = rows
+            .map((row) => row[index])
+            .filter((value) => !isCellValNull(value));
 
         const sampledRowValues = sampleSize(notNullRowValues, sizeOfSample);
         return findColumnType(colName, sampledRowValues);

--- a/querybook/webapp/lib/query-result/helper.ts
+++ b/querybook/webapp/lib/query-result/helper.ts
@@ -1,0 +1,10 @@
+/**
+ * checks if a cell of results table is empty
+ * only applies to query results in querybook
+ *
+ * @param val cell from query execution result
+ * @returns boolean
+ */
+export function isCellValNull(val: any): boolean {
+    return val === 'null' || val == null;
+}


### PR DESCRIPTION
For sparse columns, the type checking werent working before since there will be a lot of null values affecting the quality of the result.  

Changes include:
- sampling and null filtering is done ahead of time before feeding into detectors
- transformer only runs on not null columns
- unified null checking code