### PR TITLE
feat: improved query limit

### DIFF
--- a/docs_website/docs/integrations/customize_html.md
+++ b/docs_website/docs/integrations/customize_html.md
@@ -173,3 +173,19 @@ window.CUSTOM_ENGINE_UDFS = {
     },
 }
 ```
+
+### (Experimental) Row Limit Scale
+
+Querybook provides an experimental query engine feature that auto transforms select
+queries without limit into select queries with limit. By default, users can choose
+limits between 10^1,10^2,...,10^6 and the default limit is 10^3.
+
+However, you can also customize the scale and default value by modifying the following
+window variables:
+
+```js
+// now user can only pick between these values
+window.ROW_LIMIT_SCALE = [8, 64, 512, 4096, 32768];
+// the default limit is now 4096
+window.DEFAULT_ROW_LIMIT = 4096;
+```

--- a/docs_website/docs/integrations/customize_html.md
+++ b/docs_website/docs/integrations/customize_html.md
@@ -178,7 +178,7 @@ window.CUSTOM_ENGINE_UDFS = {
 
 Querybook provides an experimental query engine feature that auto transforms select
 queries without limit into select queries with limit. By default, users can choose
-limits between 10^1,10^2,...,10^6 and the default limit is 10^3.
+limits between 10^1,10^2,...,10^5 and the default limit is 10^3.
 
 However, you can also customize the scale and default value by modifying the following
 window variables:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.10.1",
+    "version": "3.10.2",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/config/datadoc.yaml
+++ b/querybook/config/datadoc.yaml
@@ -16,11 +16,13 @@ cell_types:
             engine: 0 # Engine Id
             collapsed: false
             query_collapsed: false
+            limit: 0
         meta_default:
             title: ''
             engine: null
             collapsed: false
             query_collapsed: false
+            limit: 0
     chart:
         key: 'chart'
         name: 'Chart'

--- a/querybook/webapp/__tests__/lib/sql-helper/sql-limiter.test.ts
+++ b/querybook/webapp/__tests__/lib/sql-helper/sql-limiter.test.ts
@@ -1,4 +1,81 @@
-import { getLimitedQuery } from 'lib/sql-helper/sql-limiter';
+import {
+    getLimitedQuery,
+    getSelectStatementLimit,
+} from 'lib/sql-helper/sql-limiter';
+
+describe('getSelectStatementLimit', () => {
+    describe('when it is not a SELECT statement', () => {
+        test('DELETE', () => {
+            const query = 'DELETE FROM table_1 WHERE field = 1;';
+            expect(getSelectStatementLimit(query)).toBeNull();
+        });
+        test('when running a delete query', () => {
+            const query = 'DELETE FROM table_1 WHERE field = 1;';
+            expect(getSelectStatementLimit(query)).toBeNull();
+        });
+
+        test('when running a create database query', () => {
+            const query = 'CREATE DATABASE IF NOT EXISTS db_1;';
+            expect(getSelectStatementLimit(query)).toBeNull();
+        });
+        test('when running a create table query', () => {
+            const query = 'CREATE TABLE table_1 (field1 INT);';
+            expect(getSelectStatementLimit(query)).toBeNull();
+        });
+        test('when truncating a table', () => {
+            const query = 'TRUNCATE TABLE table_1;';
+            expect(getSelectStatementLimit(query)).toBeNull();
+        });
+        test('when running a drop and create database query', () => {
+            const query = `
+                drop table if exists db.table1;
+                create table db.table1;
+            `;
+            expect(getSelectStatementLimit(query)).toBeNull();
+        });
+        test('when running an insert query', () => {
+            const query = 'INSERT INTO table_1 (field1) VALUES (1);';
+            expect(getSelectStatementLimit(query)).toBeNull();
+        });
+        test('when running an update query', () => {
+            const query = 'UPDATE table_1 SET field1 = 1 WHERE field = 1;';
+            expect(getSelectStatementLimit(query)).toBeNull();
+        });
+    });
+    describe('select statement without limits', () => {
+        test('select with join and groupby', () => {
+            const query =
+                'SELECT max(field) FROM tbl JOIN (SELECT * FROM tbl2) t2 ON tbl.a = t2.b GROUP BY c';
+            expect(getSelectStatementLimit(query)).toBe(-1);
+        });
+    });
+
+    describe('correctly extract limit', () => {
+        test('select with where, join, group by, and having', () => {
+            const query =
+                'SELECT max(field) FROM tbl JOIN (SELECT * FROM tbl2 LIMIT 10) t2 ON tbl.a = t2.b GROUP BY c HAVING max(field) < 2 LIMIT 10';
+            expect(getSelectStatementLimit(query)).toBe(10);
+        });
+        test('when running a select query with fetch', () => {
+            const query =
+                'SELECT * FROM table_1 ORDER BY id FETCH FIRST 10 ROWS ONLY;';
+            expect(getSelectStatementLimit(query, 'trino')).toBe(10);
+        });
+        test('when running a select query with offset and fetch', () => {
+            const query =
+                'SELECT * FROM table_1 ORDER BY id OFFSET 10 FETCH NEXT 20 ROWS ONLY;';
+            expect(getSelectStatementLimit(query, 'trino')).toBe(20);
+        });
+        test('when running a select query with nested query', () => {
+            const query = `select * from (select * from table limit 5) as x limit 10`;
+            expect(getSelectStatementLimit(query, 'trino')).toBe(10);
+        });
+        test('when running a select query with a where clause and a limit', () => {
+            const query = 'SELECT * FROM table_1 WHERE field = 1 LIMIT 1000;';
+            expect(getSelectStatementLimit(query, 'trino')).toBe(1000);
+        });
+    });
+});
 
 describe('getLimitedQuery', () => {
     describe('not limited', () => {
@@ -12,46 +89,6 @@ describe('getLimitedQuery', () => {
                 SELECT * FROM table_1 WHERE field = 1;
             `;
             expect(getLimitedQuery(query)).toBe(query);
