### PR TITLE
feat: show deactivated user with different ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.11.0",
+    "version": "3.11.1",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/logic/elasticsearch.py
+++ b/querybook/server/logic/elasticsearch.py
@@ -668,10 +668,13 @@ def user_to_es(user, fields=None, session=None):
             "input": process_names_for_suggestion(username, fullname),
         }
 
+    def get_fullname_field():
+        return (fullname or username) + (" (deactivated)" if user.deleted else "")
+
     field_to_getter = {
         "id": user.id,
         "username": username,
-        "fullname": (fullname or username) + (" (deactivated)" if user.deleted else ""),
+        "fullname": get_fullname_field,
         "suggest": get_suggestion_field,
     }
     return _get_dict_by_field(field_to_getter, fields=fields)

--- a/querybook/server/logic/elasticsearch.py
+++ b/querybook/server/logic/elasticsearch.py
@@ -671,7 +671,7 @@ def user_to_es(user, fields=None, session=None):
     field_to_getter = {
         "id": user.id,
         "username": username,
-        "fullname": fullname,
+        "fullname": (fullname or username) + (" (deactivated)" if user.deleted else ""),
         "suggest": get_suggestion_field,
     }
     return _get_dict_by_field(field_to_getter, fields=fields)
@@ -719,7 +719,7 @@ def update_user_by_id(uid, session=None):
     index_name = ES_CONFIG["users"]["index_name"]
 
     user = User.get(id=uid, session=session)
-    if user is None or user.deleted:
+    if user is None:
         try:
             _delete(index_name, id=uid)
         except Exception:

