### PR TITLE
feat: Add a new API of syncing a table from metastore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.8.0",
+    "version": "3.8.1",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -667,7 +667,10 @@ def get_schemas(metastore_id, limit=5, offset=0, sort_key="name", sort_order="de
     return {"results": schemas, "done": len(schemas) < limit}
 
 
-@register("/metastore/<int:metastore_id>/sync/", methods=["PUT"])
+@register(
+    "/metastore/<int:metastore_id>/<str:schema_name>/<str:table_name>/sync/",
+    methods=["PUT"],
+)
 def sync_table_from_metastore(
     metastore_id, schema_name, table_name, is_delete: bool = False
 ):
@@ -682,14 +685,11 @@ def sync_table_from_metastore(
         None if deleting a table
         table id if creating or updating a table
     """
-    with DBSession() as session:
-        metastore_loader = get_metastore_loader(metastore_id, session=session)
+    metastore_loader = get_metastore_loader(metastore_id)
 
-        if is_delete:
-            metastore_loader.sync_delete_table(schema_name, table_name, session=session)
-            return
-        else:
-            table_id = metastore_loader.sync_create_or_update_table(
-                schema_name, table_name, session=session
-            )
-            return table_id
+    if is_delete:
+        metastore_loader.sync_delete_table(schema_name, table_name)
+        return None
+    else:
+        table_id = metastore_loader.sync_create_or_update_table(schema_name, table_name)
+        return table_id

--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -665,3 +665,31 @@ def get_schemas(metastore_id, limit=5, offset=0, sort_key="name", sort_order="de
     schemas = logic.get_all_schemas(metastore_id, offset, limit, sort_key, sort_order)
 
     return {"results": schemas, "done": len(schemas) < limit}
+
+
+@register("/metastore/<int:metastore_id>/sync/", methods=["PUT"])
+def sync_table_from_metastore(
+    metastore_id, schema_name, table_name, is_delete: bool = False
+):
+    """Sync table info from metastore. Delete the table if is_delete is True.
+
+    Args:
+        metastore_id (int): metastore ID
+        schema_name (str): Schema name
+        table_name (str): Table name
+
+    Returns:
+        None if deleting a table
+        table id if creating or updating a table
+    """
+    with DBSession() as session:
+        metastore_loader = get_metastore_loader(metastore_id, session=session)
+
+        if is_delete:
+            metastore_loader.sync_delete_table(schema_name, table_name, session=session)
+            return
+        else:
+            table_id = metastore_loader.sync_create_or_update_table(
+                schema_name, table_name, session=session
+            )
+            return table_id

--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -668,7 +668,7 @@ def get_schemas(metastore_id, limit=5, offset=0, sort_key="name", sort_order="de
 
 
 @register(
-    "/table/schema_name/table_name/sync/",
+    "/table/<schema_name>/<table_name>/sync/",
     methods=["PUT"],
 )
 def sync_table_from_metastore(

--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -668,11 +668,11 @@ def get_schemas(metastore_id, limit=5, offset=0, sort_key="name", sort_order="de
 
 
 @register(
-    "/metastore/<int:metastore_id>/<str:schema_name>/<str:table_name>/sync/",
+    "/table/schema_name/table_name/sync/",
     methods=["PUT"],
 )
 def sync_table_from_metastore(
-    metastore_id, schema_name, table_name, is_delete: bool = False
+    schema_name, table_name, metastore_id, is_delete: bool = False
 ):
     """Sync table info from metastore. Delete the table if is_delete is True.
 


### PR DESCRIPTION
This new API endpoint will sync a table (given schema name and table name) for a specific metastore (given metastore id), including creating, updating and deleting a table.