-        });
-        test('when running a delete query', () => {
-            const query = 'DELETE FROM table_1 WHERE field = 1;';
-            expect(getLimitedQuery(query, 100)).toBe(query);
-        });
-        test('when running a select query with a where clause and a limit', () => {
-            const query = 'SELECT * FROM table_1 WHERE field = 1 LIMIT 1000;';
-            expect(getLimitedQuery(query, 100)).toBe(query);
-        });
-        test('when running a select query with a where clause and a group by and an order by', () => {
-            const query =
-                'SELECT field, count(*) FROM table_1 WHERE deleted = false GROUP BY field ORDER BY field';
-            expect(getLimitedQuery(query, 100)).toBe(`${query} limit 100;`);
-        });
-        test('when running a create database query', () => {
-            const query = 'CREATE DATABASE IF NOT EXISTS db_1;';
-            expect(getLimitedQuery(query, 100)).toBe(query);
-        });
-        test('when running a create table query', () => {
-            const query = 'CREATE TABLE table_1 (field1 INT);';
-            expect(getLimitedQuery(query, 100)).toBe(query);
-        });
-        test('when truncating a table', () => {
-            const query = 'TRUNCATE TABLE table_1;';
-            expect(getLimitedQuery(query, 100)).toBe(query);
-        });
-        test('when running a drop and create database query', () => {
-            const query = `
-                drop table if exists db.table1;
-                create table db.table1;
-            `;
-            expect(getLimitedQuery(query, 100)).toBe(query);
-        });
-        test('when running an insert query', () => {
-            const query = 'INSERT INTO table_1 (field1) VALUES (1);';
-            expect(getLimitedQuery(query, 100)).toBe(query);
-        });
-        test('when running an update query', () => {
-            const query = 'UPDATE table_1 SET field1 = 1 WHERE field = 1;';
-            expect(getLimitedQuery(query, 100)).toBe(query);
         });
         test('when running a select query with fetch', () => {
             const query =
@@ -67,11 +104,20 @@ describe('getLimitedQuery', () => {
             const query = `select * from (select * from table limit 5) as x limit 10`;
             expect(getLimitedQuery(query, 100, 'trino')).toBe(query);
         });
+        test('when running a select query with a where clause and a limit', () => {
+            const query = 'SELECT * FROM table_1 WHERE field = 1 LIMIT 1000;';
+            expect(getLimitedQuery(query, 100, 'trino')).toBe(query);
+        });
     });
     describe('limited', () => {
         test('when running a select query', () => {
             const query = 'SELECT * FROM table_1';
             expect(getLimitedQuery(query, 10)).toBe(`${query} limit 10;`);
+        });
+        test('when running a select query with a where clause and a group by and an order by', () => {
+            const query =
+                'SELECT field, count(*) FROM table_1 WHERE deleted = false GROUP BY field ORDER BY field';
+            expect(getLimitedQuery(query, 100)).toBe(`${query} limit 100;`);
         });
         test('when running a select query with trailing semicolon', () => {
             const query = 'SELECT * FROM table_1;';

--- a/querybook/webapp/components/AppAdmin/AdminQueryEngine.tsx
+++ b/querybook/webapp/components/AppAdmin/AdminQueryEngine.tsx
@@ -434,8 +434,8 @@ export const AdminQueryEngine: React.FunctionComponent<IProps> = ({
                                 <SimpleField
                                     stacked
                                     name="feature_params.row_limit"
-                                    type="number"
-                                    label="(Experimental) Row Limit"
+                                    type="toggle"
+                                    label="(Experimental) Enable Row Limit"
                                 />
                             </div>
                         </div>

--- a/querybook/webapp/components/QueryComposer/RunQuery.tsx
+++ b/querybook/webapp/components/QueryComposer/RunQuery.tsx
@@ -26,7 +26,7 @@ export async function transformQuery(
         engine.id
     );
 
-    if (!templatedVariables) {
+    if (!templatizedQuery) {
         return '';
     }
 

--- a/querybook/webapp/components/QueryComposer/RunQuery.tsx
+++ b/querybook/webapp/components/QueryComposer/RunQuery.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import toast from 'react-hot-toast';
+
+import { IQueryEngine } from 'const/queryEngine';
+import { sendConfirm } from 'lib/querybookUI';
+import { getDroppedTables } from 'lib/sql-helper/sql-checker';
+import { getLimitedQuery } from 'lib/sql-helper/sql-limiter';
+import { renderTemplatedQuery } from 'lib/templated-query';
+import { Nullable } from 'lib/typescript';
+import { formatError } from 'lib/utils/error';
+import { Content } from 'ui/Content/Content';
+
+export async function transformQuery(
+    query: string,
+    templatedVariables: Record<string, string>,
+    engine: IQueryEngine,
+    rowLimit: Nullable<number>
+): Promise<string> {
+    if (!query) {
+        return '';
+    }
+
+    const templatizedQuery = await transformTemplatedQuery(
+        query,
+        templatedVariables,
+        engine.id
+    );
+
+    if (!templatedVariables) {
+        return '';
+    }
+
+    const limitedQuery = transformLimitedQuery(
+        templatizedQuery,
+        rowLimit,
+        engine
+    );
+
+    return limitedQuery;
+}
+
+export async function runQuery(
+    query: string,
+    engineId: number,
+    createQueryExecution: (query: string, engineId: number) => Promise<number>
+): Promise<number> {
+    if (!query) {
+        return null;
+    }
+    const runQuery = () => createQueryExecution(query, engineId);
+    return confirmIfDroppingTablesThenRunQuery(runQuery, query);
+}
+
+async function transformTemplatedQuery(
+    query: string,
+    templatedVariables: Record<string, string>,
+    engineId: number
+) {
+    try {
+        return await renderTemplatedQuery(query, templatedVariables, engineId);
+    } catch (e) {
+        toast.error(
+            <div>
+                <p>Failed to templatize query. </p>
+                <p>{formatError(e)}</p>
+            </div>,
+            {
+                duration: 5000,
+            }
+        );
+    }
+}
+
+function transformLimitedQuery(
+    query: string,
+    rowLimit: Nullable<number>,
+    engine: IQueryEngine
+) {
+    return engine.feature_params?.row_limit && rowLimit != null
+        ? getLimitedQuery(query, rowLimit, engine.language)
+        : query;
+}
+
+async function confirmIfDroppingTablesThenRunQuery(
+    runQuery: () => Promise<number>,
+    query: string
+) {
+    const droppedTables = getDroppedTables(query);
+
+    let queryId: number;
+    if (droppedTables.length > 0) {
+        queryId = await new Promise<number>((resolve, reject) => {
+            sendConfirm({
+                header: 'Dropping Tables?',
+                message: (
+                    <Content>
+                        <div>Your query is going to drop</div>
+                        <ul>
+                            {droppedTables.map((t) => (
+                                <li key={t}>{t}</li>
+                            ))}
+                        </ul>
+                    </Content>
+                ),
+                onConfirm: () => runQuery().then(resolve, reject),
+                onDismiss: () => resolve(null),
+                confirmText: 'Continue Execution',
+            });
+        });
+    } else {
+        queryId = await runQuery();
+    }
+
+    return queryId;
+}

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.scss
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.scss
@@ -1,9 +1,9 @@
 .QueryRunButton {
     .Button {
-        width: 120px;
+        width: 100px;
         display: flex;
         justify-content: center;
-        margin: 0px 16px;
+        margin: 0px 4px;
         font-weight: bold;
     }
     .run-selection {

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
@@ -5,10 +5,11 @@ import { useSelector } from 'react-redux';
 import { IQueryEngine, QueryEngineStatus } from 'const/queryEngine';
 import { queryEngineStatusToIconStatus } from 'const/queryStatusIcon';
 import { TooltipDirection } from 'const/tooltip';
+import { DEFAULT_ROW_LIMIT, ROW_LIMIT_SCALE } from 'lib/sql-helper/sql-limiter';
 import { getShortcutSymbols, KeyMap } from 'lib/utils/keyboard';
+import { formatNumber } from 'lib/utils/number';
 import { queryEngineStatusByIdEnvSelector } from 'redux/queryEngine/selector';
 import { AsyncButton, IAsyncButtonHandles } from 'ui/AsyncButton/AsyncButton';
-import { Checkbox } from 'ui/Checkbox/Checkbox';
 import { Dropdown } from 'ui/Dropdown/Dropdown';
 import { Icon } from 'ui/Icon/Icon';
 import { ListMenu } from 'ui/Menu/ListMenu';
@@ -25,10 +26,11 @@ interface IQueryRunButtonProps extends IQueryEngineSelectorProps {
     disabled?: boolean;
     hasSelection?: boolean;
     runButtonTooltipPos?: TooltipDirection;
-    onRunClick: () => any;
-    rowLimit?: boolean;
-    onRowLimitChange?: (rowLimit: boolean) => void;
     hasLintError: boolean;
+
+    rowLimit?: number;
+    onRunClick: () => any;
+    onRowLimitChange?: (rowLimit: number) => void;
 }
 
 export interface IQueryRunButtonHandles {
@@ -89,7 +91,7 @@ export const QueryRunButton = React.forwardRef<
                 aria-label={
                     hasLintError
                         ? 'Validation failed, click to run anyway'
-                        : `Execute (${EXECUTE_QUERY_SHORTCUT})`
+                        : `Run (${EXECUTE_QUERY_SHORTCUT})`
                 }
                 data-balloon-length="fit"
                 data-balloon-pos={runButtonTooltipPos}
@@ -97,19 +99,19 @@ export const QueryRunButton = React.forwardRef<
             />
         );
 
+        const isRowLimitEnabled =
+            queryEngineById[engineId]?.feature_params.row_limit;
         const rowLimitDOM =
-            onRowLimitChange &&
-            queryEngineById[engineId]?.feature_params.row_limit ? (
-                <Checkbox
-                    onChange={onRowLimitChange}
-                    value={rowLimit}
-                    title="Limit results automatically"
+            onRowLimitChange && isRowLimitEnabled ? (
+                <QueryLimitSelector
+                    rowLimit={rowLimit}
+                    setRowLimit={onRowLimitChange}
+                    tooltipPos={runButtonTooltipPos}
                 />
             ) : null;
 
         return (
             <div className="QueryRunButton flex-row ml16">
-                {rowLimitDOM}
                 <QueryEngineSelector
                     disabled={disabled}
                     queryEngineById={queryEngineById}
@@ -117,6 +119,7 @@ export const QueryRunButton = React.forwardRef<
                     engineId={engineId}
                     onEngineIdSelect={onEngineIdSelect}
                 />
+                {rowLimitDOM}
                 {runButtonDOM}
             </div>
         );
@@ -182,5 +185,54 @@ export const QueryEngineSelector: React.FC<IQueryEngineSelectorProps> = ({
         <Tag className="mr16">{queryEngineById[engineId].name}</Tag>
     ) : (
         <div className="QueryEngineSelector">{engineButtonDOM}</div>
+    );
+};
+
+const QueryLimitSelector: React.FC<{
+    rowLimit: number;
+    setRowLimit: (rowLimit: number) => void;
+    tooltipPos: TooltipDirection;
+}> = ({ rowLimit, setRowLimit, tooltipPos }) => {
+    const rowLimitOptions = React.useMemo(
+        () =>
+            ROW_LIMIT_SCALE.map((value) => ({
+                label: formatNumber(value),
+                value,
+            })),
+        []
+    );
+
+    React.useEffect(() => {
+        if (!rowLimitOptions.some((option) => option.value === rowLimit)) {
+            setRowLimit(DEFAULT_ROW_LIMIT);
+        }
+    }, [rowLimitOptions, rowLimit, setRowLimit]);
+
+    const rowLimitMenuItems = rowLimitOptions.map((option) => ({
+        name: <span>{option.label}</span>,
+        onClick: () => setRowLimit(option.value),
+        checked: option.value === rowLimit,
+    }));
+
+    return (
+        <div>
+            <Dropdown
+                customButtonRenderer={() => (
+                    <div
+                        className="flex-center ph4"
+                        aria-label="Only applies to select statements without limit"
+                        data-balloon-pos={tooltipPos}
+                    >
+                        <span className="mr4">
+                            Limit: {formatNumber(rowLimit)}
+                        </span>
+                        <Icon name="ChevronDown" size={24} color="light" />
+                    </div>
+                )}
+                layout={['bottom', 'right']}
+            >
+                <ListMenu items={rowLimitMenuItems} type="select" />
+            </Dropdown>
+        </div>
     );
 };

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
@@ -188,25 +188,21 @@ export const QueryEngineSelector: React.FC<IQueryEngineSelectorProps> = ({
     );
 };
 
+const rowLimitOptions = ROW_LIMIT_SCALE.map((value) => ({
+    label: formatNumber(value),
+    value,
+}));
+
 const QueryLimitSelector: React.FC<{
     rowLimit: number;
     setRowLimit: (rowLimit: number) => void;
     tooltipPos: TooltipDirection;
 }> = ({ rowLimit, setRowLimit, tooltipPos }) => {
-    const rowLimitOptions = React.useMemo(
-        () =>
-            ROW_LIMIT_SCALE.map((value) => ({
-                label: formatNumber(value),
-                value,
-            })),
-        []
-    );
-
     React.useEffect(() => {
         if (!rowLimitOptions.some((option) => option.value === rowLimit)) {
             setRowLimit(DEFAULT_ROW_LIMIT);
         }
-    }, [rowLimitOptions, rowLimit, setRowLimit]);
+    }, [rowLimit, setRowLimit]);
 
     const rowLimitMenuItems = rowLimitOptions.map((option) => ({
         name: <span>{option.label}</span>,
@@ -215,24 +211,20 @@ const QueryLimitSelector: React.FC<{
     }));
 
     return (
-        <div>
-            <Dropdown
-                customButtonRenderer={() => (
-                    <div
-                        className="flex-center ph4"
-                        aria-label="Only applies to select statements without limit"
-                        data-balloon-pos={tooltipPos}
-                    >
-                        <span className="mr4">
-                            Limit: {formatNumber(rowLimit)}
-                        </span>
-                        <Icon name="ChevronDown" size={24} color="light" />
-                    </div>
-                )}
-                layout={['bottom', 'right']}
-            >
-                <ListMenu items={rowLimitMenuItems} type="select" />
-            </Dropdown>
-        </div>
+        <Dropdown
+            customButtonRenderer={() => (
+                <div
+                    className="flex-center ph4"
+                    aria-label="Only applies to select statements without limit"
+                    data-balloon-pos={tooltipPos}
+                >
+                    <span className="mr4">Limit: {formatNumber(rowLimit)}</span>
+                    <Icon name="ChevronDown" size={24} color="light" />
+                </div>
+            )}
+            layout={['bottom', 'right']}
+        >
+            <ListMenu items={rowLimitMenuItems} type="select" />
+        </Dropdown>
     );
 };

--- a/querybook/webapp/const/adhocQuery.ts
+++ b/querybook/webapp/const/adhocQuery.ts
@@ -3,5 +3,5 @@ export interface IAdhocQuery {
     templatedVariables?: Record<string, any>;
     engineId?: number;
     executionId?: number;
-    rowLimit?: boolean;
+    rowLimit?: number;
 }

--- a/querybook/webapp/const/datadoc.ts
+++ b/querybook/webapp/const/datadoc.ts
@@ -22,6 +22,7 @@ export interface IDataQueryCellMeta extends IDataCellMetaBase {
     title?: string;
     engine?: number;
     query_collapsed?: boolean;
+    limit?: number;
 }
 
 export interface IDataQueryCell extends IDataCellBase {

--- a/querybook/webapp/lib/sql-helper/sql-lexer.ts
+++ b/querybook/webapp/lib/sql-helper/sql-lexer.ts
@@ -1,4 +1,7 @@
 import { getLanguageSetting } from './sql-setting';
+import { range } from 'lodash';
+
+import { Nullable } from 'lib/typescript';
 
 const keepTokenType = new Set([
     'KEYWORD',
@@ -454,7 +457,7 @@ export function tokenize(
 
 export function simpleParse(tokens: IToken[]) {
     const statements: IToken[][] = [];
-    let bracketStack = [];
+    let bracketStack: IToken[] = [];
 
     let statement: IToken[] = [];
     tokens.forEach((token) => {
@@ -905,5 +908,35 @@ export const getQueryKeywords = (query: string) => {
     return Array.from(new Set(statements.map(getStatementType)));
 };
 
-export const containsKeyword = (statement: IToken[], keyword: string) =>
-    statement.some((token) => isKeywordToken(token) && token.text === keyword);
+/**
+ * This is similar to regex match, but instead of matching strings, we
+ * are matching tokens.
+ * It is implemented using naive double for loop comparison
+ *
+ * @param tokens an array of parsed tokens
+ * @param pattern an array of partial tokens, if any field is present, it must be matched with some token in the tokens array
+ * @returns subarray of tokens that are matched, if no match, then null is returned
+ */
+export const tokenPatternMatch = (
+    tokens: IToken[],
+    pattern: Array<Partial<IToken>>
+): Nullable<IToken[]> => {
+    const tokenMatch = (left: IToken, right: Partial<IToken>) =>
+        Object.entries(right).every(([key, value]) => left[key] === value);
+
+    for (
+        let startIdx = 0;
+        startIdx < tokens.length - pattern.length + 1;
+        startIdx++
+    ) {
+        const match = range(0, pattern.length).every((idx) => {
+            const token = tokens[startIdx + idx];
+            const patternToken = pattern[idx];
+            return tokenMatch(token, patternToken);
+        });
+        if (match) {
+            return tokens.slice(startIdx, startIdx + pattern.length);
+        }
+    }
+    return null;
+};

--- a/querybook/webapp/lib/sql-helper/sql-lexer.ts
+++ b/querybook/webapp/lib/sql-helper/sql-lexer.ts
@@ -909,7 +909,7 @@ export const getQueryKeywords = (query: string) => {
 };
 
 /**
- * This is similar to regex match, but instead of matching strings, we
+ * This is similar to substring match, but instead of matching strings, we
  * are matching tokens.
  * It is implemented using naive double for loop comparison
  *

--- a/querybook/webapp/lib/sql-helper/sql-limiter.ts
+++ b/querybook/webapp/lib/sql-helper/sql-limiter.ts
@@ -1,25 +1,86 @@
 import {
-    containsKeyword,
     getStatementRanges,
     getStatementType,
     IToken,
     simpleParse,
     tokenize,
+    tokenPatternMatch,
 } from './sql-lexer';
+import { range } from 'lodash';
+
+import { Nullable } from 'lib/typescript';
+
+/**
+ *
+/**
+ * Checks if a select statement has a limit and returns the limit
+ * If the statement is not select then null is returned
+ * If the statement has no limit then -1 is returned
+ *
+ * @param statement the query string
+ * @param language language of the query
+ * @returns the limit of query
+ */
+export function getSelectStatementLimit(
+    statement: string,
+    language?: string
+): Nullable<number> {
+    const tokens = tokenize(statement, { language });
+    const parsedStatement = simpleParse(tokens)[0];
+
+    // Strip nested statements out of the query
+    const outerStatement: IToken[] = [];
+
+    for (let tokenIdx = 0; tokenIdx < parsedStatement.length; tokenIdx++) {
+        const token = parsedStatement[tokenIdx];
+        if (token.bracketIndex != null) {
+            tokenIdx = token.bracketIndex;
+        } else if (token.type !== 'COMMENT') {
+            outerStatement.push(token);
+        }
+    }
+
+    // Only check SELECT / UNION statements
+    // Ensure it has either a LIMIT or a FETCH clause
+    if (!['select', 'union'].includes(getStatementType(outerStatement))) {
+        return null;
+    }
+
+    const matchLimitPattern = tokenPatternMatch(outerStatement, [
+        { type: 'KEYWORD', text: 'limit' },
+        { type: 'NUMBER' },
+    ]);
+
+    if (matchLimitPattern) {
+        return Number(matchLimitPattern[1].text);
+    }
+
+    const matchFetchFirstPattern = tokenPatternMatch(outerStatement, [
+        { type: 'KEYWORD', text: 'fetch' },
+        { type: 'KEYWORD' }, // could be first or next
+        { type: 'NUMBER' },
+        { type: 'KEYWORD', text: 'rows' },
+    ]);
+    if (matchFetchFirstPattern) {
+        return Number(matchFetchFirstPattern[2].text);
+    }
+
+    return -1;
+}
 
 /**
  * Automatically apply a limit to a query that does not already have a limit.
  *
  * @param {string} query - Query to be executed.
- * @param {rowLimit} query - Number of rows to limit the query to.
- * @param {language} query - Language of the query.
+ * @param {number} rowLimit - Number of rows to limit the query to.
+ * @param {string} language - Language of the query.
  * @return {string} - Query with limit applied (if necessary).
  */
-export const getLimitedQuery = (
+export function getLimitedQuery(
     query: string,
     rowLimit?: number,
     language?: string
-): string => {
+): string {
     if (rowLimit == null) {
         return query;
     }
@@ -32,42 +93,23 @@ export const getLimitedQuery = (
     let addedLimit = false;
     const updatedQuery = statements
         .map((statement) => {
-            const tokens = tokenize(statement, { language });
-            const parsedStatement = simpleParse(tokens)[0];
-
-            // Strip nested statements out of the query
-            const outerStatement: IToken[] = [];
-            let nesting = 0;
-            for (const token of parsedStatement) {
-                if (token.type === 'BRACKET') {
-                    if (token.text === '(' || token.text === '[') {
-                        nesting++;
-                    } else if (token.text === ')' || token.text === ']') {
-                        nesting--;
-                    }
-                } else if (nesting === 0) {
-                    outerStatement.push(token);
-                }
+            const existingLimit = getSelectStatementLimit(statement, language);
+            if (existingLimit == null || existingLimit >= 0) {
+                return statement + ';';
             }
 
-            // Only check SELECT / UNION statements
-            // Ensure it has either a LIMIT or a FETCH clause
-            if (
-                ['select', 'union'].includes(
-                    getStatementType(outerStatement)
-                ) &&
-                !containsKeyword(outerStatement, 'limit') &&
-                !containsKeyword(outerStatement, 'fetch')
-            ) {
-                addedLimit = true;
-                return `${statement} limit ${rowLimit};`;
-            }
-
-            return statement + ';';
+            addedLimit = true;
+            return `${statement} limit ${rowLimit};`;
         })
         .join('\n');
 
     // If no limit was added, return the original query
     // to avoid changing whitespace, etc.
     return addedLimit ? updatedQuery : query;
-};
+}
+
+// 10^1 to 10^6
+export const ROW_LIMIT_SCALE =
+    window.ROW_LIMIT_SCALE ?? range(1, 6).map((v) => Math.pow(10, v));
+// 10^3
+export const DEFAULT_ROW_LIMIT = window.DEFAULT_ROW_LIMIT ?? ROW_LIMIT_SCALE[2];

--- a/querybook/webapp/lib/sql-helper/sql-limiter.ts
+++ b/querybook/webapp/lib/sql-helper/sql-limiter.ts
@@ -6,7 +6,6 @@ import {
     tokenize,
     tokenPatternMatch,
 } from './sql-lexer';
-import { range } from 'lodash';
 
 import { Nullable } from 'lib/typescript';
 
@@ -108,8 +107,12 @@ export function getLimitedQuery(
     return addedLimit ? updatedQuery : query;
 }
 
-// 10^1 to 10^6
+// 10^1 to 10^5
 export const ROW_LIMIT_SCALE =
-    window.ROW_LIMIT_SCALE ?? range(1, 6).map((v) => Math.pow(10, v));
+    window.ROW_LIMIT_SCALE ?? [1, 2, 3, 4, 5].map((v) => Math.pow(10, v));
 // 10^3
 export const DEFAULT_ROW_LIMIT = window.DEFAULT_ROW_LIMIT ?? ROW_LIMIT_SCALE[2];
+
+if (!ROW_LIMIT_SCALE.includes(DEFAULT_ROW_LIMIT)) {
+    throw new Error('DEFAULT_ROW_LIMIT must be in ROW_LIMIT_SCALE');
+}

--- a/querybook/webapp/types.d.ts
+++ b/querybook/webapp/types.d.ts
@@ -36,6 +36,16 @@ declare global {
             Record<string, { key?: string; name?: string }>
         >;
         CUSTOM_ENGINE_UDFS?: IUDFEngineConfig[];
+
+        /**
+         * Possible values for automatic query limits.
+         * Defaults from 10^1 to 10^6
+         */
+        ROW_LIMIT_SCALE?: number[];
+        /**
+         * Must be a value in ROW_LIMIT_SCALE
+         */
+        DEFAULT_ROW_LIMIT?: number;
     }
 
     // Injected via Webpack

--- a/querybook/webapp/types.d.ts
+++ b/querybook/webapp/types.d.ts
@@ -39,7 +39,7 @@ declare global {
 
         /**
          * Possible values for automatic query limits.
-         * Defaults from 10^1 to 10^6
+         * Defaults from 10^1 to 10^5
          */
         ROW_LIMIT_SCALE?: number[];
         /**


### PR DESCRIPTION
- The feature flag is now a boolean instead of int
- You can set limit for query cells too (refactored code, so the composer and cell use the same function to transform query)
- The query limit is now a dynamic scaling system with max 10^6 and default 10^3. This value can also be configured with plugins. Also updated the plugin documentation
![image](https://user-images.githubusercontent.com/8283407/189251177-574a9ea9-823d-4894-a5c3-ae5a1db18f9b.png)

- Refactored code for detecting limit in queries
- For queries that are limited, add a warning to let the users know 
![image](https://user-images.githubusercontent.com/8283407/189251195-1ce396f3-9cbe-4bfe-b1a2-d09c640648bb.png)
