### PR TITLE
fix: long table name fit hover popover size

### DIFF
--- a/querybook/webapp/components/DataTableNavigator/DataTableHoverContent.tsx
+++ b/querybook/webapp/components/DataTableNavigator/DataTableHoverContent.tsx
@@ -26,6 +26,9 @@ export const DataTableHoverContent: React.FC<{
         () => tableColumns?.map((c) => c.name).join(', '),
         [tableColumns]
     );
+    const wrappedTableName = tableName
+        .replaceAll('_', '\u200B_')
+        .replaceAll('.', '\u200B.');
 
     const renderTableView = () => {
         const tagsDOM = <DataTableTags tableId={tableId} readonly mini />;
@@ -59,7 +62,7 @@ export const DataTableHoverContent: React.FC<{
     return (
         <div className="DataTableHoverContent">
             <Title className="mb4" size="smedium">
-                {tableName}
+                {wrappedTableName}
             </Title>
             <Loader
                 item={table}


### PR DESCRIPTION
We noticed an issue that the hover popover for table cannot fit when the table name is long. Which was like:
![image](https://user-images.githubusercontent.com/55952215/184003822-816dfb89-fde4-411a-8a67-8f9bf9c4ec00.png)

We notice there was a max-width limit and should be removed to make the popover size larger when the table name is long like:
![image](https://user-images.githubusercontent.com/55952215/184004045-01da7247-1e4a-4ad4-9d7a-6ad541614a56.png)

