### PR TITLE
Automatically add a row limit to queries

### DIFF
--- a/querybook/webapp/__tests__/lib/sql-helper/sql-lexer.test.ts
+++ b/querybook/webapp/__tests__/lib/sql-helper/sql-lexer.test.ts
@@ -1,4 +1,5 @@
 import {
+    containsKeyword,
     findTableReferenceAndAlias,
     findWithStatementPlaceholder,
     getQueryAsExplain,
@@ -368,5 +369,32 @@ describe('getStatementType', () => {
         expect(
             getStatementType(simpleParse(tokenize('selec 1;'))[0])
         ).toBeNull();
+    });
+});
+describe('containsKeyword', () => {
+    test('Simple example query contains limit', () => {
+        expect(
+            containsKeyword(simpleParse(tokenize(simpleQuery))[0], 'limit')
+        ).toBeTruthy();
+    });
+    test('Simple example query does not contain with', () => {
+        expect(
+            containsKeyword(simpleParse(tokenize(simpleQuery))[0], 'with')
+        ).toBeFalsy();
+    });
+    test('Simple insert query contains insert', () => {
+        expect(
+            containsKeyword(
+                simpleParse(
+                    tokenize(`INSERT INTO abc SELECT * FROM foobar`)
+                )[0],
+                'insert'
+            )
+        ).toBeTruthy();
+    });
+    test('Invalid query without keyword', () => {
+        expect(
+            containsKeyword(simpleParse(tokenize('selec 1;'))[0], 'limit')
+        ).toBeFalsy();
     });
 });