--- a/querybook/server/logic/schedule.py
+++ b/querybook/server/logic/schedule.py
@@ -182,7 +182,7 @@ def get_scheduled_data_docs_by_user(
         session.query(DataDoc, TaskSchedule)
         .join(
             TaskSchedule,
-            TaskSchedule.name == func.concat(DATADOC_SCHEDULE_PREFIX, DataDoc.id),
+            TaskSchedule.name == get_data_doc_schedule_name(DATADOC_SCHEDULE_PREFIX),
             isouter=(not filters.get("scheduled_only", False)),
         )
         .filter(DataDoc.owner_uid == uid)

--- a/querybook/server/logic/schedule.py
+++ b/querybook/server/logic/schedule.py
@@ -182,7 +182,7 @@ def get_scheduled_data_docs_by_user(
         session.query(DataDoc, TaskSchedule)
         .join(
             TaskSchedule,
-            TaskSchedule.name == get_data_doc_schedule_name(DATADOC_SCHEDULE_PREFIX),
+            TaskSchedule.name == func.concat(DATADOC_SCHEDULE_PREFIX, DataDoc.id),
             isouter=(not filters.get("scheduled_only", False)),
         )
         .filter(DataDoc.owner_uid == uid)

--- a/querybook/server/logic/schedule.py
+++ b/querybook/server/logic/schedule.py
@@ -12,6 +12,8 @@ from models.schedule import (
 )
 from models.datadoc import DataDoc
 
+DATADOC_SCHEDULE_PREFIX = "run_data_doc_"
+
 
 @with_session
 def get_all_task_schedules(offset=0, limit=100, session=None):
@@ -169,7 +171,7 @@ def get_task_run_record_run_by_name(
 
 
 def get_data_doc_schedule_name(id: int):
-    return f"run_data_doc_{id}"
+    return f"{DATADOC_SCHEDULE_PREFIX}{id}"
 
 
 @with_session
@@ -180,7 +182,7 @@ def get_scheduled_data_docs_by_user(
         session.query(DataDoc, TaskSchedule)
         .join(
             TaskSchedule,
-            TaskSchedule.name == func.concat("run_data_doc_", DataDoc.id),
+            TaskSchedule.name == func.concat(DATADOC_SCHEDULE_PREFIX, DataDoc.id),
             isouter=(not filters.get("scheduled_only", False)),
         )
         .filter(DataDoc.owner_uid == uid)

--- a/querybook/server/tasks/all_tasks.py
+++ b/querybook/server/tasks/all_tasks.py
@@ -17,6 +17,7 @@ from .delete_mysql_cache import delete_mysql_cache
 from .poll_engine_status import poll_engine_status
 from .presto_hive_function_scrapper import presto_hive_function_scrapper
 from .db_clean_up_jobs import run_all_db_clean_up_jobs
+from .disable_scheduled_docs import disable_scheduled_docs
 
 LOG = get_logger(__file__)
 
@@ -38,6 +39,7 @@ poll_engine_status
 presto_hive_function_scrapper
 run_all_db_clean_up_jobs
 run_sample_query
+disable_scheduled_docs
 
 LOG = get_task_logger(__name__)
 

--- a/querybook/server/tasks/disable_scheduled_docs.py
+++ b/querybook/server/tasks/disable_scheduled_docs.py
@@ -1,0 +1,66 @@
+from app.flask_app import celery
+
+from models.schedule import (
+    TaskSchedule,
+)
+from app.db import with_session
+from logic.schedule import (
+    DATADOC_SCHEDULE_PREFIX,
+    update_task_schedule,
+    with_task_logging,
+)
+from logic.datadoc import get_data_doc_by_id
+from logic.user import get_user_by_id
+from lib.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@with_session
+def get_scheduled_datadoc_tasks(session=None):
+    return (
+        session.query(TaskSchedule)
+        .filter(
+            TaskSchedule.enabled.is_(True),
+            TaskSchedule.name.like(DATADOC_SCHEDULE_PREFIX + "%"),
+        )
+        .all()
+    )
+
+
+def get_task_owner(task, session):
+    doc_id = task.kwargs["doc_id"]
+    task_uid = task.kwargs.get("user_id")
+
+    if not task_uid:
+        doc = get_data_doc_by_id(doc_id, session=session)
+        task_uid = doc.owner_uid
+
+    task_owner = get_user_by_id(task_uid, session=session)
+    return task_owner
+
+
+@with_session
+def disable_deactivated_scheduled_docs(session=None):
+    disabled_scheduled_doc_ids = []
+    tasks = get_scheduled_datadoc_tasks(session=session)
+    for task in tasks:
+        task_owner = get_task_owner(task, session=session)
+        if task_owner.deleted:
+            update_task_schedule(task.id, commit=False, session=session, enabled=False)
+            disabled_scheduled_doc_ids.append(task.kwargs["doc_id"])
+
+    session.commit()
+    return disabled_scheduled_doc_ids
+
+
+@celery.task(bind=True)
+@with_task_logging()
+def disable_scheduled_docs(self):
+    disabled_scheduled_doc_ids = disable_deactivated_scheduled_docs()
+    if len(disabled_scheduled_doc_ids) == 0:
+        logger.info("No scheduled docs disabled.")
+    else:
+        logger.info(
+            f"{len(disabled_scheduled_doc_ids)} scheduled docs were disabled, doc ids: {disabled_scheduled_doc_ids}."
+        )

--- a/querybook/tests/test_lib/test_elasticsearch/test_elasticsearch.py
+++ b/querybook/tests/test_lib/test_elasticsearch/test_elasticsearch.py
@@ -421,7 +421,9 @@ class TableTestCase(TestCase):
 
 class UserTestCase(TestCase):
     def setUp(self):
-        self.user_mock = MagicMock(username="john", fullname="John Smith 123", id=7)
+        self.user_mock = MagicMock(
+            username="john", fullname="John Smith 123", id=7, deleted=False
+        )
 
     def test_user_to_es(self):
         self.assertEqual(
@@ -432,6 +434,21 @@ class UserTestCase(TestCase):
                 "fullname": "John Smith 123",
                 "suggest": {"input": ["john", "john", "john smith", "john", "smith"]},
             },
+        )
+
+    def test_deleted_user_to_es(self):
+        self.user_mock.deleted = True
+        user_dict = user_to_es(self.user_mock, session=MagicMock())
+
+        self.assertEqual(
+            user_dict["fullname"],
+            "John Smith 123 (deactivated)",
+        )
+
+        # Should not impact search
+        self.assertEqual(
+            user_dict["suggest"],
+            ["john", "john", "john smith", "john", "smith"],
         )
 
     def test_partial_dict(self):

--- a/querybook/tests/test_lib/test_elasticsearch/test_elasticsearch.py
+++ b/querybook/tests/test_lib/test_elasticsearch/test_elasticsearch.py
@@ -448,7 +448,7 @@ class UserTestCase(TestCase):
         # Should not impact search
         self.assertEqual(
             user_dict["suggest"],
-            ["john", "john", "john smith", "john", "smith"],
+            {"input": ["john", "john", "john smith", "john", "smith"]},
         )
 
     def test_partial_dict(self):

--- a/querybook/webapp/components/DataDocViewersBadge/DataDocViewersBadge.tsx
+++ b/querybook/webapp/components/DataDocViewersBadge/DataDocViewersBadge.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux';
 
 import { DataDocViewersList } from 'components/DataDocViewersList/DataDocViewersList';
 import { UserAvatarList } from 'components/UserBadge/UserAvatarList';
+import { DELETED_USER_MSG } from 'const/user';
 import { useShallowSelector } from 'hooks/redux/useShallowSelector';
 import { Permission } from 'lib/data-doc/datadoc-permission';
 import * as dataDocActions from 'redux/dataDoc/action';
@@ -134,7 +135,7 @@ export const DataDocViewersBadge = React.memo<IDataDocViewersBadgeProps>(
                                 const displayName =
                                     userInfo.fullname ?? userInfo.username;
                                 const deletedMessage = userInfo.deleted
-                                    ? ' (deactivated)'
+                                    ? ` ${DELETED_USER_MSG}`
                                     : '';
                                 tooltip = displayName + deletedMessage;
                             }

--- a/querybook/webapp/components/DataDocViewersBadge/DataDocViewersBadge.tsx
+++ b/querybook/webapp/components/DataDocViewersBadge/DataDocViewersBadge.tsx
@@ -131,7 +131,12 @@ export const DataDocViewersBadge = React.memo<IDataDocViewersBadgeProps>(
                             uid: viewerInfo.uid,
                             tooltip:
                                 viewerInfo.uid in userInfoById
-                                    ? userInfoById[viewerInfo.uid].username
+                                    ? (userInfoById[viewerInfo.uid].fullname ??
+                                          userInfoById[viewerInfo.uid]
+                                              .username) +
+                                      (userInfoById[viewerInfo.uid].deleted
+                                          ? ' (deactivated)'
+                                          : '')
                                     : null,
                             isOnline: viewerInfo.online,
                         }))}

