### PR TITLE
fix: Make Presto Explain Validator optional install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.11.1",
+    "version": "3.11.2",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/lib/query_analysis/validation/all_validators.py
+++ b/querybook/server/lib/query_analysis/validation/all_validators.py
@@ -1,12 +1,14 @@
-from lib.utils.import_helper import import_module_with_default
+from lib.utils.import_helper import import_module_with_default, import_modules
 from .base_query_validator import BaseQueryValidator
-from .validators.presto_explain_validator import (
-    PrestoExplainValidator,
-)
 
-ALL_DEFAULT_QUERY_VALIDATORS = [
-    PrestoExplainValidator,
-]
+ALL_DEFAULT_QUERY_VALIDATORS = import_modules(
+    [
+        (
+            "lib.query_analysis..validators.presto_explain_validator",
+            "PrestoExplainValidator",
+        ),
+    ]
+)
 
 ALL_PLUGIN_QUERY_VALIDATORS_BY_NAME = import_module_with_default(
     "query_validation_plugin", "ALL_PLUGIN_QUERY_VALIDATORS_BY_NAME", default={}

--- a/querybook/server/lib/query_analysis/validation/all_validators.py
+++ b/querybook/server/lib/query_analysis/validation/all_validators.py
@@ -4,7 +4,7 @@ from .base_query_validator import BaseQueryValidator
 ALL_DEFAULT_QUERY_VALIDATORS = import_modules(
     [
         (
-            "lib.query_analysis..validators.presto_explain_validator",
+            "lib.query_analysis.validation.validators.presto_explain_validator",
             "PrestoExplainValidator",
         ),
     ]


### PR DESCRIPTION
the fix is needed as otherwise this would make Pyhive a required dependency for Querybook