--- a/querybook/webapp/__tests__/lib/sql-helper/sql-limiter.test.ts
+++ b/querybook/webapp/__tests__/lib/sql-helper/sql-limiter.test.ts
@@ -1,0 +1,127 @@
+import { getLimitedQuery } from 'lib/sql-helper/sql-limiter';
+
+describe('getLimitedQuery', () => {
+    describe('not limited', () => {
+        test('when rowLimit is not specified', () => {
+            const query = 'SELECT * FROM table_1 WHERE field = 1;';
+            expect(getLimitedQuery(query)).toBe(query);
+        });
+        test('when rowLimit is not specified for multiple queries', () => {
+            const query = `
+                SELECT * FROM table_1 WHERE field = 1;
+                SELECT * FROM table_1 WHERE field = 1;
+            `;
+            expect(getLimitedQuery(query)).toBe(query);
+        });
+        test('when running a delete query', () => {
+            const query = 'DELETE FROM table_1 WHERE field = 1;';
+            expect(getLimitedQuery(query, 100)).toBe(query);
+        });
+        test('when running a select query with a where clause and a limit', () => {
+            const query = 'SELECT * FROM table_1 WHERE field = 1 LIMIT 1000;';
+            expect(getLimitedQuery(query, 100)).toBe(query);
+        });
+        test('when running a select query with a where clause and a group by and an order by', () => {
+            const query =
+                'SELECT field, count(*) FROM table_1 WHERE deleted = false GROUP BY field ORDER BY field';
+            expect(getLimitedQuery(query, 100)).toBe(`${query} limit 100;`);
+        });
+        test('when running a create database query', () => {
+            const query = 'CREATE DATABASE IF NOT EXISTS db_1;';
+            expect(getLimitedQuery(query, 100)).toBe(query);
+        });
+        test('when running a create table query', () => {
+            const query = 'CREATE TABLE table_1 (field1 INT);';
+            expect(getLimitedQuery(query, 100)).toBe(query);
+        });
+        test('when truncating a table', () => {
+            const query = 'TRUNCATE TABLE table_1;';
+            expect(getLimitedQuery(query, 100)).toBe(query);
+        });
+        test('when running a drop and create database query', () => {
+            const query = `
+                drop table if exists db.table1;
+                create table db.table1;
+            `;
+            expect(getLimitedQuery(query, 100)).toBe(query);
+        });
+        test('when running an insert query', () => {
+            const query = 'INSERT INTO table_1 (field1) VALUES (1);';
+            expect(getLimitedQuery(query, 100)).toBe(query);
+        });
+        test('when running an update query', () => {
+            const query = 'UPDATE table_1 SET field1 = 1 WHERE field = 1;';
+            expect(getLimitedQuery(query, 100)).toBe(query);
+        });
+        test('when running a select query with fetch', () => {
+            const query =
+                'SELECT * FROM table_1 ORDER BY id FETCH FIRST 10 ROWS ONLY;';
+            expect(getLimitedQuery(query, 100, 'trino')).toBe(query);
+        });
+        test('when running a select query with offset and fetch', () => {
+            const query =
+                'SELECT * FROM table_1 ORDER BY id OFFSET 10 FETCH NEXT 10 ROWS ONLY;';
+            expect(getLimitedQuery(query, 100, 'trino')).toBe(query);
+        });
+    });
+    describe('limited', () => {
+        test('when running a select query', () => {
+            const query = 'SELECT * FROM table_1';
+            expect(getLimitedQuery(query, 10)).toBe(`${query} limit 10;`);
+        });
+        test('when running a select query with trailing semicolon', () => {
+            const query = 'SELECT * FROM table_1;';
+            expect(getLimitedQuery(query, 10)).toBe(
+                'SELECT * FROM table_1 limit 10;'
+            );
+        });
+        test('when running a select query with comments', () => {
+            const query = 'SELECT * FROM table_1 -- limit here';
+            expect(getLimitedQuery(query, 10)).toBe(
+                'SELECT * FROM table_1 limit 10;'
+            );
+        });
+        test('when running a select query with non-keyword limits', () => {
+            const query = `SELECT id, account, 'limit' FROM querybook2.limit ORDER by 'limit' ASC`;
+            expect(getLimitedQuery(query, 10)).toBe(`${query} limit 10;`);
+        });
+        test('when running a multiple select queries', () => {
+            const query = `SELECT * FROM table_1;
+SELECT col1, col2, FROM table2;`;
+            expect(getLimitedQuery(query, 10)).toBe(
+                `SELECT * FROM table_1 limit 10;
+SELECT col1, col2, FROM table2 limit 10;`
+            );
+        });
+        test('when running a select query with a where clause', () => {
+            const query = 'SELECT * FROM table_1 WHERE field = 1';
+            expect(getLimitedQuery(query, 100)).toBe(`${query} limit 100;`);
+        });
+        test('when running a select query with a where clause and an order by', () => {
+            const query =
+                'SELECT * FROM table_1 WHERE field = 1 ORDER BY field';
+            expect(getLimitedQuery(query, 100)).toBe(`${query} limit 100;`);
+        });
+        test('when running a select query with a where clause and a group by and an order by', () => {
+            const query =
+                'SELECT field, count(*) FROM table_1 WHERE deleted = false GROUP BY field ORDER BY field';
+            expect(getLimitedQuery(query, 100)).toBe(`${query} limit 100;`);
+        });
+        test('when running two select queries with mixed limits', () => {
+            const query = `SELECT * FROM table_1;
+SELECT col1, col2, FROM table2 LIMIT 300;`;
+            expect(getLimitedQuery(query, 10))
+                .toBe(`SELECT * FROM table_1 limit 10;
+SELECT col1, col2, FROM table2 LIMIT 300;`);
+        });
+        test('when running multiple select queries with mixed limits', () => {
+            const query = `SELECT * FROM table_1;
+SELECT col1, col2, FROM table2 LIMIT 300;
+SELECT field, count(1) FROM table3 GROUP BY field`;
+            expect(getLimitedQuery(query, 10))
+                .toBe(`SELECT * FROM table_1 limit 10;
+SELECT col1, col2, FROM table2 LIMIT 300;
+SELECT field, count(1) FROM table3 GROUP BY field limit 10;`);
+        });
+    });
+});

