### PR TITLE
DataDoc - Use Previous Query Engine

### DIFF
--- a/querybook/config/user_setting.yaml
+++ b/querybook/config/user_setting.yaml
@@ -20,6 +20,15 @@ default_query_engine:
     options: []
     helper: Default query engine when creating a query cell.
 
+use_previous_query_engine:
+    per_env: true
+    tab: general
+    default: disabled
+    options:
+        - enabled
+        - disabled
+    helper: Use the previous cell's selected query engine on a DataDoc when available.
+
 datadoc_arrow_key:
     default: enabled
     tab: general

--- a/querybook/webapp/components/DataDoc/DataDoc.tsx
+++ b/querybook/webapp/components/DataDoc/DataDoc.tsx
@@ -301,7 +301,8 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
         index: number,
         cellType: CELL_TYPE,
         context: string,
-        meta: IDataCellMeta
+        meta: IDataCellMeta,
+        previousEngine?: number
     ) {
         try {
             const dataDoc = this.props.dataDoc;
@@ -314,7 +315,8 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
                     index,
                     cellType,
                     context,
-                    meta
+                    meta,
+                    previousEngine
                 );
             }
         } catch (e) {
@@ -535,7 +537,8 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
         index: number,
         numberOfCells: number,
         lastQueryCellId: number,
-        queryIndexInDoc: number
+        queryIndexInDoc: number,
+        previousEngine: number
     ) {
         const { dataDoc, isEditable } = this.props;
         const { focusedCellIndex } = this.state;
@@ -556,6 +559,7 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
                             index={index}
                             numberOfCells={numberOfCells}
                             insertCellAt={insertCellAtBinded}
+                            previousEngine={previousEngine}
                             isHeader={true}
                             active={forceShow}
                             isEditable={isEditable}
@@ -586,25 +590,30 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
         const cellDOMs = [];
         const { dataDoc } = this.props;
         const dataDocCells = dataDoc.dataDocCells || [];
-        let lastQueryCellId: number = null;
+        let lastQueryCell = null;
         let queryIndexInDoc = 0;
+        let previousEngine: number = null;
 
         for (let i = 0; i < numberOfCells + 1; i++) {
             const cell = dataDocCells[i];
+            if (lastQueryCell) {
+                previousEngine = lastQueryCell.meta.engine;
+            }
             cellDOMs.push(
                 this.renderLazyDataDocCell(
                     cell,
                     i,
                     numberOfCells,
-                    lastQueryCellId,
-                    queryIndexInDoc
+                    cell ? cell.id : null,
+                    queryIndexInDoc,
+                    previousEngine
                 )
             );
 
             const isQueryCell = cell && cell.cell_type === 'query';
             if (isQueryCell) {
                 queryIndexInDoc++;
-                lastQueryCellId = cell.id;
+                lastQueryCell = cell;
             }
         }
 
@@ -856,7 +865,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
             index: number,
             cellType: CELL_TYPE,
             context: string | ContentState,
-            meta: IDataCellMeta
+            meta: IDataCellMeta,
+            previousEngine: number
         ) =>
             dispatch(
                 dataDocActions.insertDataDocCell(
@@ -864,7 +874,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
                     index,
                     cellType,
                     context,
-                    meta
+                    meta,
+                    previousEngine
                 )
             ),
 

