### PR TITLE
fix: schedule owner not update

### DIFF
--- a/querybook/server/logic/schedule.py
+++ b/querybook/server/logic/schedule.py
@@ -116,7 +116,7 @@ def update_datadoc_schedule_owner(
     if not task_schedule:
         return
 
-    task_schedule.kwargs |= {"user_id": owner_id}
+    task_schedule.kwargs = {**task_schedule.kwargs, "user_id": owner_id}
 
     if commit:
         session.commit()


### PR DESCRIPTION
with operator `|=`,  the id of `task_schedule.kwargs` remains the same, in which case `SQLAlchemy` will treat it as not mutated. 

