### PR TITLE
fix: Increase CodeMirror hint z-index above modals

### DIFF
--- a/querybook/webapp/components/QueryEditor/QueryEditor.scss
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.scss
@@ -44,7 +44,7 @@
     border: none;
     margin-left: -94px;
     overflow: auto;
-    z-index: 30;
+    z-index: 400;
 
     // New style
     background: var(--bg);


### PR DESCRIPTION
The autocomplete feature in the Query editor currently has a z-index of 30, whereas modals are 300.  This causes issues on the Snippet editor:

![Screen Shot 2022-10-05 at 9 20 12 AM](https://user-images.githubusercontent.com/3084806/194072438-7df5d833-043d-4b35-9f7a-5c92a944d909.png)

This bumps the z-index up to 400 to fix:

![Screen Shot 2022-10-05 at 9 19 47 AM](https://user-images.githubusercontent.com/3084806/194072805-b899192a-3598-4dec-b7aa-8abf8c6a3d07.png)
