### PR TITLE
feat: add formatted transpile view

### DIFF
--- a/querybook/server/lib/query_analysis/transpilation/base_query_transpiler.py
+++ b/querybook/server/lib/query_analysis/transpilation/base_query_transpiler.py
@@ -1,5 +1,14 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Optional, Tuple, TypedDict
+
+
+class TranspiledQuery(TypedDict):
+    transpiled_query: str
+
+    # The original query that's getting transformed
+    # Provide this value if the transpiled query is
+    # getting formatted for better user comparison experience
+    original_query: Optional[str]
 
 
 class BaseQueryTranspiler(ABC):
@@ -16,7 +25,9 @@ class BaseQueryTranspiler(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def transpile(self, query: str, from_language: str, to_language: str):
+    def transpile(
+        self, query: str, from_language: str, to_language: str
+    ) -> Tuple[str, str]:
         raise NotImplementedError()
 
     def to_dict(self):

--- a/querybook/server/lib/query_analysis/transpilation/transpilers/sqlglot_transpiler.py
+++ b/querybook/server/lib/query_analysis/transpilation/transpilers/sqlglot_transpiler.py
@@ -22,6 +22,10 @@ QUERYBOOK_TO_SQLGLOT_LANGUAGE_MAPPING = {
 }
 
 
+def statements_to_query(statements: List[str]):
+    return "\n".join(statement + ";" for statement in statements)
+
+
 class SQLGlotTranspiler(BaseQueryTranspiler):
     def name(self) -> str:
         return "SQLGlotTranspiler"
@@ -33,10 +37,24 @@ class SQLGlotTranspiler(BaseQueryTranspiler):
         return list(QUERYBOOK_TO_SQLGLOT_LANGUAGE_MAPPING.keys())
 
     def transpile(self, query: str, from_language: str, to_language: str):
+        sqlglot_from_language = QUERYBOOK_TO_SQLGLOT_LANGUAGE_MAPPING[from_language]
+        sqlglot_to_language = QUERYBOOK_TO_SQLGLOT_LANGUAGE_MAPPING[to_language]
+
         transpiled_statements = sqlglot.transpile(
             query,
-            read=QUERYBOOK_TO_SQLGLOT_LANGUAGE_MAPPING[from_language],
-            write=QUERYBOOK_TO_SQLGLOT_LANGUAGE_MAPPING[to_language],
+            read=sqlglot_from_language,
+            write=sqlglot_to_language,
             pretty=True,
         )
-        return "\n".join(statement + ";" for statement in transpiled_statements)
+
+        original_formatted_statements = sqlglot.transpile(
+            query,
+            read=sqlglot_from_language,
+            write=sqlglot_from_language,
+            pretty=True,
+        )
+
+        return {
+            "transpiled_query": statements_to_query(transpiled_statements),
+            "original_query": statements_to_query(original_formatted_statements),
+        }

--- a/querybook/webapp/const/queryEngine.ts
+++ b/querybook/webapp/const/queryEngine.ts
@@ -1,3 +1,5 @@
+import { Nullable } from 'lib/typescript';
+
 export interface IQueryEngine {
     id: number;
 
@@ -46,4 +48,9 @@ export interface IQueryTranspiler {
     name: string;
     from_languages: string[];
     to_languages: string[];
+}
+
+export interface ITranspiledQuery {
+    transpiled_query: string;
+    original_query?: Nullable<string>;
 }

--- a/querybook/webapp/resource/queryExecution.ts
+++ b/querybook/webapp/resource/queryExecution.ts
@@ -1,5 +1,5 @@
 import type { IAccessRequest } from 'const/accessRequest';
-import { IQueryTranspiler } from 'const/queryEngine';
+import { IQueryTranspiler, ITranspiledQuery } from 'const/queryEngine';
 import {
     IQueryError,
     IQueryExecution,
@@ -177,7 +177,7 @@ export const TemplatedQueryResource = {
         fromLanguage: string,
         toLanguage: string
     ) =>
-        ds.save<string>(`/query/transpile/${transpiler}/`, {
+        ds.save<ITranspiledQuery>(`/query/transpile/${transpiler}/`, {
             query,
             from_language: fromLanguage,
             to_language: toLanguage,


### PR DESCRIPTION
Now when transpiled with SQLGlot, we would also format the query previously for better comparison view:

Original query: select MAP(ARRAY[ARRAY['foo'], ARRAY['bar']], ARRAY[1, 2]) limit 1000;

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/8283407/194177456-1e587eac-14d3-4198-a922-101cc88398a4.png">
