### PR TITLE
feat: add support of syncing table description from metastore

### DIFF
--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -42,6 +42,9 @@ class DataTable(NamedTuple):
     type: str = None
     owner: str = None
 
+    # Table description
+    description: str = None
+
     # Expected in UTC seconds
     table_created_at: int = None
     table_updated_at: int = None
@@ -237,6 +240,7 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
             ).id
             create_table_information(
                 data_table_id=table_id,
+                description=table.description,
                 latest_partitions=json.dumps((table.partitions or [])[-10:]),
                 earliest_partitions=json.dumps((table.partitions or [])[:10]),
                 hive_metastore_description=table.raw_description,

--- a/querybook/server/logic/metastore.py
+++ b/querybook/server/logic/metastore.py
@@ -253,6 +253,7 @@ def update_table(id, golden=None, score=None, commit=True, session=None):
 @with_session
 def create_table_information(
     data_table_id=None,
+    description=None,
     latest_partitions=None,
     earliest_partitions=None,
     hive_metastore_description=None,
@@ -269,6 +270,13 @@ def create_table_information(
         earliest_partitions=earliest_partitions,
         hive_metastore_description=hive_metastore_description,
     )
+
+    # As parameter descripton is newly added, for backward compatible,
+    # only set the description explicitly when it's not None.
+    # Otherwise, for those existing metastores which dont sync description
+    # to querybook, it will wipe out the existing description.
+    if description is not None:
+        new_table_information.description = description
 
     if not table_information:
         session.add(new_table_information)


### PR DESCRIPTION
Some systems may have the metastore as the source of truth for the table description, as well as the table schema. This change is to add the support of syncing table description from the metastore.