### PR TITLE
fix: parse big nubmers in json

### DIFF
--- a/querybook/webapp/lib/query-result/transformer.tsx
+++ b/querybook/webapp/lib/query-result/transformer.tsx
@@ -97,7 +97,15 @@ const queryResultTransformers: IColumnTransformer[] = [
         auto: true,
         transform: (v: string): React.ReactNode => {
             try {
-                const json = JSON.parse(v);
+                // replace big nubmer as string before the Json parse
+                const json = JSON.parse(
+                    v.replaceAll(/:\s*(\d+)/g, (match, p1) => {
+                        if (Number.isSafeInteger(+p1)) {
+                            return `: ${p1}`;
+                        }
+                        return `: "${p1}"`;
+                    })
+                );
                 // Cannot pass following into <ReactJson />, returning original value in order to protect ReactJson from failing
                 if (!json || isNumeric(json) || isBoolean(json)) {
                     return v;


### PR DESCRIPTION
JSON.parse can't handle big numbers properly, which will be rounded. A workaround here is to replace all the big number in a json with string before the parsing. 

![image](https://user-images.githubusercontent.com/8308723/192352990-893db248-447c-4245-bad5-ef96b891ae6c.png)
