### PR TITLE
feat: allow user to bypass LIMIT

### DIFF
--- a/docs_website/docs/integrations/customize_html.md
+++ b/docs_website/docs/integrations/customize_html.md
@@ -188,4 +188,6 @@ window variables:
 window.ROW_LIMIT_SCALE = [8, 64, 512, 4096, 32768];
 // the default limit is now 4096
 window.DEFAULT_ROW_LIMIT = 4096;
+// this removes the option for user to pick limit: none
+window.ALLOW_UNLIMITED_QUERY = false;
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.10.4",
+    "version": "3.10.5",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/components/ConfirmationManager/ConfirmationManager.tsx
+++ b/querybook/webapp/components/ConfirmationManager/ConfirmationManager.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import * as querybookUIActions from 'redux/querybookUI/action';
@@ -12,12 +12,10 @@ export const ConfirmationManager: React.FunctionComponent = () => {
     );
     const dispatch: Dispatch = useDispatch();
 
-    const wrapOnConfirmationEnd = (callback?: () => any) => () => {
+    const handleHide = useCallback(() => {
         dispatch(querybookUIActions.removeConfirmation());
-        if (callback != null) {
-            callback();
-        }
-    };
+        confirmation?.onHide?.();
+    }, [confirmation, dispatch]);
 
     if (confirmation == null) {
         return null;
@@ -25,9 +23,9 @@ export const ConfirmationManager: React.FunctionComponent = () => {
 
     const mergedProps = {
         ...confirmation,
-        onConfirm: wrapOnConfirmationEnd(confirmation.onConfirm),
-        onDismiss: wrapOnConfirmationEnd(confirmation.onDismiss),
-        onHide: wrapOnConfirmationEnd(confirmation.onHide),
+        onConfirm: confirmation.onConfirm,
+        onDismiss: confirmation.onDismiss,
+        onHide: handleHide,
     };
 
     return <ConfirmationMessage {...mergedProps} />;

--- a/querybook/webapp/components/ConfirmationManager/ConfirmationMessage.tsx
+++ b/querybook/webapp/components/ConfirmationManager/ConfirmationMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { useEvent } from 'hooks/useEvent';
 import { KeyMap, matchKeyMap } from 'lib/utils/keyboard';
@@ -68,6 +68,14 @@ export const ConfirmationMessage: React.FunctionComponent<
         },
         [onConfirm, onDismiss, onHide]
     );