--- a/querybook/webapp/components/DataDocViewersBadge/DataDocViewersBadge.tsx
+++ b/querybook/webapp/components/DataDocViewersBadge/DataDocViewersBadge.tsx
@@ -127,19 +127,24 @@ export const DataDocViewersBadge = React.memo<IDataDocViewersBadgeProps>(
                 <UserAvatarList
                     users={viewerInfos
                         .slice(0, numberBadges)
-                        .map((viewerInfo) => ({
-                            uid: viewerInfo.uid,
-                            tooltip:
-                                viewerInfo.uid in userInfoById
-                                    ? (userInfoById[viewerInfo.uid].fullname ??
-                                          userInfoById[viewerInfo.uid]
-                                              .username) +
-                                      (userInfoById[viewerInfo.uid].deleted
-                                          ? ' (deactivated)'
-                                          : '')
-                                    : null,
-                            isOnline: viewerInfo.online,
-                        }))}
+                        .map((viewerInfo) => {
+                            const userInfo = userInfoById[viewerInfo.uid];
+                            let tooltip: string;
+                            if (userInfo) {
+                                const displayName =
+                                    userInfo.fullname ?? userInfo.username;
+                                const deletedMessage = userInfo.deleted
+                                    ? ' (deactivated)'
+                                    : '';
+                                tooltip = displayName + deletedMessage;
+                            }
+
+                            return {
+                                uid: viewerInfo.uid,
+                                tooltip,
+                                isOnline: viewerInfo.online,
+                            };
+                        })}
                     extraCount={extraViewersCount}
                 />
             );

--- a/querybook/webapp/components/UserBadge/UserAvatar.scss
+++ b/querybook/webapp/components/UserBadge/UserAvatar.scss
@@ -31,18 +31,25 @@
         bottom: 0;
         border-radius: 50%;
         border: solid 2px var(--bg);
-    }
 
-    .online {
-        background-color: var(--color-true);
-    }
+        &.online {
+            background-color: var(--color-true);
+        }
 
-    .offline {
-        background-color: var(--color-null);
+        &.offline {
+            background-color: var(--color-null);
+        }
     }
 
     &.tiny {
         height: 20px;
         width: 20px;
+    }
+
+    &.deleted {
+        img,
+        canvas {
+            filter: grayscale(90%);
+        }
     }
 }

