### PR TITLE
feat: add support of syncing table/column description from metastore

### DIFF
--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -42,7 +42,7 @@ class DataTable(NamedTuple):
     type: str = None
     owner: str = None
 
-    # description from metastore
+    # description from metastore, expect HTML format
     description: str = None
 
     # Expected in UTC seconds
@@ -65,9 +65,11 @@ class DataTable(NamedTuple):
 class DataColumn(NamedTuple):
     name: str
     type: str
+
+    # column comment from sql query when creating the table
     comment: str = None
 
-    # description from metastore
+    # user edited description from metastore, expect HTML format
     description: str = None
 
 

--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -42,6 +42,9 @@ class DataTable(NamedTuple):
     type: str = None
     owner: str = None
 
+    # description from metastore
+    description: str = None
+
     # Expected in UTC seconds
     table_created_at: int = None
     table_updated_at: int = None
@@ -63,6 +66,9 @@ class DataColumn(NamedTuple):
     name: str
     type: str
     comment: str = None
+
+    # description from metastore
+    description: str = None
 
 
 class BaseMetastoreLoader(metaclass=ABCMeta):
@@ -237,6 +243,7 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
             ).id
             create_table_information(
                 data_table_id=table_id,
+                description=table.description,
                 latest_partitions=json.dumps((table.partitions or [])[-10:]),
                 earliest_partitions=json.dumps((table.partitions or [])[:10]),
                 hive_metastore_description=table.raw_description,
@@ -251,6 +258,7 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
                     name=column.name,
                     type=column.type,
                     comment=column.comment,
+                    description=column.description,
                     table_id=table_id,
                     commit=False,
                     session=session,

--- a/querybook/server/logic/metastore.py
+++ b/querybook/server/logic/metastore.py
@@ -271,10 +271,6 @@ def create_table_information(
         hive_metastore_description=hive_metastore_description,
     )
 
-    # As parameter descripton is newly added, for backward compatible,
-    # only set the description explicitly when it's not None.
-    # Otherwise, for those existing metastores which dont sync description
-    # to querybook, it will wipe out the existing description.
     if description is not None:
         new_table_information.description = description
 

--- a/querybook/server/logic/metastore.py
+++ b/querybook/server/logic/metastore.py
@@ -271,6 +271,10 @@ def create_table_information(
         hive_metastore_description=hive_metastore_description,
     )
 
+    # The reason that we dont add description direclty in
+    # DataTableInformation() above is because it's optional.
+    # Otherwise, for those existing metastores which dont sync description
+    # to querybook, it will wipe out the existing description.
     if description is not None:
         new_table_information.description = description
 

--- a/querybook/server/logic/metastore.py
+++ b/querybook/server/logic/metastore.py
@@ -253,6 +253,7 @@ def update_table(id, golden=None, score=None, commit=True, session=None):
 @with_session
 def create_table_information(
     data_table_id=None,
+    description=None,
     latest_partitions=None,
     earliest_partitions=None,
     hive_metastore_description=None,
@@ -269,6 +270,13 @@ def create_table_information(
         earliest_partitions=earliest_partitions,
         hive_metastore_description=hive_metastore_description,
     )
+
+    # As parameter descripton is newly added, for backward compatible,
+    # only set the description explicitly when it's not None.
+    # Otherwise, for those existing metastores which dont sync description
+    # to querybook, it will wipe out the existing description.
+    if description is not None:
+        new_table_information.description = description
 
     if not table_information:
         session.add(new_table_information)
@@ -419,7 +427,13 @@ def get_all_column_name_by_table_id(table_id, session=None):
 
 @with_session
 def create_column(
-    name=None, type=None, comment=None, table_id=None, commit=True, session=None
+    name=None,
+    type=None,
+    comment=None,
+    description=None,
+    table_id=None,
+    commit=True,
+    session=None,
 ):
     old_table_column = get_column_by_name(name, table_id, session=session)
     if old_table_column:
@@ -431,6 +445,9 @@ def create_column(
         comment=comment,
         table_id=table_id,
     )
+
+    if description is not None:
+        new_table_column.description = description
 
     if not old_table_column:
         session.add(new_table_column)


### PR DESCRIPTION
Some systems may have the metastore as the source of truth for the table/column description, as well as the table schema. This change is to add the support of syncing table description from the metastore.