### PR TITLE
fix: disable autocomplete for exact keyword matches

### DIFF
--- a/querybook/webapp/lib/sql-helper/sql-autocompleter.ts
+++ b/querybook/webapp/lib/sql-helper/sql-autocompleter.ts
@@ -184,6 +184,14 @@ export class SqlAutoCompleter {
             }
         }
 
+        // If user already has typed the full keyword, dont show the hint
+        if (
+            result.length === 1 &&
+            searchStr.toUpperCase() === result[0].text.toUpperCase()
+        ) {
+            return [];
+        }
+
         return result;
     }
 


### PR DESCRIPTION
for the sql keyword auto completion, when the user already has type the exact keyword, it will still show the hint and it will be selected when user types "enter". Here we're not going to show the hint for this case.