### PR TITLE
fix: ExecutedQueryCell auto scropll to top during execution

### DIFF
--- a/querybook/webapp/components/QueryExecution/ExecutedQueryCell.tsx
+++ b/querybook/webapp/components/QueryExecution/ExecutedQueryCell.tsx
@@ -28,7 +28,8 @@ export const ExecutedQueryCell: React.FunctionComponent<IProps> = ({
     const queryEngineById = useSelector(queryEngineByIdEnvSelector);
     const highlightRanges = useMemo(
         () => (highlightRange ? [highlightRange] : []),
-        [highlightRange]
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [highlightRange.from, highlightRange.to, highlightRange.className]
     );
 
     if (!queryExecution) {


### PR DESCRIPTION
**Issue**: 
the scroll bar in the "show query" window keeps resetting to its top position when the query is actively running.

**Cause**: 
Although we used `useMemo` for `ThemedCodeHighlightWithMark`'s prop `highlightRanges`, but it depends on `highlightRange`,  which will be recreated every time when passed from its parent, which leads to re-render
```            <ExecutedQueryCell
                queryExecution={queryExecution}
                highlightRange={
                    statementExecution && {
                        from: statementExecution.statement_range_start,
                        to: statementExecution.statement_range_end,
                    }
                }
                changeCellContext={changeCellContext}
            />
```
Another option tried is to memoize this `highlightRange` on its parent component
```
const highlightRange = useMemo(()=>statementExecution && {
                        from: statementExecution.statement_range_start,
                        to: statementExecution.statement_range_end,
                    }, [statementExecution])
```
but the problem is this `statementExecution` will change every time as it gets from below selector, which has a `map` operator to create a new object every time.

```export const makeStatementExecutionsSelector = () =>
    createSelector(
        queryExecutionSelector,
        (state) => state.queryExecutions.statementExecutionById,
        (queryExecution, statementExecutionById) =>
            queryExecution?.statement_executions?.map(
                (id) => statementExecutionById[id]
            ) ?? []
    );
```

**Fix**
So in the end,  we'd like to do a deep compare for `highlightRange` in `ExecutedQueryCell.tsx` to fix it.
