### PR TITLE
fix: transfer schedule's ownership along with datadoc's ownership

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.10.6",
+    "version": "3.10.7",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/datasources/datadoc.py
+++ b/querybook/server/datasources/datadoc.py
@@ -27,7 +27,7 @@ from logic.datadoc_permission import assert_can_read, assert_can_write, assert_i
 from logic.query_execution import get_query_execution_by_id
 from logic.schedule import (
     run_and_log_scheduled_task,
-    update_task_schedule_owner,
+    update_datadoc_schedule_owner,
 )
 from models.environment import Environment
 from lib.notify.utils import notify_user
@@ -615,8 +615,8 @@ def update_datadoc_owner(doc_id, next_owner_id, originator=None):
         doc = logic.update_data_doc(
             id=doc_id, commit=False, session=session, owner_uid=next_owner_uid
         )
-        # Update datadoc schedule's owner to next owner
-        update_task_schedule_owner(
+        # Update datadoc schedule's owner to next owner if there is any
+        update_datadoc_schedule_owner(
             doc_id=doc_id, owner_id=next_owner_uid, commit=False, session=session
         )
 

--- a/querybook/server/datasources/datadoc.py
+++ b/querybook/server/datasources/datadoc.py
@@ -25,7 +25,10 @@ from logic import (
 )
 from logic.datadoc_permission import assert_can_read, assert_can_write, assert_is_owner
 from logic.query_execution import get_query_execution_by_id
-from logic.schedule import run_and_log_scheduled_task
+from logic.schedule import (
+    run_and_log_scheduled_task,
+    update_task_schedule_owner,
+)
 from models.environment import Environment
 from lib.notify.utils import notify_user
 
@@ -612,6 +615,11 @@ def update_datadoc_owner(doc_id, next_owner_id, originator=None):
         doc = logic.update_data_doc(
             id=doc_id, commit=False, session=session, owner_uid=next_owner_uid
         )
+        # Update datadoc schedule's owner to next owner
+        update_task_schedule_owner(
+            doc_id=doc_id, owner_id=next_owner_uid, commit=False, session=session
+        )
+
         doc_dict = doc.to_dict()
         session.commit()
         socketio.emit(

--- a/querybook/server/logic/schedule.py
+++ b/querybook/server/logic/schedule.py
@@ -96,7 +96,37 @@ def update_task_schedule(id, commit=True, session=None, no_changes=False, **kwar
 
     if commit:
         session.commit()
-    task_schedule.id
+
+    return task_schedule
+
+
+@with_session
+def update_task_schedule_owner(
+    doc_id,
+    owner_id,
+    commit=True,
+    session=None,
+):
+    """Update the schedule's owner, which is the user_id field in kwargs."""
+    schedule_name = get_data_doc_schedule_name(doc_id)
+    task_schedule = get_task_schedule_by_name(schedule_name, session=session)
+
+    if not task_schedule:
+        raise Exception(
+            "unable to find any schedules for data doc id {}".format(doc_id)
+        )
+
+    update_model_fields(
+        task_schedule,
+        field_names=[
+            "kwargs",
+        ],
+        kwargs={**task_schedule.kwargs, "user_id": owner_id},
+    )
+
+    if commit:
+        session.commit()
+
     return task_schedule
 
 

--- a/querybook/server/logic/schedule.py
+++ b/querybook/server/logic/schedule.py
@@ -101,28 +101,20 @@ def update_task_schedule(id, commit=True, session=None, no_changes=False, **kwar
 
 
 @with_session
-def update_task_schedule_owner(
+def update_datadoc_schedule_owner(
     doc_id,
     owner_id,
     commit=True,
     session=None,
 ):
-    """Update the schedule's owner, which is the user_id field in kwargs."""
+    """Update datadoc schedule's owner, which is the user_id field in kwargs."""
     schedule_name = get_data_doc_schedule_name(doc_id)
     task_schedule = get_task_schedule_by_name(schedule_name, session=session)
 
     if not task_schedule:
-        raise Exception(
-            "unable to find any schedules for data doc id {}".format(doc_id)
-        )
+        return
 
-    update_model_fields(
-        task_schedule,
-        field_names=[
-            "kwargs",
-        ],
-        kwargs={**task_schedule.kwargs, "user_id": owner_id},
-    )
+    task_schedule.kwargs |= {"user_id": owner_id}
 
     if commit:
         session.commit()

--- a/querybook/webapp/components/DataDocSchedule/DataDocScheduleForm.tsx
+++ b/querybook/webapp/components/DataDocSchedule/DataDocScheduleForm.tsx
@@ -114,9 +114,6 @@ export const DataDocScheduleForm: React.FunctionComponent<
     onDelete,
     onRun,
 }) => {
-    const dataDoc = useSelector(
-        (state: IStoreState) => state.dataDoc.dataDocById[docId]
-    );
     const exporters = useSelector(
         (state: IStoreState) => state.queryExecutions.statementExporters
     );
@@ -184,7 +181,7 @@ export const DataDocScheduleForm: React.FunctionComponent<
                             Notification will be sent to the owner of the
                             datadoc{' '}
                             <b>
-                                @<UserName uid={dataDoc.owner_uid} />
+                                @<UserName uid={kwargs.user_id} />
                             </b>
                             , who will be running the scheduled queries.
                         </div>

--- a/querybook/webapp/components/DataDocSchedule/DataDocScheduleForm.tsx
+++ b/querybook/webapp/components/DataDocSchedule/DataDocScheduleForm.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import * as Yup from 'yup';
 
+import { UserName } from 'components/UserBadge/UserName';
 import type { IQueryResultExporter } from 'const/queryExecution';
 import { IDataDocScheduleKwargs, NotifyOn } from 'const/schedule';
 import { getExporterAuthentication } from 'lib/result-export';
@@ -113,6 +114,9 @@ export const DataDocScheduleForm: React.FunctionComponent<
     onDelete,
     onRun,
 }) => {
+    const dataDoc = useSelector(
+        (state: IStoreState) => state.dataDoc.dataDocById[docId]
+    );
     const exporters = useSelector(
         (state: IStoreState) => state.queryExecutions.statementExporters
     );
@@ -176,6 +180,14 @@ export const DataDocScheduleForm: React.FunctionComponent<
                 const notificationField = (
                     <>
                         <FormSectionHeader>Notification</FormSectionHeader>
+                        <div>
+                            Notification will be sent to the owner of the
+                            datadoc{' '}
+                            <b>
+                                @<UserName uid={dataDoc.owner_uid} />
+                            </b>
+                            , who will be running the scheduled queries.
+                        </div>
                         <SimpleField
                             label="Notify With"
                             name="kwargs.notify_with"

--- a/querybook/webapp/components/DataDocSchedule/DataDocScheduleForm.tsx
+++ b/querybook/webapp/components/DataDocSchedule/DataDocScheduleForm.tsx
@@ -114,6 +114,9 @@ export const DataDocScheduleForm: React.FunctionComponent<
     onDelete,
     onRun,
 }) => {
+    const userId = useSelector(
+        (state: IStoreState) => state.user.myUserInfo.uid
+    );
     const exporters = useSelector(
         (state: IStoreState) => state.queryExecutions.statementExporters
     );
@@ -178,12 +181,16 @@ export const DataDocScheduleForm: React.FunctionComponent<
                     <>
                         <FormSectionHeader>Notification</FormSectionHeader>
                         <div>
-                            Notification will be sent to the owner of the
-                            datadoc{' '}
+                            Notifications will be sent to the user who created
+                            or updated the schedule{' '}
                             <b>
-                                @<UserName uid={kwargs.user_id} />
+                                @
+                                <UserName
+                                    uid={isCreateForm ? userId : kwargs.user_id}
+                                />
                             </b>
-                            , who will be running the scheduled queries.
+                            , and scheduled queries will also run in the name of
+                            them.
                         </div>
                         <SimpleField
                             label="Notify With"

--- a/querybook/webapp/components/DataDocSchedule/DataDocScheduleForm.tsx
+++ b/querybook/webapp/components/DataDocSchedule/DataDocScheduleForm.tsx
@@ -189,8 +189,7 @@ export const DataDocScheduleForm: React.FunctionComponent<
                                     uid={isCreateForm ? userId : kwargs.user_id}
                                 />
                             </b>
-                            , and scheduled queries will also run in the name of
-                            them.
+                            , and scheduled queries will also run by them.
                         </div>
                         <SimpleField
                             label="Notify With"

--- a/querybook/webapp/const/schedule.ts
+++ b/querybook/webapp/const/schedule.ts
@@ -66,6 +66,8 @@ export enum NotifyOn {
 }
 
 export interface IDataDocScheduleKwargs {
+    doc_id?: number;
+    user_id?: number;
     notify_with?: string;
     notify_on?: NotifyOn;
     exports?: Array<{


### PR DESCRIPTION
Today when the datadoc gets transferred, the datadoc's schedule wont be transferred. This PR is to fix it.

Also adding a message in the schedule form to tell people that the datadoc's owner will be sent for notification and it is also the one who will be running the query.
![image](https://user-images.githubusercontent.com/8308723/190217368-04089840-d65c-4cd4-9679-7b4b84c5f445.png)

![schedule_owner](https://user-images.githubusercontent.com/8308723/190066875-77354891-c6b4-4b08-bd1f-bae300c70994.gif)
