### PR TITLE
fix: Convert impression views from a tuple to a list

### DIFF
--- a/querybook/server/logic/impression.py
+++ b/querybook/server/logic/impression.py
@@ -106,14 +106,17 @@ def get_viewers_count_by_item_after_date(item_type, item_id, after_date, session
 
 @with_session
 def get_item_timeseries_after_date(item_type, item_id, after_date, session=None):
-    return (
-        session.query(func.count(Impression.uid), func.date(Impression.created_at))
-        .distinct(Impression.uid)
-        .filter_by(item_type=item_type, item_id=item_id)
-        .filter(Impression.created_at >= after_date)
-        .group_by(func.date(Impression.created_at))
-        .all()
-    )
+    return [
+        list(i)
+        for i in (
+            session.query(func.count(Impression.uid), func.date(Impression.created_at))
+            .distinct(Impression.uid)
+            .filter_by(item_type=item_type, item_id=item_id)
+            .filter(Impression.created_at >= after_date)
+            .group_by(func.date(Impression.created_at))
+            .all()
+        )
+    ]
 
 
 @with_session


### PR DESCRIPTION
Previously, `get_item_timeseries_after_date()` returns a list of tuples, which is not being correctly rendered as a list of lists in the response to the browser.  This breaks the Views over Time feature.

This change manually converts the tuple into a list, which is the expected format.
 
<img width="568" alt="Screen Shot 2022-09-16 at 6 01 22 AM" src="https://user-images.githubusercontent.com/3084806/190644841-8878e328-b142-410b-b07d-1481a0c0b928.png">
