### PR TITLE
fix: disable json formatting by default

### DIFF
--- a/querybook/webapp/lib/query-result/transformer.tsx
+++ b/querybook/webapp/lib/query-result/transformer.tsx
@@ -96,7 +96,7 @@ const queryResultTransformers: IColumnTransformer[] = [
         name: 'Parse JSON',
         appliesToType: ['json'],
         priority: 0,
-        auto: true,
+        auto: false,
         transform: (v: string): React.ReactNode => {
             try {
                 const json = JSONBigString.parse(v);


### PR DESCRIPTION
From user's feedback, by enabling the json formatting by default causes inconvenience for them. 

Here we'd like to disable the auto formatting, but user can transform the column as needed by themselves.