### PR TITLE
ui: keep the search string when switching the search type

### DIFF
--- a/querybook/webapp/components/Search/SearchOverview.tsx
+++ b/querybook/webapp/components/Search/SearchOverview.tsx
@@ -606,7 +606,7 @@ export const SearchOverview: React.FC<ISearchOverviewProps> = ({
                     {getAuthorFiltersDOM('owner_uid')}
                 </div>
                 <div className="search-filter">
-                    <span className="filter-title">Date</span>
+                    <span className="filter-title">Created At</span>
                     {dateFilterDOM}
                 </div>
             </>
@@ -634,7 +634,7 @@ export const SearchOverview: React.FC<ISearchOverviewProps> = ({
                     </div>
                 </div>
                 <div className="search-filter">
-                    <span className="filter-title">Date</span>
+                    <span className="filter-title">Created At</span>
                     {dateFilterDOM}
                 </div>
                 <div className="search-filter">

--- a/querybook/webapp/redux/search/reducer.ts
+++ b/querybook/webapp/redux/search/reducer.ts
@@ -114,11 +114,10 @@ export default function search(
                     searchFilters: draft.searchFilters,
                 };
 
-                // rehydrate from past state
+                // rehydrate from past state, except for the search string
                 const searchStateForNewType = draft.pastSearchStateByType[
                     action.payload.searchType
                 ] ?? {
-                    searchString: '',
                     searchFilters: {},
                     searchFields:
                         draft.searchType === SearchType.Table
@@ -131,7 +130,6 @@ export default function search(
                 };
 
                 draft.searchType = action.payload.searchType;
-                draft.searchString = searchStateForNewType.searchString;
                 draft.searchFilters = searchStateForNewType.searchFilters;
                 draft.searchFields = searchStateForNewType.searchFields;
                 return;

--- a/querybook/webapp/redux/search/reducer.ts
+++ b/querybook/webapp/redux/search/reducer.ts
@@ -109,7 +109,6 @@ export default function search(
             case '@@search/SEARCH_TYPE_UPDATE': {
                 // Save the current state into past state
                 draft.pastSearchStateByType[draft.searchType] = {
-                    searchString: draft.searchString,
                     searchFields: draft.searchFields,
                     searchFilters: draft.searchFilters,
                 };

--- a/querybook/webapp/redux/search/types.ts
+++ b/querybook/webapp/redux/search/types.ts
@@ -166,7 +166,6 @@ export interface ISearchState extends ISearchPaginationState {
         Record<
             SearchType,
             {
-                searchString: string;
                 searchFilters: Record<string, any>;
                 searchFields: TSearchField;
             }


### PR DESCRIPTION
When switching the search type tab, we'd like to keep the search string the same, to make it the behavior consistent with popular search engines.
![image](https://user-images.githubusercontent.com/8308723/195950502-79b270c1-d147-4d36-ae5b-207fa0b11fcd.png)

Also updated some the date filters for the table and datadoc tab as `Created At` to make it less confused. 