### PR TITLE
Feat: add schema filtering for table search

### DIFF
--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -667,9 +667,13 @@ def delete_table_warning(warning_id):
 
 
 @register("/schemas/", methods=["GET"])
-def get_schemas(metastore_id, limit=5, offset=0, sort_key="name", sort_order="desc"):
+def get_schemas(
+    metastore_id, limit=5, offset=0, sort_key="name", sort_order="desc", name=None
+):
     verify_metastore_permission(metastore_id)
-    schemas = logic.get_all_schemas(metastore_id, offset, limit, sort_key, sort_order)
+    schemas = logic.get_all_schemas(
+        metastore_id, offset, limit, sort_key, sort_order, name
+    )
 
     return {"results": schemas, "done": len(schemas) < limit}
 

--- a/querybook/server/logic/metastore.py
+++ b/querybook/server/logic/metastore.py
@@ -23,7 +23,13 @@ from tasks.sync_elasticsearch import sync_elasticsearch
 
 @with_session
 def get_all_schemas(
-    metastore_id, offset=0, limit=5, sort_key="name", sort_order="desc", session=None
+    metastore_id,
+    offset=0,
+    limit=5,
+    sort_key="name",
+    sort_order="desc",
+    name=None,
+    session=None,
 ):
     """Get all the schemas."""
     query = session.query(DataSchema)
@@ -32,6 +38,9 @@ def get_all_schemas(
 
     if sort_order == "desc":
         col = col.desc()
+
+    if name:
+        query = query.filter(DataSchema.name.like("%" + name + "%"))
 
     result = (
         query.order_by(col)

--- a/querybook/webapp/components/Search/SearchOverview.tsx
+++ b/querybook/webapp/components/Search/SearchOverview.tsx
@@ -56,6 +56,7 @@ import {
     QueryItem,
 } from './SearchResultItem';
 import { TableSelect } from './TableSelect';
+import { SearchSchemaSelect } from './SearchSchemaSelect';
 
 import './SearchOverview.scss';
 
@@ -632,6 +633,13 @@ export const SearchOverview: React.FC<ISearchOverviewProps> = ({
                             )}
                         />
                     </div>
+                </div>
+                <div className="search-filter">
+                    <span className="filter-title">Schemas</span>
+                    <SearchSchemaSelect
+                        updateSearchFilter={updateSearchFilter}
+                        schema={searchFilters?.schema}
+                    />
                 </div>
                 <div className="search-filter">
                     <span className="filter-title">Created At</span>

--- a/querybook/webapp/components/Search/SearchSchemaSelect.tsx
+++ b/querybook/webapp/components/Search/SearchSchemaSelect.tsx
@@ -1,0 +1,69 @@
+import React, { useMemo, useCallback } from 'react';
+import AsyncSelect from 'react-select/async';
+import { useSelector } from 'react-redux';
+import { IStoreState } from 'redux/store/types';
+import {
+    makeReactSelectStyle,
+    asyncReactSelectStyles,
+    IOptions,
+} from 'lib/utils/react-select';
+import { SearchSchemaResource } from 'resource/search';
+
+interface ISearchSchemaSelectProps {
+    schema?: string[];
+    updateSearchFilter: (key: string, value: string[]) => void;
+}
+
+const tableReactSelectStyle = makeReactSelectStyle(
+    true,
+    asyncReactSelectStyles
+);
+
+export const SearchSchemaSelect: React.FC<ISearchSchemaSelectProps> = ({
+    updateSearchFilter,
+    schema,
+}) => {
+    const currentMetastoreId = useSelector(
+        (state: IStoreState) => state.environment.currentEnvironmentId
+    );
+
+    const handleUpdateSearchFilter = useCallback((option: IOptions<string>) => {
+        updateSearchFilter(
+            'schema',
+            option.map((o) => o.value)
+        );
+    }, []);
+
+    const loadOptions = useCallback(async (value) => {
+        const searchRequest = await SearchSchemaResource.getMore({
+            metastore_id: currentMetastoreId,
+            name: value,
+        });
+
+        return searchRequest.data.results.map((schema) => ({
+            label: schema.name,
+            value: schema.name,
+        }));
+    }, []);
+
+    const selectedSchemaItems = useMemo(
+        () =>
+            (schema || []).map((s) => ({
+                value: s,
+                label: s,
+            })),
+        [schema]
+    );
+    return (
+        <AsyncSelect
+            styles={tableReactSelectStyle}
+            placeholder={'search schema name'}
+            value={selectedSchemaItems}
+            onChange={handleUpdateSearchFilter}
+            loadOptions={loadOptions}
+            defaultOptions={[]}
+            noOptionsMessage={() => 'No schema found.'}
+            isMulti
+        />
+    );
+};

--- a/querybook/webapp/resource/search.ts
+++ b/querybook/webapp/resource/search.ts
@@ -34,17 +34,24 @@ export const SearchTableResource = {
 };
 
 export const SearchSchemaResource = {
-    getMore: (params: {
+    getMore: ({
+        offset = 0,
+        limit = 30,
+        sort_key = 'name',
+        sort_order = 'asc',
+        ...params
+    }: {
         metastore_id: number;
-        offset: number;
-        limit: number;
-        sort_key: 'name' | 'table_count';
-        sort_order: 'desc' | 'asc';
+        offset?: number;
+        limit?: number;
+        sort_key?: 'name' | 'table_count';
+        sort_order?: 'desc' | 'asc';
+        name?: string;
     }) =>
         ds.fetch<{
             results: IDataSchema[];
             done: boolean;
-        }>('/schemas/', params),
+        }>('/schemas/', { offset, limit, sort_key, sort_order, ...params }),
 };
 
 export const SearchQueryResource = {


### PR DESCRIPTION
This feature allows DataDocs to be filtered by a schema. 
A user can select schema using multi select.
A user can select more than one schema.
A user can remove any selected schema.

![schemaFiltering](https://user-images.githubusercontent.com/59963571/189539712-c7292103-df2a-46d3-9e84-363392976e75.png)