--- a/querybook/webapp/components/DataDoc/DataDocCellControl.tsx
+++ b/querybook/webapp/components/DataDoc/DataDocCellControl.tsx
@@ -35,11 +35,13 @@ interface IProps {
     pasteCellAt?: (index: number) => any;
     copyCellAt?: (index: number, cut?: boolean) => any;
 
+    previousEngine?: number;
     insertCellAt: (
         index: number,
         cellKey: string,
         context: string,
-        meta: IDataCellMeta
+        meta: IDataCellMeta,
+        previousEngine: number
     ) => any;
     deleteCellAt?: (index: number) => any;
 
@@ -58,6 +60,7 @@ export const DataDocCellControl: React.FunctionComponent<IProps> = ({
 
     numberOfCells,
     moveCellAt,
+    previousEngine,
     insertCellAt,
     deleteCellAt,
 
@@ -214,6 +217,7 @@ export const DataDocCellControl: React.FunctionComponent<IProps> = ({
         centerButtons.push(
             <InsertCellButtons
                 index={index}
+                previousEngine={previousEngine}
                 key="insert-cell-buttons"
                 insertCellAt={insertCellAt}
             />
@@ -267,10 +271,11 @@ export const DataDocCellControl: React.FunctionComponent<IProps> = ({
 const InsertCellButtons: React.FC<{
     insertCellAt: IProps['insertCellAt'];
     index: number;
-}> = React.memo(({ insertCellAt, index }) => {
+    previousEngine: number;
+}> = React.memo(({ insertCellAt, index, previousEngine }) => {
     const handleInsertcell = useCallback(
-        (cellType: string) => insertCellAt(index, cellType, null, null),
-        [insertCellAt, index]
+        (cellType: string) => insertCellAt(index, cellType, null, null, previousEngine),
+        [insertCellAt, index, previousEngine]
     );
 
     const buttonsDOM = Object.entries(cellTypes).map(([cellKey, cellType]) => (

--- a/querybook/webapp/components/UserSettingsMenu/UserSettingsMenu.scss
+++ b/querybook/webapp/components/UserSettingsMenu/UserSettingsMenu.scss
@@ -4,7 +4,7 @@
     }
     .UserSettingsMenu-setting {
         white-space: nowrap;
-        width: 180px;
+        width: 190px;
     }
     .control {
         width: 180px;

--- a/querybook/webapp/context/DataDoc.ts
+++ b/querybook/webapp/context/DataDoc.ts
@@ -10,7 +10,8 @@ export interface IDataDocContextType {
         index: number,
         cellKey: string,
         context: string,
-        meta: IDataCellMeta
+        meta: IDataCellMeta,
+        previousEngine: number
     ) => Promise<any>;
     updateCell: (cellId: number, fields: DataCellUpdateFields) => Promise<any>;
     copyCellAt: (index: number, cut: boolean) => void;

--- a/querybook/webapp/redux/dataDoc/action.ts
+++ b/querybook/webapp/redux/dataDoc/action.ts
@@ -277,7 +277,8 @@ export function insertDataDocCell(
     index: number,
     cellType: CELL_TYPE,
     context: string | ContentState,
-    meta: IDataCellMeta
+    meta: IDataCellMeta,
+    previousEngine?: number
 ): ThunkResult<Promise<any>> {
     return (dispatch, getState) => {
         const state = getState();
@@ -297,13 +298,16 @@ export function insertDataDocCell(
                 state.environment.environmentEngineIds[
                     state.environment.currentEnvironmentId
                 ];
+            const defaultQueryEngine = previousEngine
+                ? previousEngine
+                : getQueryEngineId(
+                    userSetting['default_query_engine'],
+                    queryEngineIds
+                );
             const engine =
                 meta && meta['engine'] != null
                     ? meta['engine']
-                    : getQueryEngineId(
-                          userSetting['default_query_engine'],
-                          queryEngineIds
-                      );
+                    : defaultQueryEngine;
             meta = {
                 ...meta,
                 engine,

--- a/querybook/webapp/redux/dataDoc/action.ts
+++ b/querybook/webapp/redux/dataDoc/action.ts
@@ -298,12 +298,14 @@ export function insertDataDocCell(
                 state.environment.environmentEngineIds[
                     state.environment.currentEnvironmentId
                 ];
-            const defaultQueryEngine = previousEngine
-                ? previousEngine
-                : getQueryEngineId(
-                    userSetting['default_query_engine'],
-                    queryEngineIds
-                );
+            const defaultQueryEngine =
+                previousEngine &&
+                userSetting['use_previous_query_engine'] === 'enabled'
+                    ? previousEngine
+                    : getQueryEngineId(
+                          userSetting['default_query_engine'],
+                          queryEngineIds
+                      );
             const engine =
                 meta && meta['engine'] != null
                     ? meta['engine']


### PR DESCRIPTION
We noticed there's a default query engine set that's used when creating a new query cell on a DataDoc, but we wanted to have the option of defaulting to a query cell's previous selected query engine since it's easier in the case of having multiple query engines and when users are creating query cells for the same previously used query engine.

This is the new option on the User Settings page:
![image](https://user-images.githubusercontent.com/1399744/187309782-c08d37ae-8702-4e42-bb51-6f84acce5d25.png)

Functionality when `Use Previous Query Engine` is enabled:
![querybook-use-previous-query-engine](https://user-images.githubusercontent.com/1399744/187310593-fa916357-83d1-4cb0-8fec-61053f4ff113.gif)

