### PR TITLE
fix: QueryComposer additional buttons nested right

### DIFF
--- a/querybook/webapp/components/QueryComposer/QueryComposer.tsx
+++ b/querybook/webapp/components/QueryComposer/QueryComposer.tsx
@@ -685,7 +685,7 @@ const QueryComposer: React.FC = () => {
                     menuIcon="MoreVertical"
                     className="query-cell-additional-dropdown"
                 >
-                    <ListMenu items={additionalButtons} />
+                    <ListMenu items={additionalButtons} isNestedRight={true} />
                 </Dropdown>
                 {templatedModalDOM}
                 {templatedQueryViewModalDOM}


### PR DESCRIPTION
Fixes issues with the Transpile Query submenu appearing under the sidebar.

### Before:
![Screen Shot 2022-10-19 at 2 17 46 PM](https://user-images.githubusercontent.com/3084806/196772909-673ac456-e62b-45da-8ced-67ddd99b4760.png)

### After:
![Screen Shot 2022-10-19 at 2 18 02 PM](https://user-images.githubusercontent.com/3084806/196772922-e841b436-56e5-47e1-be3a-ee995c30dca8.png)