--- a/querybook/webapp/components/AppAdmin/AdminQueryEngine.tsx
+++ b/querybook/webapp/components/AppAdmin/AdminQueryEngine.tsx
@@ -406,7 +406,7 @@ export const AdminQueryEngine: React.FunctionComponent<IProps> = ({
                                     stacked
                                     name="feature_params.row_limit"
                                     type="number"
-                                    label="Row Limit"
+                                    label="(Experimental) Row Limit"
                                 />
                             </div>
                         </div>

--- a/querybook/webapp/components/AppAdmin/AdminQueryEngine.tsx
+++ b/querybook/webapp/components/AppAdmin/AdminQueryEngine.tsx
@@ -401,6 +401,13 @@ export const AdminQueryEngine: React.FunctionComponent<IProps> = ({
                                     options={tableUploadExporterNames}
                                     withDeselect
                                 />
+
+                                <SimpleField
+                                    stacked
+                                    name="feature_params.row_limit"
+                                    type="number"
+                                    label="Row Limit"
+                                />
                             </div>
                         </div>
 

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
@@ -8,6 +8,7 @@ import { TooltipDirection } from 'const/tooltip';
 import { getShortcutSymbols, KeyMap } from 'lib/utils/keyboard';
 import { queryEngineStatusByIdEnvSelector } from 'redux/queryEngine/selector';
 import { AsyncButton, IAsyncButtonHandles } from 'ui/AsyncButton/AsyncButton';
+import { Checkbox } from 'ui/Checkbox/Checkbox';
 import { Dropdown } from 'ui/Dropdown/Dropdown';
 import { Icon } from 'ui/Icon/Icon';
 import { ListMenu } from 'ui/Menu/ListMenu';
@@ -25,6 +26,8 @@ interface IQueryRunButtonProps extends IQueryEngineSelectorProps {
     hasSelection?: boolean;
     runButtonTooltipPos?: TooltipDirection;
     onRunClick: () => any;
+    rowLimit?: boolean;
+    onRowLimitChange?: (rowLimit: boolean) => void;
 }
 
 export interface IQueryRunButtonHandles {
@@ -45,6 +48,8 @@ export const QueryRunButton = React.forwardRef<
             queryEngines,
             engineId,
             onEngineIdSelect,
+            rowLimit,
+            onRowLimitChange,
         },
         ref
     ) => {
@@ -77,8 +82,19 @@ export const QueryRunButton = React.forwardRef<
             />
         );
 
+        const rowLimitDOM =
+            onRowLimitChange &&
+            queryEngineById[engineId]?.feature_params.row_limit ? (
+                <Checkbox
+                    onChange={onRowLimitChange}
+                    value={rowLimit}
+                    title="Limit results automatically"
+                />
+            ) : null;
+
         return (
             <div className="QueryRunButton flex-row ml16">
+                {rowLimitDOM}
                 <QueryEngineSelector
                     disabled={disabled}
                     queryEngineById={queryEngineById}

--- a/querybook/webapp/const/adhocQuery.ts
+++ b/querybook/webapp/const/adhocQuery.ts
@@ -3,4 +3,5 @@ export interface IAdhocQuery {
     templatedVariables?: Record<string, any>;
     engineId?: number;
     executionId?: number;
+    rowLimit?: boolean;
 }

--- a/querybook/webapp/const/queryEngine.ts
+++ b/querybook/webapp/const/queryEngine.ts
@@ -9,6 +9,7 @@ export interface IQueryEngine {
     executor: string;
 
     feature_params: {
+        row_limit?: number;
         status_checker?: string;
         upload_exporter?: string;
     };

--- a/querybook/webapp/lib/sql-helper/sql-lexer.ts
+++ b/querybook/webapp/lib/sql-helper/sql-lexer.ts
@@ -70,6 +70,8 @@ const contextSensitiveKeyWord = {
     // delete: 'table',
 
     limit: 'none',
+    fetch: 'none',
+    offset: 'none',
 };
 
 type TokenType =
@@ -902,3 +904,8 @@ export const getQueryKeywords = (query: string) => {
 
     return Array.from(new Set(statements.map(getStatementType)));
 };
+
+export const containsKeyword = (statements: IToken[], keyword: string) =>
+    statements.some(
+        (statement) => isKeywordToken(statement) && statement.text === keyword
+    );

--- a/querybook/webapp/lib/sql-helper/sql-lexer.ts
+++ b/querybook/webapp/lib/sql-helper/sql-lexer.ts
@@ -905,7 +905,5 @@ export const getQueryKeywords = (query: string) => {
     return Array.from(new Set(statements.map(getStatementType)));
 };
 
-export const containsKeyword = (statements: IToken[], keyword: string) =>
-    statements.some(
-        (statement) => isKeywordToken(statement) && statement.text === keyword
-    );
+export const containsKeyword = (statement: IToken[], keyword: string) =>
+    statement.some((token) => isKeywordToken(token) && token.text === keyword);

--- a/querybook/webapp/lib/sql-helper/sql-limiter.ts
+++ b/querybook/webapp/lib/sql-helper/sql-limiter.ts
@@ -1,0 +1,53 @@
+import {
+    containsKeyword,
+    getStatementRanges,
+    getStatementType,
+    simpleParse,
+    tokenize,
+} from './sql-lexer';
+
+/**
+ * Automatically apply a limit to a query that does not already have a limit.
+ *
+ * @param {string} query - Query to be executed.
+ * @param {rowLimit} query - Number of rows to limit the query to.
+ * @param {language} query - Language of the query.
+ * @return {string} - Query with limit applied (if necessary).
+ */
+export const getLimitedQuery = (
+    query: string,
+    rowLimit?: number,
+    language?: string
+): string => {
+    if (rowLimit == null) {
+        return query;
+    }
+
+    const statementRanges = getStatementRanges(query, null, language);
+    const statements = statementRanges
+        .map((range) => query.slice(range[0], range[1]))
+        .filter((statement) => statement.length > 0);
+
+    let addedLimit = false;
+    const updatedQuery = statements
+        .map((statement) => {
+            const tokens = tokenize(statement, { language });
+            const parsedStatements = simpleParse(tokens)[0];
+
+            if (
+                getStatementType(parsedStatements) === 'select' &&
+                !containsKeyword(parsedStatements, 'limit') &&
+                !containsKeyword(parsedStatements, 'fetch')
+            ) {
+                addedLimit = true;
+                return `${statement} limit ${rowLimit};`;
+            }
+
+            return statement + ';';
+        })
+        .join('\n');
+
+    // If no limit was added, return the original query
+    // to avoid changing whitespace, etc.
+    return addedLimit ? updatedQuery : query;
+};

--- a/querybook/webapp/lib/sql-helper/sql-setting.ts
+++ b/querybook/webapp/lib/sql-helper/sql-setting.ts
@@ -66,9 +66,24 @@ const SettingsByLanguage: Record<string, ILanguageSetting> = {
         operatorChars: /^[*+\-%<>!=&|^~]/,
         punctuationChars: /^[/:.]/,
     },
+    trino: {
+        keywords: new Set(
+            (
+                SQL_KEYWORDS +
+                'alter and as between by case cast constraint create cross cube current_date current_path current_time current_timestamp current_user deallocate delete describe distinct drop else end escape except execute exists extract false fetch first for formatted from full group grouping having if in inner insert intersect into is join left like limit localtime localtimestamp natural next normalize not null offset on only or order outer prepare recursive right rollup row rows select table then ties true uescape union unnest using use values when where with'
+            ).split(' ')
+        ),
+        type: new Set(
+            'boolean tinyint smallint integer bigint real double decimal varchar char varbinary json date time timestamp interval array map row ipaddress'.split(
+                ' '
+            )
+        ),
+        bool: new Set('false true null'.split(' ')),
+        operatorChars: /^[*+\-%<>!=|]/,
+        punctuationChars: /^[/:.]/,
+    },
 };
 SettingsByLanguage['sparksql'] = SettingsByLanguage['hive'];
-SettingsByLanguage['trino'] = SettingsByLanguage['presto'];
 
 export function getLanguageSetting(
     language: string,


### PR DESCRIPTION
This change adds an optional Row Limit configuration to Query Engines.  When enabled, queries without a `LIMIT` clause will have one automatically added prior to execution, with the configured number of rows.  This is desirable to avoid inadvertently running unbounded queries on massive tables.

Users can manually disable this feature with a checkbox in the ad hoc editor, or by manually providing a `LIMIT` in their query.  This feature is not enabled for DataDocs.

Query detection support has been added for `LIMIT` and the SQL Standard `FETCH FIRST/NEXT` syntax, which covers a number of languages.  Additional parsing support would be needed to fully support other languages (e.g. SQL Server's `TOP`).

Additionally, the Trino language has been split from the Presto language to add support for [`FETCH FIRST/NEXT`](https://trino.io/blog/2020/02/03/beyond-limit-presto-meets-offset-and-ties.html), which Presto does not currently support. 

![Screenshot 2022-08-04 at 11-23-56 Querybook](https://user-images.githubusercontent.com/3084806/183148289-1bbe7f71-7c99-437c-be72-e493bbda3fde.png)

![Screenshot 2022-08-04 at 11-24-30 Adhoc Query - Querybook](https://user-images.githubusercontent.com/3084806/183148399-2e054046-9c2d-490a-ba3a-9d822df00744.png)