+    const handleConfirm = useMemo(
+        () => onCloseButtonClick(true),
+        [onCloseButtonClick]
+    );
+    const handleReject = useMemo(
+        () => onCloseButtonClick(false),
+        [onCloseButtonClick]
+    );
 
     const onEnterPress = useCallback(
         (evt: KeyboardEvent) => {
@@ -83,14 +91,14 @@ export const ConfirmationMessage: React.FunctionComponent<
     const actionButtons = [
         <Button
             key="cancel"
-            onClick={onCloseButtonClick(false)}
+            onClick={handleReject}
             icon={cancelIcon}
             title={cancelText}
             color={cancelColor}
         />,
         <Button
             key="confirm"
-            onClick={onCloseButtonClick(true)}
+            onClick={handleConfirm}
             icon={confirmIcon}
             title={confirmText}
             color={confirmColor}
@@ -102,7 +110,7 @@ export const ConfirmationMessage: React.FunctionComponent<
     }
 
     return (
-        <Modal onHide={onHide} className="message-size" title={header}>
+        <Modal onHide={handleReject} className="message-size" title={header}>
             <div className="ConfirmationMessage" ref={selfRef} tabIndex={0}>
                 <div className="confirmation-message">{message}</div>
                 <div className="confirmation-buttons flex-right mt36">

--- a/querybook/webapp/components/QueryComposer/RunQuery.tsx
+++ b/querybook/webapp/components/QueryComposer/RunQuery.tsx
@@ -106,13 +106,14 @@ async function transformLimitedQuery(
             message: (
                 <Content>
                     <div>
-                        The following SELECT statement have no limit. Please
-                        make sure you intend to get all the rows returned.
+                        The following SELECT statement has no limit. Please make
+                        sure you intend to get all the rows returned.
                     </div>
                     <div>
                         <i>
                             Tip: to avoid seeing this message, add a LIMIT in
-                            the query or set it on left of the run button.
+                            the query or set a limit value on the left of the
+                            run button.
                         </i>
                     </div>
                     <pre>

--- a/querybook/webapp/components/QueryComposer/RunQuery.tsx
+++ b/querybook/webapp/components/QueryComposer/RunQuery.tsx
@@ -4,11 +4,15 @@ import toast from 'react-hot-toast';
 import { IQueryEngine } from 'const/queryEngine';
 import { sendConfirm } from 'lib/querybookUI';
 import { getDroppedTables } from 'lib/sql-helper/sql-checker';
-import { getLimitedQuery } from 'lib/sql-helper/sql-limiter';
+import {
+    getLimitedQuery,
+    hasQueryContainUnlimitedSelect,
+} from 'lib/sql-helper/sql-limiter';
 import { renderTemplatedQuery } from 'lib/templated-query';
 import { Nullable } from 'lib/typescript';
 import { formatError } from 'lib/utils/error';
 import { Content } from 'ui/Content/Content';
+import { ShowMoreText } from 'ui/ShowMoreText/ShowMoreText';
 
 export async function transformQuery(
     query: string,
@@ -30,7 +34,7 @@ export async function transformQuery(
         return '';
     }
 
-    const limitedQuery = transformLimitedQuery(
+    const limitedQuery = await transformLimitedQuery(
         templatizedQuery,
         rowLimit,
         engine
@@ -71,14 +75,58 @@ async function transformTemplatedQuery(
     }
 }
 
-function transformLimitedQuery(
+async function transformLimitedQuery(
     query: string,
     rowLimit: Nullable<number>,
     engine: IQueryEngine
 ) {
-    return engine.feature_params?.row_limit && rowLimit != null
-        ? getLimitedQuery(query, rowLimit, engine.language)
-        : query;
+    if (!engine.feature_params?.row_limit) {
+        return query;
+    }
+
+    if (rowLimit != null && rowLimit >= 0) {
+        return getLimitedQuery(query, rowLimit, engine.language);
+    }
+
+    // query is unlimited but engine has row limit feature turned on
+
+    const unlimitedSelectQuery = hasQueryContainUnlimitedSelect(
+        query,
+        engine.language
+    );
+
+    if (!unlimitedSelectQuery) {
+        return query;
+    }
+
+    // Show a warning modal to let user confirm what they are doing
+    return new Promise<string>((resolve, reject) => {
+        sendConfirm({
+            header: 'Your SELECT query is unbounded',
+            message: (
+                <Content>
+                    <div>
+                        The following SELECT statement have no limit. Please
+                        make sure you intend to get all the rows returned.
+                    </div>
+                    <div>
+                        <i>
+                            Tip: to avoid seeing this message, add a LIMIT in
+                            the query or set it on left of the run button.
+                        </i>
+                    </div>
+                    <pre>
+                        <code>
+                            <ShowMoreText text={unlimitedSelectQuery} />
+                        </code>
+                    </pre>
+                </Content>
+            ),
+            onConfirm: () => resolve(query),
+            onDismiss: () => reject(),
+            confirmText: 'Run without LIMIT',
+        });
+    });
 }
 
 async function confirmIfDroppingTablesThenRunQuery(
@@ -103,8 +151,8 @@ async function confirmIfDroppingTablesThenRunQuery(
                     </Content>
                 ),
                 onConfirm: () => runQuery().then(resolve, reject),
-                onDismiss: () => resolve(null),
-                confirmText: 'Continue Execution',
+                onDismiss: () => reject(),
+                confirmText: 'DROP the table',
             });
         });
     } else {

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
@@ -209,7 +209,7 @@ const QueryLimitSelector: React.FC<{
     }, [rowLimit, setRowLimit]);
 
     const selectedRowLimitText = React.useMemo(() => {
-        if (rowLimit != null && rowLimit >= 0) {
+        if (rowLimit >= 0) {
             return formatNumber(rowLimit);
         }
         return 'none';

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
@@ -5,7 +5,11 @@ import { useSelector } from 'react-redux';
 import { IQueryEngine, QueryEngineStatus } from 'const/queryEngine';
 import { queryEngineStatusToIconStatus } from 'const/queryStatusIcon';
 import { TooltipDirection } from 'const/tooltip';
-import { DEFAULT_ROW_LIMIT, ROW_LIMIT_SCALE } from 'lib/sql-helper/sql-limiter';
+import {
+    ALLOW_UNLIMITED_QUERY,
+    DEFAULT_ROW_LIMIT,
+    ROW_LIMIT_SCALE,
+} from 'lib/sql-helper/sql-limiter';
 import { getShortcutSymbols, KeyMap } from 'lib/utils/keyboard';
 import { formatNumber } from 'lib/utils/number';
 import { queryEngineStatusByIdEnvSelector } from 'redux/queryEngine/selector';
@@ -191,7 +195,7 @@ export const QueryEngineSelector: React.FC<IQueryEngineSelectorProps> = ({
 const rowLimitOptions = ROW_LIMIT_SCALE.map((value) => ({
     label: formatNumber(value),
     value,
-}));
+})).concat(ALLOW_UNLIMITED_QUERY ? [{ label: 'none', value: -1 }] : []);
 
 const QueryLimitSelector: React.FC<{
     rowLimit: number;
@@ -203,6 +207,13 @@ const QueryLimitSelector: React.FC<{
             setRowLimit(DEFAULT_ROW_LIMIT);
         }
     }, [rowLimit, setRowLimit]);
+
+    const selectedRowLimitText = React.useMemo(() => {
+        if (rowLimit != null && rowLimit >= 0) {
+            return formatNumber(rowLimit);
+        }
+        return 'none';
+    }, [rowLimit]);
 
     const rowLimitMenuItems = rowLimitOptions.map((option) => ({
         name: <span>{option.label}</span>,
@@ -218,7 +229,7 @@ const QueryLimitSelector: React.FC<{
                     aria-label="Only applies to SELECT query without LIMIT"
                     data-balloon-pos={tooltipPos}
                 >
-                    <span className="mr4">Limit: {formatNumber(rowLimit)}</span>
+                    <span className="mr4">Limit: {selectedRowLimitText}</span>
                     <Icon name="ChevronDown" size={24} color="light" />
                 </div>
             )}

--- a/querybook/webapp/lib/sql-helper/sql-lexer.ts
+++ b/querybook/webapp/lib/sql-helper/sql-lexer.ts
@@ -574,7 +574,7 @@ export function getStatementRanges(
 }
 
 /**
- * Split a query into multiple statements. Return the non-emptry ones
+ * Split a query into multiple statements. Return the non-empty ones
  *
  * @param query
  * @returns array of statements

--- a/querybook/webapp/lib/sql-helper/sql-lexer.ts
+++ b/querybook/webapp/lib/sql-helper/sql-lexer.ts
@@ -573,6 +573,24 @@ export function getStatementRanges(
     return statementRanges;
 }
 
+/**
+ * Split a query into multiple statements. Return the non-emptry ones
+ *
+ * @param query
+ * @returns array of statements
+ */
+export function getStatementsFromQuery(
+    query: string,
+    language?: string
+): string[] {
+    const statementRanges = getStatementRanges(query, null, language);
+    const statements = statementRanges
+        .map((range) => query.slice(range[0], range[1]))
+        .filter((statement) => statement.length > 0);
+
+    return statements;
+}
+
 export function getSelectedQuery(query: string, selectedRange: IRange = null) {
     const statementRanges = selectedRange
         ? getStatementRanges(query, selectedRange)

--- a/querybook/webapp/lib/sql-helper/sql-limiter.ts
+++ b/querybook/webapp/lib/sql-helper/sql-limiter.ts
@@ -68,8 +68,8 @@ export function getSelectStatementLimit(
 }
 
 /**
- * Check if the query have any statements that is SELECT and does not have LIMT
- * If so, return the statement that is unbounded, else, return null
+ * Check if the query has any statements that is SELECT and does not have LIMIT
+ * If so, return the unlimited select statement, else, return null
  *
  * @param query
  * @param language
@@ -127,7 +127,7 @@ export const ROW_LIMIT_SCALE =
     window.ROW_LIMIT_SCALE ?? [1, 2, 3, 4, 5].map((v) => Math.pow(10, v));
 // 10^3
 export const DEFAULT_ROW_LIMIT = window.DEFAULT_ROW_LIMIT ?? ROW_LIMIT_SCALE[2];
-export const ALLOW_UNLIMITED_QUERY = true;
+export const ALLOW_UNLIMITED_QUERY = window.ALLOW_UNLIMITED_QUERY ?? true;
 
 if (!ROW_LIMIT_SCALE.includes(DEFAULT_ROW_LIMIT)) {
     throw new Error('DEFAULT_ROW_LIMIT must be in ROW_LIMIT_SCALE');

--- a/querybook/webapp/lib/sql-helper/sql-limiter.ts
+++ b/querybook/webapp/lib/sql-helper/sql-limiter.ts
@@ -1,5 +1,5 @@
 import {
-    getStatementRanges,
+    getStatementsFromQuery,
     getStatementType,
     IToken,
     simpleParse,
@@ -68,6 +68,24 @@ export function getSelectStatementLimit(
 }
 
 /**
+ * Check if the query have any statements that is SELECT and does not have LIMT
+ * If so, return the statement that is unbounded, else, return null
+ *
+ * @param query
+ * @param language
+ */
+export function hasQueryContainUnlimitedSelect(
+    query: string,
+    language?: string
+): string {
+    const statements = getStatementsFromQuery(query, language);
+
+    return statements.find(
+        (statement) => getSelectStatementLimit(statement, language) === -1
+    );
+}
+
+/**
  * Automatically apply a limit to a query that does not already have a limit.
  *
  * @param {string} query - Query to be executed.
@@ -84,10 +102,7 @@ export function getLimitedQuery(
         return query;
     }
 
-    const statementRanges = getStatementRanges(query, null, language);
-    const statements = statementRanges
-        .map((range) => query.slice(range[0], range[1]))
-        .filter((statement) => statement.length > 0);
+    const statements = getStatementsFromQuery(query, language);
 
     let addedLimit = false;
     const updatedQuery = statements
@@ -112,6 +127,7 @@ export const ROW_LIMIT_SCALE =
     window.ROW_LIMIT_SCALE ?? [1, 2, 3, 4, 5].map((v) => Math.pow(10, v));
 // 10^3
 export const DEFAULT_ROW_LIMIT = window.DEFAULT_ROW_LIMIT ?? ROW_LIMIT_SCALE[2];
+export const ALLOW_UNLIMITED_QUERY = true;
 
 if (!ROW_LIMIT_SCALE.includes(DEFAULT_ROW_LIMIT)) {
     throw new Error('DEFAULT_ROW_LIMIT must be in ROW_LIMIT_SCALE');

--- a/querybook/webapp/types.d.ts
+++ b/querybook/webapp/types.d.ts
@@ -46,6 +46,12 @@ declare global {
          * Must be a value in ROW_LIMIT_SCALE
          */
         DEFAULT_ROW_LIMIT?: number;
+        /**
+         * If true, allow user to choose an option for unlimited query
+         * However, users will be shown a warning modal when they run an unlimited
+         * query
+         */
+        ALLOW_UNLIMITED_QUERY?: boolean;
     }
 
     // Injected via Webpack


### PR DESCRIPTION
Added a new flag ALLOW_UNLIMITED_QUERY which is turned on by default. This means there is an new option "none" to skip the limit query postprocessing

![image](https://user-images.githubusercontent.com/8283407/189783702-5cec2c51-bb51-409a-8659-bbdab590a8cf.png)

If user did pick none and ran a query without limit, they are shown this warning modal every time:
![image](https://user-images.githubusercontent.com/8283407/189783770-f2b54a46-fb3e-4928-8830-c0313d814067.png)


