### PR TITLE
Bugfix: scatter/bubble charts were losing their labels after save

### DIFF
--- a/querybook/webapp/lib/chart/chart-data-processing.ts
+++ b/querybook/webapp/lib/chart/chart-data-processing.ts
@@ -153,6 +153,8 @@ export function processChartJSData(
         chartData['labels'] = dataRows.map((row) =>
             processDataPoint(row[xAxisIdx], xAxesScaleType)
         );
+    } else {
+        chartData['labels'] = dataRows.map((row) => row[0]);
     }
 
     return chartData;

--- a/querybook/webapp/lib/chart/chart-meta-processing.ts
+++ b/querybook/webapp/lib/chart/chart-meta-processing.ts
@@ -193,6 +193,9 @@ export function mapMetaToChartOptions(
                 titleMarginBottom: 8,
             },
             datalabels: {
+                formatter: (value, context) => {
+                    return context.chart.data.labels[context.dataIndex];
+                },
                 display:
                     meta.visual.values?.display === ChartValueDisplayType.TRUE
                         ? true


### PR DESCRIPTION
Hi, I was asked to investigate an issue involving the `datalabels` plugin, as it was rendering `[object Object]` instead of any other value... after inspecting the integration code I realized that `chartData['labels']` is not always populated!

Then, I tried to play with the `datalabels.formatter` callback to see if was possible to get the missing label from there but it was not possible, after you save the chart options then `context.chart.data.labels` becomes an empty array.

It seems whenever the `chartjs-plugin-datalabels` receives an `undefined` value from any formatter then it renders `[object Object]` instead? &mdash; my workaround sets `charData['labels']` from the first-field on `dataRows` because I am not using `x_axis` (`xAxisIdx` is not zero!) as the same value for the labels, e.g.

1. First, we create some sample data:

```sql
CREATE TABLE test_table(
   id   INTEGER NOT NULL PRIMARY KEY
  ,name VARCHAR(41) NOT NULL
  ,a    INTEGER  NOT NULL
  ,b    INTEGER  NOT NULL
  ,c    INTEGER  NOT NULL
  ,d    INTEGER  NOT NULL
);
INSERT INTO test_table(name,a,b,c,d) VALUES ('extinct',2278286,14347746,99079961,1927908);
INSERT INTO test_table(name,a,b,c,d) VALUES ('disappear',737184,30059,31556,12812);
INSERT INTO test_table(name,a,b,c,d) VALUES ('horizon',79358,404477,61049325,24140);
INSERT INTO test_table(name,a,b,c,d) VALUES ('command',7692138,4909601,83163263,418289);
INSERT INTO test_table(name,a,b,c,d) VALUES ('visual',624265,14360365,99057338,1905921);
INSERT INTO test_table(name,a,b,c,d) VALUES ('neighborhood',734783,30059,31555,12811);
INSERT INTO test_table(name,a,b,c,d) VALUES ('modernize',37830126,0,436967,432945);
INSERT INTO test_table(name,a,b,c,d) VALUES ('complain',37855786,462964,36796556,1136975);
INSERT INTO test_table(name,a,b,c,d) VALUES ('retired',37842292,677455,61470550,1730112);
INSERT INTO test_table(name,a,b,c,d) VALUES ('tell',6356376,54380358,57275104,1460489);
INSERT INTO test_table(name,a,b,c,d) VALUES ('deprive',4078907,0,42266,42026);
INSERT INTO test_table(name,a,b,c,d) VALUES ('serve',6345303,1679243,626652,137366);
INSERT INTO test_table(name,a,b,c,d) VALUES ('marine',4056700,0,42266,42026);
INSERT INTO test_table(name,a,b,c,d) VALUES ('float',2101702,1052977,14386199,74937);
INSERT INTO test_table(name,a,b,c,d) VALUES ('tasty',737055,30059,31547,12803);
INSERT INTO test_table(name,a,b,c,d) VALUES ('bold',737013,30059,31545,12801);
INSERT INTO test_table(name,a,b,c,d) VALUES ('pumpkin',2689606,0,37092,36799);
INSERT INTO test_table(name,a,b,c,d) VALUES ('triangle',2689546,0,37092,36799);
INSERT INTO test_table(name,a,b,c,d) VALUES ('swell',37851463,660926,73648999,1501929);
INSERT INTO test_table(name,a,b,c,d) VALUES ('tribe',3133317,336202,101648,54797);
```

2. Run the following query:
```sql
select name,a,b,c,d from test_table
```

3. Then, we add a _scatter_ chart with the following settings:
    Chart > X Axis: d, Scale: linear
    Visuals > Values > Display: Show values with overlap

### Before

Without the code changes the chart will eventually render as this:

![SCR-20220829-qyu](https://user-images.githubusercontent.com/206371/187322031-8d4f4475-c1db-40e5-8d01-b0b4cfd08c93.png)

> Note: this step (3) may be confusing, if you follow the steps one by one, then the state of the app preserves the previous labels giving you a false positive as they render fine... but, as soon as you save the changes the bug appears!

### After

With the code changes, now it looks as this:

![SCR-20220829-rdi](https://user-images.githubusercontent.com/206371/187323155-c566218d-fed1-410d-aced-25153048b08a.png)

> I was thinking on adding an extra `<SimpleField />` to capture which nth-field we want to use as label (see line 157) but I think it requires more work, so if you accept this PR I can work on making it more comfortable for end users.

Thank you! :beers: