### PR TITLE
feat: show 404 page when table gets deleted

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.10.5",
+    "version": "3.10.6",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -210,7 +210,7 @@ def create_table_ownership(table_id):
 @register("/table/<int:table_id>/refresh/", methods=["PUT"])
 def sync_table_by_table_id(table_id):
     """Refetch table info from metastore
-    It returns -1 if the table gets deleted.
+    It returns None if the table gets deleted.
     Otherwise, it will return the updated table.
     """
     with DBSession() as session:
@@ -223,7 +223,7 @@ def sync_table_by_table_id(table_id):
         metastore_loader = get_metastore_loader(metastore_id, session=session)
         table_id = metastore_loader.sync_table(schema.name, table.name, session=session)
         if table_id == -1:
-            return -1
+            return None
 
         session.refresh(table)
         return table

--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -305,7 +305,7 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
         """Create or update a table.
         If detailed table info is given (parameter table and columns), it will just use
         them to create/update the table.  Otherwise, it will try to get the table
-        infofrom the metastore first and then create/update.
+        info from the metastore first and then create/update.
         """
         if not table:
             try:

--- a/querybook/webapp/components/DataTableView/DataTableView.tsx
+++ b/querybook/webapp/components/DataTableView/DataTableView.tsx
@@ -288,8 +288,16 @@ class DataTableViewComponent extends React.PureComponent<
                 item={table}
                 itemKey={tableId}
                 itemLoader={getTable.bind(null, tableId)}
+                emptyRenderer={() => (
+                    <FourOhFour>
+                        Table doesn't exist or has been deleted from Metastore
+                    </FourOhFour>
+                )}
                 errorRenderer={(error) => (
-                    <ErrorPage errorMessage={formatError(error)} />
+                    <ErrorPage
+                        errorCode={error.response?.status}
+                        errorMessage={formatError(error)}
+                    />
                 )}
             >
                 {this.renderTableView()}

--- a/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
+++ b/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
@@ -23,6 +23,7 @@ import {
     IDataTableWarning,
     IPaginatedQuerySampleFilters,
 } from 'const/metastore';
+import { useMounted } from 'hooks/useMounted';
 import { titleize } from 'lib/utils';
 import { generateFormattedDate } from 'lib/utils/datetime';
 import { getAppName } from 'lib/utils/global';
@@ -55,6 +56,7 @@ const dataTableDetailsRows = [
 
 function useRefreshMetastore(table: IDataTable) {
     const dispatch = useDispatch();
+    const isMounted = useMounted();
     const [isRefreshing, setIsRefreshing] = useState(false);
 
     const handleRefreshTable = useCallback(() => {
@@ -62,7 +64,11 @@ function useRefreshMetastore(table: IDataTable) {
         const refreshRequest = dispatch(
             refreshDataTableInMetastore(table.id)
         ) as unknown as Promise<void>;
-        refreshRequest.finally(() => setIsRefreshing(false));
+        refreshRequest.finally(() => {
+            if (isMounted()) {
+                setIsRefreshing(false);
+            }
+        });
 
         toast.promise(refreshRequest, {
             loading: 'Refreshing table from metastore',

--- a/querybook/webapp/hooks/ui/useContextMenu.ts
+++ b/querybook/webapp/hooks/ui/useContextMenu.ts
@@ -28,7 +28,7 @@ export const useContextMenu = (ref: React.RefObject<HTMLElement>) => {
 
     useEvent('contextmenu', handleContextMenu, {
         element: ref.current,
-        disabled: !(mounted && ref.current != null),
+        disabled: !(mounted() && ref.current != null),
     });
     useEvent('mousedown', handleClickOutside, {
         element: document,

--- a/querybook/webapp/hooks/useMounted.ts
+++ b/querybook/webapp/hooks/useMounted.ts
@@ -1,12 +1,15 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 export function useMounted() {
-    const [mounted, setMounted] = useState(false);
+    const mounted = useRef(false);
+
     useEffect(() => {
-        setMounted(true);
+        mounted.current = true;
+
         return () => {
-            setMounted(false);
+            mounted.current = false;
         };
     }, []);
-    return mounted;
+
+    return useCallback(() => mounted.current, []);
 }

--- a/querybook/webapp/redux/dataSources/action.ts
+++ b/querybook/webapp/redux/dataSources/action.ts
@@ -43,6 +43,7 @@ import {
     IReceiveDataTableSamplesPollingAction,
     IReceiveParentDataLineageAction,
     IReceiveQueryExampleIdsAction,
+    IRemoveDataTableAction,
     ThunkResult,
 } from './types';
 
@@ -130,7 +131,11 @@ export function refreshDataTableInMetastore(
 ): ThunkResult<Promise<void>> {
     return async (dispatch) => {
         const { data } = await TableResource.refresh(tableId);
-        dispatch(receiveRawDataTable(data));
+        if (data == -1) {
+            dispatch(removeDataTable(tableId));
+        } else {
+            dispatch(receiveRawDataTable(data));
+        }
     };
 }
 
@@ -280,6 +285,15 @@ export function receiveDataTable(
             ),
             dataSchemasById: dataSchema,
             dataTableWarningById: dataTableWarning,
+        },
+    };
+}
+
+export function removeDataTable(tableId: number): IRemoveDataTableAction {
+    return {
+        type: '@@dataSources/REMOVE_DATA_TABLE',
+        payload: {
+            dataTableId: tableId,
         },
     };
 }

--- a/querybook/webapp/redux/dataSources/action.ts
+++ b/querybook/webapp/redux/dataSources/action.ts
@@ -131,7 +131,7 @@ export function refreshDataTableInMetastore(
 ): ThunkResult<Promise<void>> {
     return async (dispatch) => {
         const { data } = await TableResource.refresh(tableId);
-        if (data === -1) {
+        if (!data) {
             dispatch(removeDataTable(tableId));
         } else {
             dispatch(receiveRawDataTable(data));

--- a/querybook/webapp/redux/dataSources/action.ts
+++ b/querybook/webapp/redux/dataSources/action.ts
@@ -131,7 +131,7 @@ export function refreshDataTableInMetastore(
 ): ThunkResult<Promise<void>> {
     return async (dispatch) => {
         const { data } = await TableResource.refresh(tableId);
-        if (data == -1) {
+        if (data === -1) {
             dispatch(removeDataTable(tableId));
         } else {
             dispatch(receiveRawDataTable(data));

--- a/querybook/webapp/redux/dataSources/reducer.ts
+++ b/querybook/webapp/redux/dataSources/reducer.ts
@@ -118,6 +118,11 @@ function dataTablesByIdReducer(
                 }
                 return;
             }
+            case '@@dataSources/REMOVE_DATA_TABLE': {
+                const { dataTableId } = action.payload;
+                delete draft[dataTableId];
+                return;
+            }
             case '@@dataSources/RECEIVE_DATA_TABLE_WARNING': {
                 const warning = action.payload;
                 if (!draft[warning.table_id].warnings.includes(warning.id)) {

--- a/querybook/webapp/redux/dataSources/types.ts
+++ b/querybook/webapp/redux/dataSources/types.ts
@@ -42,6 +42,13 @@ export interface IReceiveDataTableAction extends Action {
     };
 }
 
+export interface IRemoveDataTableAction extends Action {
+    type: '@@dataSources/REMOVE_DATA_TABLE';
+    payload: {
+        dataTableId: number;
+    };
+}
+
 export interface IReceiveParentDataLineageAction extends Action {
     type: '@@dataSources/RECEIVE_PARENT_DATA_LINEAGE';
     payload: {
@@ -183,6 +190,7 @@ export interface IRemoveDataTableOwnership extends Action {
 export type DataSourcesAction =
     | IReceiveQueryMetastoresAction
     | IReceiveDataTableAction
+    | IRemoveDataTableAction
     | IReceiveParentDataLineageAction
     | IReceiveChildDataLineageAction
     | IReceiveDataJobMetadataAction

--- a/querybook/webapp/resource/table.ts
+++ b/querybook/webapp/resource/table.ts
@@ -158,7 +158,7 @@ export const TableResource = {
     },
 
     refresh: (tableId: number) =>
-        ds.update<IDataTable>(`/table/${tableId}/refresh/`),
+        ds.update<IDataTable | -1>(`/table/${tableId}/refresh/`),
 };
 
 export const TableColumnResource = {

--- a/querybook/webapp/resource/table.ts
+++ b/querybook/webapp/resource/table.ts
@@ -158,7 +158,7 @@ export const TableResource = {
     },
 
     refresh: (tableId: number) =>
-        ds.update<IDataTable | -1>(`/table/${tableId}/refresh/`),
+        ds.update<IDataTable>(`/table/${tableId}/refresh/`),
 };
 
 export const TableColumnResource = {

--- a/querybook/webapp/ui/ErrorPage/ErrorPage.scss
+++ b/querybook/webapp/ui/ErrorPage/ErrorPage.scss
@@ -2,6 +2,7 @@
 
 .ErrorPage {
     position: relative;
+    min-height: 200px;
     .ErrorPage-message {
         @include ellipsis(30);
         white-space: pre-wrap;


### PR DESCRIPTION
When clicking "Refresh from metastore", if the table gets deleted, we'll show an empty 404 page.
![sync-deleted](https://user-images.githubusercontent.com/8308723/189985924-f1a7d0ad-225d-4ab1-92d2-26d37523d64d.gif)


Also the previous error page of table not found is not rendered properly.

**Before**
![error_modal](https://user-images.githubusercontent.com/8308723/189985995-34d42413-ec6a-4a9d-abcc-6edb6d396b1d.png)
![error_page](https://user-images.githubusercontent.com/8308723/189986020-b55a7de2-0da4-40d1-8569-90eb81b63192.png)

**After**
![404_page](https://user-images.githubusercontent.com/8308723/189986046-df7c0c84-90df-47db-903d-20f923ffe82d.png)

