### PR TITLE
feat: Allow disabling Query Engines

### DIFF
--- a/querybook/server/datasources/query_snippet.py
+++ b/querybook/server/datasources/query_snippet.py
@@ -14,7 +14,11 @@ from logic import admin as admin_logic
 def get_query_snippet_by_id(query_snippet_id):
     with DBSession() as session:
         query_snippet = logic.get_snippet_by_id(query_snippet_id, session=session)
-        verify_query_engine_permission(query_snippet.engine_id, session=session)
+        verify_query_engine_permission(
+            query_snippet.engine_id,
+            allow_disabled=True,  # Allow viewing snippet even if query engine is disabled
+            session=session,
+        )
         return query_snippet
 
 

--- a/querybook/webapp/components/AppAdmin/AdminQueryEngine.tsx
+++ b/querybook/webapp/components/AppAdmin/AdminQueryEngine.tsx
@@ -373,6 +373,14 @@ export const AdminQueryEngine: React.FunctionComponent<IProps> = ({
                                 onChange={updateExecutor}
                             />
                         </div>
+                        <div className="flex-row stacked-fields flex0-children">
+                            <SimpleField
+                                stacked
+                                name="feature_params.disabled"
+                                type="toggle"
+                                label="Disabled"
+                            />
+                        </div>
                         <div className="AdminForm-section">
                             <div className="AdminForm-section-top flex-row">
                                 <div className="AdminForm-section-title">

--- a/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
+++ b/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
@@ -39,8 +39,8 @@ import { doesLanguageSupportUDF } from 'lib/utils/udf';
 import * as dataSourcesActions from 'redux/dataSources/action';
 import { setSidebarTableId } from 'redux/querybookUI/action';
 import {
+    enabledQueryEngineSelector,
     queryEngineByIdEnvSelector,
-    queryEngineSelector,
 } from 'redux/queryEngine/selector';
 import { createQueryExecution } from 'redux/queryExecutions/action';
 import { Dispatch, IStoreState } from 'redux/store/types';
@@ -901,7 +901,7 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
 }
 
 function mapStateToProps(state: IStoreState) {
-    const queryEngines = queryEngineSelector(state);
+    const queryEngines = enabledQueryEngineSelector(state);
 
     return {
         queryTranspilers: state.queryEngine.queryTranspilers,

--- a/querybook/webapp/components/DataTableViewSamples/DataTableViewSamples.tsx
+++ b/querybook/webapp/components/DataTableViewSamples/DataTableViewSamples.tsx
@@ -61,6 +61,7 @@ export const DataTableViewSamples: React.FunctionComponent<
             ] ?? [];
         return queryEngineIds
             .map((engineId) => state.queryEngine.queryEngineById[engineId])
+            .filter((engine) => engine.feature_params.disabled !== true)
             .filter((engine) => engine?.metastore_id === schema.metastore_id);
     });
 

--- a/querybook/webapp/components/QueryComposer/QueryComposer.tsx
+++ b/querybook/webapp/components/QueryComposer/QueryComposer.tsx
@@ -45,8 +45,8 @@ import { doesLanguageSupportUDF } from 'lib/utils/udf';
 import * as adhocQueryActions from 'redux/adhocQuery/action';
 import * as dataDocActions from 'redux/dataDoc/action';
 import {
+    enabledQueryEngineSelector,
     queryEngineByIdEnvSelector,
-    queryEngineSelector,
 } from 'redux/queryEngine/selector';
 import * as queryExecutionsAction from 'redux/queryExecutions/action';
 import { Dispatch, IStoreState } from 'redux/store/types';
@@ -89,7 +89,7 @@ const useEngine = (dispatch: Dispatch, environmentId: number) => {
         (state: IStoreState) => state.adhocQuery[environmentId]?.engineId
     );
     const queryEngineById = useSelector(queryEngineByIdEnvSelector);
