### PR TITLE
feat: Add a new function to sync table with metastore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.10.3",
+    "version": "3.10.4",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -671,25 +671,18 @@ def get_schemas(metastore_id, limit=5, offset=0, sort_key="name", sort_order="de
     "/table/<schema_name>/<table_name>/sync/",
     methods=["PUT"],
 )
-def sync_table_from_metastore(
-    schema_name, table_name, metastore_id, is_delete: bool = False
-):
-    """Sync table info from metastore. Delete the table if is_delete is True.
+def sync_table_from_metastore(schema_name, table_name, metastore_id):
+    """Sync table info with metastore.
 
     Args:
-        metastore_id (int): metastore ID
+        metastore_id (int): Metastore ID
         schema_name (str): Schema name
         table_name (str): Table name
 
     Returns:
-        None if deleting a table
+        None if the table doesn't exist neither metastore nor querybook
+        -1 if table is deleted
         table id if creating or updating a table
     """
     metastore_loader = get_metastore_loader(metastore_id)
-
-    if is_delete:
-        metastore_loader.sync_delete_table(schema_name, table_name)
-        return None
-    else:
-        table_id = metastore_loader.sync_create_or_update_table(schema_name, table_name)
-        return table_id
+    return metastore_loader.sync_table(schema_name, table_name)

--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -214,9 +214,7 @@ def refresh_table_from_metastore(table_id):
 
         metastore_id = schema.metastore_id
         metastore_loader = get_metastore_loader(metastore_id, session=session)
-        metastore_loader.sync_create_or_update_table(
-            schema.name, table.name, session=session
-        )
+        metastore_loader.sync_table(schema.name, table.name, session=session)
 
         session.refresh(table)
         return table

--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -150,10 +150,11 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
     def sync_create_or_update_table(
         self, schema_name: str, table_name: str, session=None
     ) -> int:
-        """Given a full qualified table name,
-           sync the data in metastore with database.
-           Note: if table does not exist, this doesn't create a new table. But
-           it does create an empty schema.
+        """DEPRECATED!!! PLEASE USE `sync_table` INSTEAD.
+        Given a full qualified table name,
+        sync the data in metastore with database.
+        Note: if table does not exist, this doesn't create a new table. But
+        it does create an empty schema.
 
         Arguments:
             schema_name {str} -- the schema name
@@ -192,8 +193,9 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
 
     @with_session
     def sync_delete_table(self, schema_name, table_name, session=None):
-        """Given a full qualified table name,
-           Remove the table if it exists
+        """DEPRECATED!!! PLEASE USE `sync_table` INSTEAD.
+        Given a full qualified table name,
+        Remove the table if it exists
 
         Arguments:
             schema_name {str} -- the schema name

--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -302,6 +302,11 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
     def _create_table_table(
         self, schema_id, schema_name, table_name, table=None, columns=None, session=None
     ):
+        """Create or update a table.
+        If detailed table info is given (parameter table and columns), it will just use
+        them to create/update the table.  Otherwise, it will try to get the table
+        infofrom the metastore first and then create/update.
+        """
         if not table:
             try:
                 table, columns = self.get_table_and_columns(schema_name, table_name)

--- a/querybook/server/lib/table_upload/exporter/base_exporter.py
+++ b/querybook/server/lib/table_upload/exporter/base_exporter.py
@@ -45,9 +45,7 @@ class BaseTableUploadExporter(ABC):
         loader = self._get_metastore_loader(session=session)
         if loader:
             schema_name, table_name = self._fq_table_name
-            return loader.sync_create_or_update_table(
-                schema_name, table_name, session=session
-            )
+            return loader.sync_table(schema_name, table_name, session=session)
         return None
 
     @with_session

--- a/querybook/server/tasks/log_query_per_table.py
+++ b/querybook/server/tasks/log_query_per_table.py
@@ -95,16 +95,19 @@ def sync_table_to_metastore(
             for table in tables:
                 tables_to_sync.add(table)
         elif statement_type is not None:
+            # Otherwise for things like insert/select we only update
+            # if it doesn't exist in the Querybook database
             for table in tables:
-                schema_name, table_name = table.split(".")
-                query_table = m_logic.get_table_by_name(
-                    schema_name,
-                    table_name,
-                    metastore_id=metastore_id,
-                    session=session,
-                )
-                if not query_table:
-                    tables_to_sync.add(table)
+                if table not in tables_to_sync:
+                    schema_name, table_name = table.split(".")
+                    query_table = m_logic.get_table_by_name(
+                        schema_name,
+                        table_name,
+                        metastore_id=metastore_id,
+                        session=session,
+                    )
+                    if not query_table:
+                        tables_to_sync.add(table)
 
     for table in tables_to_sync:
         schema_name, table_name = table.split(".")


### PR DESCRIPTION
For syncing a table with metastore, the caller may not know if it's an updating or deleting, it should be the sync function's responsibility to keep it sync with metastore, whether it's creating, updating or deleting.

Also the `get_all_table_names_in_schema` method used for checking table existence is actually not very efficient for those schema with a huge amount of tables, it could cost 1 to 2 seconds. So this new function will use `get_table_and_columns` to check, and its response will also be used for creating/updating the table as it will be needed anyway if it's not deleting.