### PR TITLE
fix: codemirror starts with a wrong height

### DIFF
--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -585,6 +585,13 @@ export const QueryEditor: React.FC<
 
         const editorDidMount = useCallback((editor: CodeMirror.Editor) => {
             editorRef.current = editor;
+
+            // There is a strange bug where codemirror would start with the wrong height (on Execs tab)
+            // which can only be solved by clicking on it
+            // The current work around is to add refresh on mount
+            setTimeout(() => {
+                editor.refresh();
+            }, 50);
         }, []);
 
         const onBeforeChange = useCallback(


### PR DESCRIPTION
On the `Execs` tab, the query editor starts with empty, only shows query after clicking it. Forgot to move this over when refactoring from class to functional component. Added it back here.