### PR TITLE
fix: overflow in raw metastore info

### DIFF
--- a/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.scss
+++ b/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.scss
@@ -20,4 +20,7 @@
             }
         }
     }
+    .raw-metastore-info{
+        word-break: break-all;
+    }
 }

--- a/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
+++ b/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
@@ -140,7 +140,7 @@ export const DataTableViewOverview: React.FC<
         });
 
     const rawMetastoreInfoDOM = table.hive_metastore_description ? (
-        <pre>
+        <pre className="raw-metastore-info">
             <ShowMoreText
                 seeLess
                 length={200}


### PR DESCRIPTION
We notice a possible overflow in "raw metastore info" section. In the case below, some of the column names is too long to fit in one line.
![image](https://user-images.githubusercontent.com/55952215/185483807-06c39dd4-721c-4955-b676-5156f97fbfc5.png)

We did some css changes to break up the string if it is too long as
![image](https://user-images.githubusercontent.com/55952215/185483923-0841471e-f74e-4f3d-9633-b5f71269c20d.png)
