### PR TITLE
feat: pass execution type to executor client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.10.0",
+    "version": "3.10.1",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/const/query_execution.py
+++ b/querybook/server/const/query_execution.py
@@ -3,6 +3,11 @@ from enum import Enum
 # Keep these the same as const/queryExecution.ts
 
 
+class QueryExecutionType(Enum):
+    ADHOC = "adhoc"
+    SCHEDULED = "scheduled"
+
+
 class QueryExecutionStatus(Enum):
     INITIALIZED = 0
     DELIVERED = 1

--- a/querybook/server/datasources/datadoc.py
+++ b/querybook/server/datasources/datadoc.py
@@ -10,7 +10,6 @@ from app.datasource import register, api_assert, with_impression
 from app.flask_app import socketio
 from app.db import DBSession, with_session
 from const.impression import ImpressionItemType
-from const.query_execution import QueryExecutionType
 from env import QuerybookSettings
 
 from lib.celery.cron import validate_cron
@@ -291,8 +290,6 @@ def create_datadoc_schedule(
                 **kwargs,
                 "user_id": current_user.id,
                 "doc_id": id,
-                "scheduled": True,
-                "execution_type": QueryExecutionType.SCHEDULED.value,
             },
             task_type="user",
             session=session,

--- a/querybook/server/datasources/datadoc.py
+++ b/querybook/server/datasources/datadoc.py
@@ -10,6 +10,7 @@ from app.datasource import register, api_assert, with_impression
 from app.flask_app import socketio
 from app.db import DBSession, with_session
 from const.impression import ImpressionItemType
+from const.query_execution import QueryExecutionType
 from env import QuerybookSettings
 
 from lib.celery.cron import validate_cron
@@ -286,7 +287,13 @@ def create_datadoc_schedule(
             schedule_name,
             "tasks.run_datadoc.run_datadoc",
             cron=cron,
-            kwargs={**kwargs, "user_id": current_user.id, "doc_id": id},
+            kwargs={
+                **kwargs,
+                "user_id": current_user.id,
+                "doc_id": id,
+                "scheduled": True,
+                "execution_type": QueryExecutionType.SCHEDULED.value,
+            },
             task_type="user",
             session=session,
         )

--- a/querybook/server/lib/query_executor/base_executor.py
+++ b/querybook/server/lib/query_executor/base_executor.py
@@ -493,8 +493,10 @@ class QueryExecutorBaseClass(metaclass=ABCMeta):
         query: str,
         statement_ranges,
         client_setting,
+        execution_type,
     ):
         self._query = query
+        self._execution_type = execution_type
 
         if self.SINGLE_QUERY_QUERY_ENGINE():
             self._statement_ranges = [[0, len(query)]]

--- a/querybook/server/lib/query_executor/executor_factory.py
+++ b/querybook/server/lib/query_executor/executor_factory.py
@@ -17,16 +17,23 @@ LOG = get_logger(__file__)
 
 
 @with_session
-def create_executor_from_execution(query_execution_id, celery_task, session=None):
+def create_executor_from_execution(
+    query_execution_id, celery_task, execution_type, session=None
+):
     executor_params, engine = _get_executor_params_and_engine(
-        query_execution_id, celery_task=celery_task, session=session
+        query_execution_id,
+        celery_task=celery_task,
+        execution_type=execution_type,
+        session=session,
     )
     executor = get_executor_class(engine.language, engine.executor)(**executor_params)
     return executor
 
 
 @with_session
-def _get_executor_params_and_engine(query_execution_id, celery_task, session=None):
+def _get_executor_params_and_engine(
+    query_execution_id, celery_task, execution_type, session=None
+):
     query, statement_ranges, uid, engine_id = _get_query_execution_info(
         query_execution_id, session=session
     )
@@ -36,6 +43,7 @@ def _get_executor_params_and_engine(query_execution_id, celery_task, session=Non
         raise ArchivedQueryEngine("This query engine is disabled.")
 
     client_setting = get_client_setting_from_engine(engine, uid, session=session)
+    client_setting["execution_type"] = execution_type
 
     return (
         {

--- a/querybook/server/lib/query_executor/executor_factory.py
+++ b/querybook/server/lib/query_executor/executor_factory.py
@@ -43,7 +43,6 @@ def _get_executor_params_and_engine(
         raise ArchivedQueryEngine("This query engine is disabled.")
 
     client_setting = get_client_setting_from_engine(engine, uid, session=session)
-    client_setting["execution_type"] = execution_type
 
     return (
         {
@@ -52,6 +51,7 @@ def _get_executor_params_and_engine(
             "query": query,
             "statement_ranges": statement_ranges,
             "client_setting": client_setting,
+            "execution_type": execution_type,
         },
         engine,
     )

--- a/querybook/server/tasks/run_datadoc.py
+++ b/querybook/server/tasks/run_datadoc.py
@@ -3,7 +3,7 @@ from celery import chain
 from app.db import DBSession
 from app.flask_app import celery
 
-from const.query_execution import QueryExecutionStatus
+from const.query_execution import QueryExecutionStatus, QueryExecutionType
 from const.schedule import NotifyOn, TaskRunStatus
 
 from lib.logger import get_logger
@@ -37,6 +37,7 @@ def run_datadoc_with_config(
     self,
     doc_id,
     user_id=None,
+    execution_type=QueryExecutionType.SCHEDULED.value,
     # Notification related settings
     notify_with=None,
     notify_on=NotifyOn.ALL.value,
@@ -77,7 +78,7 @@ def run_datadoc_with_config(
                 else _start_query_execution_task.s(**start_query_execution_kwargs)
             )
 
-            tasks_to_run.append(run_query_task.s())
+            tasks_to_run.append(run_query_task.s(execution_type=execution_type))
 
         # Create db entry record
         record_id = create_task_run_record_for_celery_task(self, session=session)

--- a/querybook/webapp/const/queryExecution.ts
+++ b/querybook/webapp/const/queryExecution.ts
@@ -1,6 +1,11 @@
 import { ICancelablePromise } from 'lib/datasource';
 
 // Keep this the same as the Enum defined in const/query_execution.py
+export enum QueryExecutionType {
+    ADHOC = 'adhoc',
+    SCHEDULED = 'scheduled',
+}
+
 export enum QueryExecutionStatus {
     INITIALIZED = 0,
     DELIVERED,

--- a/querybook/webapp/const/queryExecution.ts
+++ b/querybook/webapp/const/queryExecution.ts
@@ -1,6 +1,9 @@
 import { ICancelablePromise } from 'lib/datasource';
 
-// Keep this the same as the Enum defined in const/query_execution.py
+/*
+ *  Keep definitions in this file to be same as const/query_execution.py
+ */
+
 export enum QueryExecutionType {
     ADHOC = 'adhoc',
     SCHEDULED = 'scheduled',


### PR DESCRIPTION
Add query execution type as enum, and pass it down to the executor client
* adhoc
* scheduled

with that, we can pass the scheduled flag to the Presto client, something like 
```
connection = presto.connect(
...
session_props={'presto_scheduled_query': 'true'}, # when execution type is scheduled
)

```