--- a/querybook/webapp/components/UserBadge/UserAvatar.tsx
+++ b/querybook/webapp/components/UserBadge/UserAvatar.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import React, { useEffect } from 'react';
 
 import { IUserInfo } from 'const/user';
@@ -80,6 +81,7 @@ export const UserAvatarComponent: React.FunctionComponent<
 > = ({ loading, userInfo, isOnline, tiny, onClick = null }) => {
     const profileImage = userInfo ? userInfo.profile_img : null;
     const userName = userInfo ? userInfo.fullname ?? userInfo.username : null;
+    const isDeleted = userInfo?.deleted;
 
     const imageDOM = loading ? (
         <div className="spinner-wrapper">
@@ -91,19 +93,24 @@ export const UserAvatarComponent: React.FunctionComponent<
         <img src={profileImage} />
     );
 
-    const isOnlineClasses = isOnline
-        ? 'is-online-dot online'
-        : 'is-online-dot offline';
-
     const isOnlineDot =
-        isOnline === undefined ? null : <span className={isOnlineClasses} />;
+        isOnline === undefined || tiny || isDeleted ? null : (
+            <span
+                className={clsx(
+                    'is-online-dot',
+                    isOnline ? 'online' : 'offline'
+                )}
+            />
+        );
 
-    return tiny ? (
-        <span className="UserAvatar tiny" onClick={onClick}>
-            {imageDOM}
-        </span>
-    ) : (
-        <span className="UserAvatar" onClick={onClick}>
+    const classNames = clsx(
+        'UserAvatar',
+        tiny && 'tiny',
+        isDeleted && 'deleted'
+    );
+
+    return (
+        <span className={classNames} onClick={onClick}>
             {imageDOM}
             {isOnlineDot}
         </span>

--- a/querybook/webapp/components/UserBadge/UserBadge.tsx
+++ b/querybook/webapp/components/UserBadge/UserBadge.tsx
@@ -43,6 +43,8 @@ export const UserBadge: React.FunctionComponent<IProps> = ({
         [userInfo, name]
     );
 
+    const deletedText = userInfo.deleted ? '(deactivated)' : '';
+
     if (mini) {
         return (
             <span
@@ -54,7 +56,7 @@ export const UserBadge: React.FunctionComponent<IProps> = ({
             >
                 <figure>{avatarDOM}</figure>
                 <AccentText className="username" weight="bold">
-                    {userInfo?.fullname ?? userName}
+                    {userInfo?.fullname ?? userName} {deletedText}
                 </AccentText>
             </span>
         );
@@ -81,7 +83,7 @@ export const UserBadge: React.FunctionComponent<IProps> = ({
                     <UserNameComponent userInfo={userInfo} loading={loading} />
                 </AccentText>
                 <AccentText className="handle" size="small" color="light">
-                    @{userName}
+                    @{userName} {deletedText}
                 </AccentText>
             </div>
         </div>

--- a/querybook/webapp/components/UserBadge/UserBadge.tsx
+++ b/querybook/webapp/components/UserBadge/UserBadge.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import React, { useMemo } from 'react';
 
+import { DELETED_USER_MSG } from 'const/user';
 import { useUser } from 'hooks/redux/useUser';
 import { AccentText } from 'ui/StyledText/StyledText';
 
@@ -43,7 +44,7 @@ export const UserBadge: React.FunctionComponent<IProps> = ({
         [userInfo, name]
     );
 
-    const deletedText = userInfo.deleted ? '(deactivated)' : '';
+    const deletedText = userInfo.deleted ? DELETED_USER_MSG : '';
 
     if (mini) {
         return (

--- a/querybook/webapp/const/user.ts
+++ b/querybook/webapp/const/user.ts
@@ -18,3 +18,5 @@ export interface IMyUserInfo {
     permission?: number;
     isAdmin: boolean;
 }
+
+export const DELETED_USER_MSG = '(deactivated)';


### PR DESCRIPTION
Disabled users are now searchable in user search.
They will also look different in UI, with grayed out icon and `(deactivated)` added to their name:
![image](https://user-images.githubusercontent.com/8283407/191645004-24522fd8-d28b-4e6c-ab14-40f5887f569b.png)

Also added a task to disable scheduled docs if the owner is deleted, this task is optional
