### PR TITLE
fix: lint error doesn't disappear when switching to templating query

### DIFF
--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -403,6 +403,7 @@ export class QueryEditor extends React.PureComponent<
             isQueryUsingTemplating(code) ||
             !getLintErrors
         ) {
+            // purge previous lint errors
             if (onLintCompletion) {
                 onLintCompletion(false);
             }

--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -403,6 +403,9 @@ export class QueryEditor extends React.PureComponent<
             isQueryUsingTemplating(code) ||
             !getLintErrors
         ) {
+            if (onLintCompletion) {
+                onLintCompletion(false);
+            }
             onComplete([]);
             return;
         }


### PR DESCRIPTION
When updating a query with lint error to use template variables, the error still remains, while it's supposed to disappear for templating queries.

![Snip20220908_27](https://user-images.githubusercontent.com/8308723/189183636-ca10cbd9-3ed2-45cb-ab96-d5885aca29fe.png)