-    const queryEngines = useSelector(queryEngineSelector);
+    const queryEngines = useSelector(enabledQueryEngineSelector);
     const defaultEngineId = useSelector((state: IStoreState) =>
         getQueryEngineId(
             state.user.computedSettings['default_query_engine'],

--- a/querybook/webapp/components/QuerySnippetComposer/QuerySnippetComposer.tsx
+++ b/querybook/webapp/components/QuerySnippetComposer/QuerySnippetComposer.tsx
@@ -9,8 +9,8 @@ import { getTemplatedQueryVariables } from 'lib/templated-query';
 import { generateFormattedDate } from 'lib/utils/datetime';
 import { navigateWithinEnv } from 'lib/utils/query-string';
 import {
+    enabledQueryEngineSelector,
     queryEngineByIdEnvSelector,
-    queryEngineSelector,
 } from 'redux/queryEngine/selector';
 import * as querySnippetsActions from 'redux/querySnippets/action';
 import { IQueryForm, IQuerySnippet } from 'redux/querySnippets/types';
@@ -525,7 +525,7 @@ class QuerySnippetComposerComponent extends React.PureComponent<
 }
 
 const mapStateToProps = (state: IStoreState) => ({
-    queryEngines: queryEngineSelector(state),
+    queryEngines: enabledQueryEngineSelector(state),
     queryEngineById: queryEngineByIdEnvSelector(state),
     user: state.user.myUserInfo,
 });

--- a/querybook/webapp/components/QueryViewNavigator/QueryViewNavigator.tsx
+++ b/querybook/webapp/components/QueryViewNavigator/QueryViewNavigator.tsx
@@ -4,8 +4,8 @@ import { connect } from 'react-redux';
 
 import { IQueryExecution, QueryExecutionStatus } from 'const/queryExecution';
 import {
+    enabledQueryEngineSelector,
     queryEngineByIdEnvSelector,
-    queryEngineSelector,
 } from 'redux/queryEngine/selector';
 import * as queryExecutionsActions from 'redux/queryExecutions/action';
 import * as queryViewActions from 'redux/queryView/action';
@@ -141,7 +141,7 @@ const mapStateToProps = (state: IStoreState) => ({
     queryResults: queryExecutionResultSelector(state),
     isLoadingQueries: state.queryView.isLoading,
     queryViewFilters: state.queryView.filters,
-    queryEngines: queryEngineSelector(state),
+    queryEngines: enabledQueryEngineSelector(state),
     queryEngineById: queryEngineByIdEnvSelector(state),
 });
 

--- a/querybook/webapp/components/TableUploader/useQueryEnginesForUpload.ts
+++ b/querybook/webapp/components/TableUploader/useQueryEnginesForUpload.ts
@@ -1,11 +1,11 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
-import { queryEngineSelector } from 'redux/queryEngine/selector';
+import { enabledQueryEngineSelector } from 'redux/queryEngine/selector';
 import { IStoreState } from 'redux/store/types';
 
 export function useQueryEnginesForUpload(metastoreId?: number) {
-    const queryEngines = useSelector(queryEngineSelector);
+    const queryEngines = useSelector(enabledQueryEngineSelector);
     return useMemo(
         () =>
             queryEngines.filter(
@@ -18,7 +18,7 @@ export function useQueryEnginesForUpload(metastoreId?: number) {
 }
 
 export function useMetastoresForUpload() {
-    const queryEngines = useSelector(queryEngineSelector);
+    const queryEngines = useSelector(enabledQueryEngineSelector);
     const availableForUploadMetaStoreIds = useMemo(
         () =>
             new Set(

--- a/querybook/webapp/components/UserSettingsMenu/UserSettingsMenu.tsx
+++ b/querybook/webapp/components/UserSettingsMenu/UserSettingsMenu.tsx
@@ -5,7 +5,7 @@ import { UserSettingsTab } from 'components/EnvironmentAppRouter/modalRoute/User
 import { titleize } from 'lib/utils';
 import { availableEnvironmentsSelector } from 'redux/environment/selector';
 import { notificationServiceSelector } from 'redux/notificationService/selector';
-import { queryEngineSelector } from 'redux/queryEngine/selector';
+import { enabledQueryEngineSelector } from 'redux/queryEngine/selector';
 import { IStoreState } from 'redux/store/types';
 import * as userActions from 'redux/user/action';
 import { makeSelectOptions, Select } from 'ui/Select/Select';
@@ -39,7 +39,7 @@ export const UserSettingsMenu: React.FC<{ tab: UserSettingsTab }> = ({
         (state: IStoreState) => state.environment.currentEnvironmentId
     );
     const availableEnvironments = useSelector(availableEnvironmentsSelector);
-    const queryEngines = useSelector(queryEngineSelector);
+    const queryEngines = useSelector(enabledQueryEngineSelector);
     const notifiers = useSelector(notificationServiceSelector);
 
     const dispatch = useDispatch();

--- a/querybook/webapp/const/queryEngine.ts
+++ b/querybook/webapp/const/queryEngine.ts
@@ -9,6 +9,7 @@ export interface IQueryEngine {
     executor: string;
 
     feature_params: {
+        disabled?: boolean;
         row_limit?: number;
         status_checker?: string;
         upload_exporter?: string;

--- a/querybook/webapp/hooks/dataDoc/useCreateDataDoc.ts
+++ b/querybook/webapp/hooks/dataDoc/useCreateDataDoc.ts
@@ -6,12 +6,12 @@ import history from 'lib/router-history';
 import { getQueryEngineId } from 'lib/utils';
 import { createDataDoc } from 'redux/dataDoc/action';
 import { currentEnvironmentSelector } from 'redux/environment/selector';
-import { queryEngineSelector } from 'redux/queryEngine/selector';
+import { enabledQueryEngineSelector } from 'redux/queryEngine/selector';
 import { Dispatch, IStoreState } from 'redux/store/types';
 
 export function useCreateDataDoc(withTour = false) {
     const environment = useSelector(currentEnvironmentSelector);
-    const queryEngines = useSelector(queryEngineSelector);
+    const queryEngines = useSelector(enabledQueryEngineSelector);
     const defaultEngineId = useSelector((state: IStoreState) =>
         getQueryEngineId(
             state.user.computedSettings['default_query_engine'],


### PR DESCRIPTION
This feature allows Query Engines to be disabled without deleting or removing them from an environment.  Disabled Query Engines cannot be used to execute queries and they do not appear in the Query Engine dropdown.  However, they do appear in search results, search filters, and where used in DataDocs and snippets.

![Screen Shot 2022-09-06 at 6 21 09 PM](https://user-images.githubusercontent.com/3084806/188750642-e30d5f60-2757-4f5a-9f86-543e53e8deb2.png)
