### PR TITLE
fix: column icon css for partition keys

### DIFF
--- a/querybook/webapp/components/DataTableViewMini/ColumnIcon.tsx
+++ b/querybook/webapp/components/DataTableViewMini/ColumnIcon.tsx
@@ -22,12 +22,12 @@ export const ColumnIcon: React.FunctionComponent<IColumnIconProps> = ({
     };
     if (tooltip) {
         spanProps['aria-label'] = tooltip;
-        spanProps['data-balloon-pos'] = 'up';
+        spanProps['data-balloon-pos'] = 'right';
     }
 
     return (
         <span {...spanProps}>
-            <Icon name={name} size={16} fill={fill} />
+            <Icon name={name} size={14} fill={fill} />
         </span>
     );
 };

--- a/querybook/webapp/components/DataTableViewMini/TablePanelView.tsx
+++ b/querybook/webapp/components/DataTableViewMini/TablePanelView.tsx
@@ -6,11 +6,11 @@ import { DataTableTags } from 'components/DataTableTags/DataTableTags';
 import { useDataTable } from 'hooks/redux/useDataTable';
 import { generateFormattedDate } from 'lib/utils/datetime';
 import { getHumanReadableByteSize } from 'lib/utils/number';
+import { AllLucideIconNames } from 'ui/Icon/LucideIcons';
 import { Loader } from 'ui/Loader/Loader';
 
-import { PanelSection, SubPanelSection } from './PanelSection';
-import { AllLucideIconNames } from 'ui/Icon/LucideIcons';
 import { ColumnIcon } from './ColumnIcon';
+import { PanelSection, SubPanelSection } from './PanelSection';
 
 interface ITablePanelViewProps {
     tableId: number;
@@ -120,6 +120,7 @@ const StyledColumnRow = styled.div<IStyledColumnRowProps>`
     margin-bottom: 4px;
     display: flex;
     flex-direction: row;
+    align-items: center;
 
     .column-row-name {
         user-select: none;
@@ -170,7 +171,7 @@ const ColumnRow: React.FunctionComponent<{
             {icon && (
                 <ColumnIcon
                     name={icon}
-                    tooltip={'Partitioned Column'}
+                    tooltip={'Partition key'}
                     fill={false}
                 />
             )}


### PR DESCRIPTION
The column icon for partition keys doesn't look properly, here we
* center aligned it and make the icon size a bit smaller
* move the tooltip to right

**Before**
![image](https://user-images.githubusercontent.com/8308723/187370571-7d6872ed-28d9-46c4-8561-93bce920570a.png)

**After**
![Snip20220829_11](https://user-images.githubusercontent.com/8308723/187370591-f9ecf877-f810-4534-a546-06c5fa822253.png)
