### PR TITLE
fix: Add sort_key and sort_order to table search

### DIFF
--- a/querybook/webapp/components/DataTableNavigator/DataTableNavigatorSearch.tsx
+++ b/querybook/webapp/components/DataTableNavigator/DataTableNavigatorSearch.tsx
@@ -129,6 +129,7 @@ export const DataTableNavigatorSearch: React.FC<{
                 <OrderByButton
                     className="mr4"
                     asc={sortTableAsc}
+                    hideAscToggle={sortTableKey === 'importance_score'}
                     orderByField={startCase(sortTableKey)}
                     orderByFieldSymbol={sortTableKey === 'name' ? 'Aa' : 'Is'}
                     onAscToggle={() => {

--- a/querybook/webapp/components/DataTableNavigator/DataTableNavigatorSearch.tsx
+++ b/querybook/webapp/components/DataTableNavigator/DataTableNavigatorSearch.tsx
@@ -4,7 +4,10 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { TableTagGroupSelect } from 'components/DataTableTags/TableTagGroupSelect';
 import { useToggleState } from 'hooks/useToggleState';
-import { changeSchemasSort } from 'redux/dataTableSearch/action';
+import {
+    changeSchemasSort,
+    updateTableSort,
+} from 'redux/dataTableSearch/action';
 import { ITableSearchFilters } from 'redux/dataTableSearch/types';
 import { IStoreState } from 'redux/store/types';
 import { SoftButton } from 'ui/Button/Button';
@@ -44,6 +47,11 @@ export const DataTableNavigatorSearch: React.FC<{
         () => Object.keys(searchFilters).length,
         [searchFilters]
     );
+
+    const { asc: sortTableAsc, key: sortTableKey } = useSelector(
+        (state: IStoreState) => state.dataTableSearch.sortTablesBy
+    );
+
     const { key: sortSchemaKey, asc: sortSchemaAsc } = useSelector(
         (state: IStoreState) => state.dataTableSearch.schemas.sortSchemasBy
     );
@@ -116,6 +124,27 @@ export const DataTableNavigatorSearch: React.FC<{
                 placeholder="Search by Name"
                 transparent
             />
+
+            {showTableSearchResult && (
+                <OrderByButton
+                    className="mr4"
+                    asc={sortTableAsc}
+                    orderByField={startCase(sortTableKey)}
+                    orderByFieldSymbol={sortTableKey === 'name' ? 'Aa' : 'Is'}
+                    onAscToggle={() => {
+                        dispatch(updateTableSort(null, !sortTableAsc));
+                    }}
+                    onOrderByFieldToggle={() => {
+                        dispatch(
+                            updateTableSort(
+                                sortTableKey === 'name'
+                                    ? 'importance_score'
+                                    : 'name'
+                            )
+                        );
+                    }}
+                />
+            )}
 
             {!showTableSearchResult && (
                 <OrderByButton

--- a/querybook/webapp/components/DataTableNavigator/SchemaTableView/SchemaTableItem.tsx
+++ b/querybook/webapp/components/DataTableNavigator/SchemaTableView/SchemaTableItem.tsx
@@ -87,6 +87,7 @@ export const SchemaTableItem: React.FC<{
                 </div>
                 <OrderByButton
                     asc={sortOrder.asc}
+                    hideAscToggle={sortOrder.key === 'importance_score'}
                     orderByField={startCase(sortOrder.key)}
                     orderByFieldSymbol={sortOrder.key === 'name' ? 'Aa' : 'Is'}
                     onAscToggle={() => onSortChanged(null, !sortOrder.asc)}

--- a/querybook/webapp/const/search.ts
+++ b/querybook/webapp/const/search.ts
@@ -39,7 +39,7 @@ export interface ISearchTableParams {
     filters?: Array<[filterName: string, filterValue: any]>;
     fields?: string[];
     sort_key?: string | string[];
-    sort_order?: 'desc' | 'asc' | Array<[desc: string, asc: string]>;
+    sort_order?: 'desc' | 'asc' | Array<'desc' | 'asc'>;
     limit?: number;
     offset?: number;
 }

--- a/querybook/webapp/const/search.ts
+++ b/querybook/webapp/const/search.ts
@@ -39,7 +39,7 @@ export interface ISearchTableParams {
     filters?: Array<[filterName: string, filterValue: any]>;
     fields?: string[];
     sort_key?: string | string[];
-    sort_order?: 'desc' | 'asc';
+    sort_order?: 'desc' | 'asc' | Array<[desc: string, asc: string]>;
     limit?: number;
     offset?: number;
 }

--- a/querybook/webapp/redux/dataTableSearch/action.ts
+++ b/querybook/webapp/redux/dataTableSearch/action.ts
@@ -96,6 +96,9 @@ function searchDataTable(): ThunkResult<Promise<ITableSearchResult[]>> {
                 const tableSortAsc = tableSort.asc ? 'asc' : 'desc';
                 search['sort_key'] = ['schema', 'name'];
                 search['sort_order'] = [tableSortAsc, tableSortAsc];
+            } else if (tableSort.key === 'importance_score') {
+                search['sort_key'] = '_score';
+                search['sort_order'] = tableSort.asc ? 'asc' : 'desc';
             }
             const searchRequest = SearchTableResource.searchConcise(search);
             dispatch(resetSearchResult());
@@ -196,7 +199,8 @@ export function searchTableBySchema(
                         schema: schemaName,
                     },
                 }),
-                sort_key: orderBy.key,
+                sort_key:
+                    orderBy.key === 'importance_score' ? '_score' : orderBy.key,
                 sort_order: orderBy.asc ? 'asc' : 'desc',
                 offset: resultsCount,
             });

--- a/querybook/webapp/redux/dataTableSearch/action.ts
+++ b/querybook/webapp/redux/dataTableSearch/action.ts
@@ -90,9 +90,11 @@ function searchDataTable(): ThunkResult<Promise<ITableSearchResult[]>> {
             if (state.searchRequest) {
                 state.searchRequest.cancel();
             }
-            const searchRequest = SearchTableResource.searchConcise(
-                mapStateToSearch(state)
-            );
+            const searchRequest = SearchTableResource.searchConcise({
+                ...mapStateToSearch(state),
+                sort_key: ['schema', 'name'],
+                sort_order: ['asc', 'asc'],
+            });
             dispatch(resetSearchResult());
             dispatch({
                 type: '@@dataTableSearch/DATA_TABLE_SEARCH_STARTED',

--- a/querybook/webapp/redux/dataTableSearch/action.ts
+++ b/querybook/webapp/redux/dataTableSearch/action.ts
@@ -3,6 +3,7 @@ import {
     SchemaSortKey,
     SchemaTableSortKey,
 } from 'const/metastore';
+import { Nullable } from 'lib/typescript';
 import { queryMetastoresSelector } from 'redux/dataSources/selector';
 import { SearchSchemaResource, SearchTableResource } from 'resource/search';
 
@@ -98,7 +99,7 @@ function searchDataTable(): ThunkResult<Promise<ITableSearchResult[]>> {
                 search['sort_order'] = [tableSortAsc, tableSortAsc];
             } else if (tableSort.key === 'importance_score') {
                 search['sort_key'] = '_score';
-                search['sort_order'] = tableSort.asc ? 'asc' : 'desc';
+                search['sort_order'] = 'desc';
             }
             const searchRequest = SearchTableResource.searchConcise(search);
             dispatch(resetSearchResult());
@@ -191,6 +192,7 @@ export function searchTableBySchema(
         try {
             const orderBy =
                 state.schemas.schemaSortByIds[id] || defaultSortSchemaTableBy;
+            const sortOrder = orderBy.asc ? 'asc' : 'desc';
             const searchRequest = SearchTableResource.searchConcise({
                 ...mapStateToSearch({
                     ...state,
@@ -201,7 +203,8 @@ export function searchTableBySchema(
                 }),
                 sort_key:
                     orderBy.key === 'importance_score' ? '_score' : orderBy.key,
-                sort_order: orderBy.asc ? 'asc' : 'desc',
+                sort_order:
+                    orderBy.key === 'importance_score' ? 'desc' : sortOrder,
                 offset: resultsCount,
             });
             dispatch({
@@ -298,7 +301,7 @@ export function updateSearchString(searchString: string): ThunkResult<void> {
 }
 
 export function updateTableSort(
-    sortKey?: SchemaTableSortKey | undefined | null,
+    sortKey?: Nullable<SchemaTableSortKey>,
     sortAsc?: boolean | undefined | null
 ): ThunkResult<void> {
     return (dispatch) => {

--- a/querybook/webapp/redux/dataTableSearch/action.ts
+++ b/querybook/webapp/redux/dataTableSearch/action.ts
@@ -90,11 +90,14 @@ function searchDataTable(): ThunkResult<Promise<ITableSearchResult[]>> {
             if (state.searchRequest) {
                 state.searchRequest.cancel();
             }
-            const searchRequest = SearchTableResource.searchConcise({
-                ...mapStateToSearch(state),
-                sort_key: ['schema', 'name'],
-                sort_order: ['asc', 'asc'],
-            });
+            const tableSort = state.sortTablesBy;
+            const search = { ...mapStateToSearch(state) };
+            if (tableSort.key === 'name') {
+                const tableSortAsc = tableSort.asc ? 'asc' : 'desc';
+                search['sort_key'] = ['schema', 'name'];
+                search['sort_order'] = [tableSortAsc, tableSortAsc];
+            }
+            const searchRequest = SearchTableResource.searchConcise(search);
             dispatch(resetSearchResult());
             dispatch({
                 type: '@@dataTableSearch/DATA_TABLE_SEARCH_STARTED',
@@ -284,6 +287,24 @@ export function updateSearchString(searchString: string): ThunkResult<void> {
             type: '@@dataTableSearch/DATA_TABLE_SEARCH_STRING_UPDATE',
             payload: {
                 searchString,
+            },
+        });
+        dispatch(searchDataTable());
+    };
+}
+
+export function updateTableSort(
+    sortKey?: SchemaTableSortKey | undefined | null,
+    sortAsc?: boolean | undefined | null
+): ThunkResult<void> {
+    return (dispatch) => {
+        dispatch({
+            type: '@@dataTableSearch/DATA_TABLE_SEARCH_SORT_UPDATE',
+            payload: {
+                sortTablesBy: {
+                    sortKey,
+                    sortAsc,
+                },
             },
         });
         dispatch(searchDataTable());

--- a/querybook/webapp/redux/dataTableSearch/reducer.ts
+++ b/querybook/webapp/redux/dataTableSearch/reducer.ts
@@ -25,6 +25,7 @@ const initialState: IDataTableSearchState = {
     searchString: '',
     searchRequest: null,
     metastoreId: null,
+    sortTablesBy: defaultSortSchemaTableBy,
     ...initialResultState,
 };
 
@@ -74,6 +75,18 @@ export default function dataTableSearch(
             }
             case '@@dataTableSearch/DATA_TABLE_SEARCH_STRING_UPDATE': {
                 draft.searchString = action.payload.searchString;
+                return;
+            }
+            case '@@dataTableSearch/DATA_TABLE_SEARCH_SORT_UPDATE': {
+                const { sortKey, sortAsc } = action.payload.sortTablesBy;
+
+                if (sortKey != null) {
+                    draft.sortTablesBy.key = sortKey;
+                }
+                if (sortAsc != null) {
+                    draft.sortTablesBy.asc = sortAsc;
+                }
+
                 return;
             }
             case '@@dataTableSearch/DATA_TABLE_SEARCH_FILTER_UPDATE': {

--- a/querybook/webapp/redux/dataTableSearch/types.ts
+++ b/querybook/webapp/redux/dataTableSearch/types.ts
@@ -66,6 +66,16 @@ export interface IDataTableSearchStringUpdateAction extends Action {
     };
 }
 
+export interface IDataTableSearchSortUpdateAction extends Action {
+    type: '@@dataTableSearch/DATA_TABLE_SEARCH_SORT_UPDATE';
+    payload: {
+        sortTablesBy: {
+            sortKey?: SchemaTableSortKey | undefined;
+            sortAsc?: boolean | undefined;
+        };
+    };
+}
+
 export interface IDataTableSearchSelectMetastoreAction extends Action {
     type: '@@dataTableSearch/DATA_TABLE_SEARCH_SELECT_METASTORE';
     payload: {
@@ -156,6 +166,7 @@ export type DataTableSearchAction =
     | IDataTableSearchDoneAction
     | IDataTableSearchFailedAction
     | IDataTableSearchStringUpdateAction
+    | IDataTableSearchSortUpdateAction
     | IDataTableSearchFilterUpdateAction
     | IDataTableSearchResetFilterAction
     | IDataTableSearchMoreAction
@@ -196,6 +207,10 @@ export interface IDataTableSearchState extends IDataTableSearchPaginationState {
     searchString: string;
     searchRequest?: ICancelablePromise<any>;
     metastoreId?: number;
+    sortTablesBy: {
+        asc: boolean;
+        key: SchemaTableSortKey;
+    };
 }
 
 export type ThunkResult<R> = ThunkAction<

--- a/querybook/webapp/ui/OrderByButton/OrderByButton.tsx
+++ b/querybook/webapp/ui/OrderByButton/OrderByButton.tsx
@@ -22,6 +22,7 @@ export interface ISortButtonProps {
      */
     orderByFieldSymbol?: string;
     className?: string;
+    hideAscToggle?: boolean;
 
     onOrderByFieldToggle?: () => void;
     onAscToggle?: () => void;
@@ -32,6 +33,7 @@ export const OrderByButton: React.FC<ISortButtonProps> = ({
     orderByField,
     orderByFieldSymbol,
     className,
+    hideAscToggle,
 
     onOrderByFieldToggle = NOOP,
     onAscToggle = NOOP,
@@ -41,15 +43,19 @@ export const OrderByButton: React.FC<ISortButtonProps> = ({
         [orderByField, orderByFieldSymbol]
     );
 
+    console.log(`Hide Asc Toggle: ${hideAscToggle}`);
+
     return (
         <span className={clsx('OrderByButton', className)}>
-            <TextToggleButton
-                value={false}
-                onChange={onAscToggle}
-                tooltip={asc ? 'Ascending' : 'Descending'}
-                tooltipPos="left"
-                text={asc ? '↑' : '↓'}
-            />
+            {!hideAscToggle && (
+                <TextToggleButton
+                    value={false}
+                    onChange={onAscToggle}
+                    tooltip={asc ? 'Ascending' : 'Descending'}
+                    tooltipPos="left"
+                    text={asc ? '↑' : '↓'}
+                />
+            )}
             <TextToggleButton
                 value={false}
                 onChange={onOrderByFieldToggle}


### PR DESCRIPTION
Since the table search currently doesn't have a sort order, this PR is to have the search result list in ascending order using schema and name.

Note: Also fixed the `importance_score` sorting feature on the schema table sort

![search-table-sort-filter](https://user-images.githubusercontent.com/1399744/198754205-40e7cbeb-93fd-42db-93d1-6f7b1c5ffe44.gif)

