### PR TITLE
fix: do not transform presto map keys

### DIFF
--- a/querybook/server/lib/query_executor/clients/utils/presto_cursor.py
+++ b/querybook/server/lib/query_executor/clients/utils/presto_cursor.py
@@ -30,6 +30,7 @@ class PrestoCursorMixin(Generic[CursorT, CursorReturnT], ABC):
 
     @property
     def presto_types(self) -> List[PrestoType]:
+        print(self._cursor.description)
         return [PrestoType.from_string(i[1]) for i in self._cursor.description]
 
     @property

--- a/querybook/server/lib/query_executor/clients/utils/presto_types.py
+++ b/querybook/server/lib/query_executor/clients/utils/presto_types.py
@@ -115,10 +115,7 @@ class MapType(PrestoType):
     def format_data(self, data: Optional[Dict]) -> Optional[Dict]:
         if data is None:
             return data
-        return {
-            self.key_type.format_data(k): self.value_type.format_data(v)
-            for k, v in data.items()
-        }
+        return {k: self.value_type.format_data(v) for k, v in data.items()}
 
 
 @dataclass

--- a/querybook/tests/test_lib/test_query_executor/test_clients/test_utils/test_presto_types.py
+++ b/querybook/tests/test_lib/test_query_executor/test_clients/test_utils/test_presto_types.py
@@ -156,6 +156,27 @@ from lib.query_executor.clients.utils.presto_types import (
             ),
         ),
         (
+            # select MAP(ARRAY[ARRAY['foo'], ARRAY['bar']], ARRAY[CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE)), CAST(ROW(3, 4.0) AS ROW(x BIGINT, y DOUBLE))])
+            "map(array(string), row(x bigint, y double))",
+            MapType(
+                key_type=ArrayType(element_type=AtomicType(type_="string")),
+                value_type=RowType(
+                    fields=OrderedDict(
+                        [
+                            (
+                                "x",
+                                AtomicType(type_="bigint"),
+                            ),
+                            (
+                                "y",
+                                AtomicType(type_="double"),
+                            ),
+                        ]
+                    )
+                ),
+            ),
+        ),
+        (
             "map(string, row(map map(string, string)))",
             MapType(
                 key_type=AtomicType(type_="string"),
@@ -264,6 +285,28 @@ def test_parse_from_string(string_definition: str, exp_type: PrestoType) -> None
             ),
             ({"a": 111, "b": 222},),
             {"map": {"a": 111, "b": 222}},
+        ),
+        (
+            # select MAP(ARRAY[ARRAY['foo' ], ARRAY['bar']], ARRAY[CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE)), CAST(ROW(3, 4.0) AS ROW(x BIGINT, y DOUBLE))])
+            MapType(
+                key_type=ArrayType(element_type=AtomicType(type_="string")),
+                value_type=RowType(
+                    fields=OrderedDict(
+                        [
+                            (
+                                "x",
+                                AtomicType(type_="bigint"),
+                            ),
+                            (
+                                "y",
+                                AtomicType(type_="double"),
+                            ),
+                        ]
+                    )
+                ),
+            ),
+            {"[foo]": [1, 2.0], "[bar]": [3, 4.0]},
+            {"[foo]": {"x": 1, "y": 2.0}, "[bar]": {"x": 3, "y": 4.0}},
         ),
     ],
 )


### PR DESCRIPTION
This is a fix for #991 
example query that fails:
```sql
select MAP(ARRAY[ARRAY['foo' ], ARRAY['bar']], ARRAY[CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE)), CAST(ROW(3, 4.0) AS ROW(x BIGINT, y DOUBLE))])
```
The reason is that MAP is converted to Python dict, but Python dict cannot have keys with type `list` (which is what ARRAY gets translated to).

When Presto output rows in JSON, the keys are already serialized to strings, which means they are not parsable anyway, in this case, we just do not translate the keys at all.

Also added testing
