### PR TITLE
ui: fix overflow for long table name and .Title css

### DIFF
--- a/querybook/webapp/components/BoardExpandableList/BoardExpandableSection.scss
+++ b/querybook/webapp/components/BoardExpandableList/BoardExpandableSection.scss
@@ -20,12 +20,6 @@
         .board-header-title {
             cursor: pointer;
             overflow: hidden;
-
-            .Title {
-                color: var(--text-light);
-                text-transform: capitalize;
-                user-select: none;
-            }
         }
 
         .header-control-section {

--- a/querybook/webapp/components/DataTableNavigator/DataTableHoverContent.scss
+++ b/querybook/webapp/components/DataTableNavigator/DataTableHoverContent.scss
@@ -5,4 +5,8 @@
         margin-bottom: 4px;
         margin-left: -2px;
     }
+
+    .DataTableHoverContent-name {
+        word-break: break-all;
+    }
 }

--- a/querybook/webapp/components/DataTableNavigator/DataTableHoverContent.tsx
+++ b/querybook/webapp/components/DataTableNavigator/DataTableHoverContent.tsx
@@ -58,7 +58,7 @@ export const DataTableHoverContent: React.FC<{
 
     return (
         <div className="DataTableHoverContent">
-            <Title className="mb4" size="smedium">
+            <Title className="mb4 DataTableHoverContent-name" size="smedium">
                 {tableName}
             </Title>
             <Loader

--- a/querybook/webapp/components/DataTableNavigator/DataTableNavigatorSearch.scss
+++ b/querybook/webapp/components/DataTableNavigator/DataTableNavigatorSearch.scss
@@ -34,7 +34,7 @@
             padding-bottom: 2px;
         }
 
-        .Title {
+        .search-filter-title {
             margin-left: 10px;
             min-width: 70px;
         }

--- a/querybook/webapp/components/DataTableNavigator/DataTableNavigatorSearch.tsx
+++ b/querybook/webapp/components/DataTableNavigator/DataTableNavigatorSearch.tsx
@@ -159,7 +159,7 @@ const SearchFilterRow: React.FC<{ title: string; className?: string }> = ({
     className,
 }) => (
     <div className={`search-filter-row ${className ?? ''}`}>
-        <Title className="mr8" size="text">
+        <Title className="mr8 search-filter-title" size="text">
             {title}
         </Title>
         <div className="search-filter-row-item">{children}</div>


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/8283407/184422082-c80277cc-c3f8-4a8b-9083-9ae76ed545ca.png)

After
![image](https://user-images.githubusercontent.com/8283407/184421746-759570dd-71a6-42ae-aa8b-a7aff7b188ea.png)

Before
![image](https://user-images.githubusercontent.com/8283407/184422051-a57f5051-bbbe-41b4-86a4-10f3018bd56e.png)

After
![image](https://user-images.githubusercontent.com/8283407/184421801-66616aa3-3566-4087-b5e4-b613c291b7a2.png)
