### PR TITLE
feat: add query engine validation for dag exporter

### DIFF
--- a/docs_website/docs/integrations/add_dag_exporter.md
+++ b/docs_website/docs/integrations/add_dag_exporter.md
@@ -19,9 +19,7 @@ Due to the many ways a workflow app may be configured, it is unlikely that a dag
 Here are some fields of exporter that you must configure in the setup process:
 
 -   DAG_EXPORTER_NAME: This will get displayed on the Querybook website.
--   DAG_EXPORTER_TYPE: There are 2 types of exporters:
-    -   `url`: This is useful when the created workflow can be accessed by a url.
-    -   `text`: This is useful when you want to generate a file for users to create a workflow
+-   DAG_EXPORTER_ENGINES: This is the engine ids that the exporter supports.
 -   DAG_EXPORTER_META: This will be displayed as form for users to set the settings for creating the workflow. Must use one of AllFormField that lives in <project_root>/querybook/server/lib/form/\_\_init\_\_.py.
 -   export(cls, nodes, edges, meta, cell_by_id): This is the actual export function.
 

--- a/querybook/server/datasources/dag_exporter.py
+++ b/querybook/server/datasources/dag_exporter.py
@@ -1,6 +1,6 @@
 from app.auth.permission import verify_data_doc_permission
 from app.datasource import register
-
+from logic.admin import get_query_engines_by_environment
 
 from logic import (
     datadoc as logic,
@@ -25,8 +25,17 @@ def create_or_update_dag_export(id, dag, meta):
 
 
 @register("/dag_exporter/", methods=["GET"])
-def get_dag_exporters():
-    return ALL_DAG_EXPORTERS
+def get_dag_exporters(environment_id: int):
+    """Return dag exporters which supports the given environment"""
+    engines = get_query_engines_by_environment(environment_id)
+    engine_ids = [engine.id for engine in engines]
+
+    exporters = []
+    for dag_exporter in ALL_DAG_EXPORTERS:
+        if not set(engine_ids).isdisjoint(dag_exporter.dag_exporter_engines):
+            exporters.append(dag_exporter)
+
+    return exporters
 
 
 @register("/datadoc/<int:id>/dag_export/export/", methods=["POST"])

--- a/querybook/server/lib/dag_exporter/all_dag_exporter.py
+++ b/querybook/server/lib/dag_exporter/all_dag_exporter.py
@@ -1,5 +1,4 @@
 from lib.utils.import_helper import import_module_with_default
-from .exporters.demo_dag_exporter import DemoDAGExporter
 
 ALL_PLUGIN_DAG_EXPORTERS = import_module_with_default(
     "dag_exporter_plugin",

--- a/querybook/server/lib/dag_exporter/all_dag_exporter.py
+++ b/querybook/server/lib/dag_exporter/all_dag_exporter.py
@@ -1,4 +1,5 @@
 from lib.utils.import_helper import import_module_with_default
+from .exporters.demo_dag_exporter import DemoDAGExporter
 
 ALL_PLUGIN_DAG_EXPORTERS = import_module_with_default(
     "dag_exporter_plugin",
@@ -6,7 +7,7 @@ ALL_PLUGIN_DAG_EXPORTERS = import_module_with_default(
     default=[],
 )
 
-ALL_DAG_EXPORTERS = []
+ALL_DAG_EXPORTERS = [] + ALL_PLUGIN_DAG_EXPORTERS
 
 
 def get_dag_exporter_class(name: str):

--- a/querybook/server/lib/dag_exporter/base_dag_exporter.py
+++ b/querybook/server/lib/dag_exporter/base_dag_exporter.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from logic.admin import get_query_engines_by_ids
 
 
 class BaseDAGExporter(metaclass=ABCMeta):
@@ -7,6 +8,18 @@ class BaseDAGExporter(metaclass=ABCMeta):
     def dag_exporter_name(self) -> str:
         """Name of the dag exporter that will be shown on the frontend"""
         raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def dag_exporter_engines(self) -> list[int]:
+        """Supprted engine ids of the dag exporter"""
+        raise NotImplementedError()
+
+    @property
+    def dag_exporter_engine_names(self) -> list[str]:
+        """Get the supported engine names"""
+        query_engines = get_query_engines_by_ids(self.dag_exporter_engines)
+        return [engine.name for engine in query_engines]
 
     # TODO: update documentation
     @property
@@ -40,5 +53,6 @@ class BaseDAGExporter(metaclass=ABCMeta):
     def to_dict(self):
         return {
             "name": self.dag_exporter_name,
+            "engines": self.dag_exporter_engines,
             "meta": self.dag_exporter_meta,
         }

--- a/querybook/server/lib/dag_exporter/exporters/demo_dag_exporter.py
+++ b/querybook/server/lib/dag_exporter/exporters/demo_dag_exporter.py
@@ -2,7 +2,6 @@ from app.db import with_session
 from lib.dag_exporter.base_dag_exporter import BaseDAGExporter
 from lib.logger import get_logger
 from lib.form import StructFormField, FormField
-from logic.admin import get_query_engine_by_id
 
 import re
 

--- a/querybook/server/logic/admin.py
+++ b/querybook/server/logic/admin.py
@@ -34,6 +34,11 @@ def get_query_engine_by_id(id, session=None):
 
 
 @with_session
+def get_query_engines_by_ids(ids, session=None):
+    return session.query(QueryEngine).filter(QueryEngine.id.in_(ids)).all()
+
+
+@with_session
 def get_all_query_engines(session=None):
     return session.query(QueryEngine).all()
 

--- a/querybook/webapp/components/DataDocDAGExporter/DataDocDAGExporter.scss
+++ b/querybook/webapp/components/DataDocDAGExporter/DataDocDAGExporter.scss
@@ -58,6 +58,11 @@
                         margin-top: 0px;
                     }
                 }
+
+                .DataDocDAGExporterSettings-engines {
+                    list-style: '- ';
+                    margin-left: var(--margin-sm);
+                }
             }
 
             .DataDocDAGExporter-bottom {

--- a/querybook/webapp/components/DataDocDAGExporter/DataDocDAGExporter.scss
+++ b/querybook/webapp/components/DataDocDAGExporter/DataDocDAGExporter.scss
@@ -58,11 +58,6 @@
                         margin-top: 0px;
                     }
                 }
-
-                .DataDocDAGExporterSettings-engines {
-                    list-style: '- ';
-                    margin-left: var(--margin-sm);
-                }
             }
 
             .DataDocDAGExporter-bottom {

--- a/querybook/webapp/components/DataDocDAGExporter/DataDocDAGExporterListItem.tsx
+++ b/querybook/webapp/components/DataDocDAGExporter/DataDocDAGExporterListItem.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useDrag } from 'react-dnd';
 
 import { IDataQueryCell } from 'const/datadoc';
 import { IQueryEngine } from 'const/queryEngine';
+import { DataDocDAGExporterContext } from 'context/DataDocDAGExporter';
 import { getQueryKeywords } from 'lib/sql-helper/sql-lexer';
 import { generateFormattedDate } from 'lib/utils/datetime';
 import NOOP from 'lib/utils/noop';
 import { ThemedCodeHighlight } from 'ui/CodeHighlight/ThemedCodeHighlight';
+import { Icon } from 'ui/Icon/Icon';
 import { Popover } from 'ui/Popover/Popover';
 import { PopoverHoverWrapper } from 'ui/Popover/PopoverHoverWrapper';
 import { AccentText, StyledText } from 'ui/StyledText/StyledText';
@@ -22,6 +24,11 @@ export interface IDataDocDAGExporterListItemProps {
 export const DataDocDAGExporterListItem =
     React.memo<IDataDocDAGExporterListItemProps>(
         ({ queryCell, queryEngineById }) => {
+            const { isEngineSupported } = useContext(DataDocDAGExporterContext);
+            const queryEngineName = queryEngineById[queryCell.meta.engine].name;
+
+            const engineSupported = isEngineSupported(queryCell.meta.engine);
+
             const [, drag] = useDrag({
                 type: queryCellDraggableType,
                 item: {
@@ -46,13 +53,18 @@ export const DataDocDAGExporterListItem =
                                             queryCell.created_at
                                         )}
                                     </StyledText>
-                                    <Tag mini light>
-                                        {
-                                            queryEngineById[
-                                                queryCell.meta.engine
-                                            ].name
-                                        }
-                                    </Tag>
+                                    <div className="flex-left">
+                                        <Tag mini light>
+                                            {queryEngineName}
+                                        </Tag>
+                                        {!engineSupported && (
+                                            <Icon
+                                                name="AlertCircle"
+                                                size={16}
+                                                color="false"
+                                            />
+                                        )}
+                                    </div>
                                 </div>
                                 <div className="DataDocDagExporterListItem-title mb4">
                                     {queryCell.meta.title ? (
@@ -80,6 +92,23 @@ export const DataDocDAGExporterListItem =
                                         anchor={anchorElement}
                                         layout={['right', 'top']}
                                     >
+                                        {!engineSupported && (
+                                            <div className="flex-left mb8">
+                                                <Icon
+                                                    name="AlertCircle"
+                                                    size={16}
+                                                    color="false"
+                                                    className="mr4"
+                                                />
+                                                <AccentText
+                                                    color="accent"
+                                                    size="small"
+                                                >
+                                                    Selected exporter doesn't
+                                                    support this query engine
+                                                </AccentText>
+                                            </div>
+                                        )}
                                         <ThemedCodeHighlight
                                             value={queryCell.context}
                                         />

--- a/querybook/webapp/components/DataDocDAGExporter/DataDocDAGExporterListItem.tsx
+++ b/querybook/webapp/components/DataDocDAGExporter/DataDocDAGExporterListItem.tsx
@@ -101,7 +101,7 @@ export const DataDocDAGExporterListItem =
                                                     className="mr4"
                                                 />
                                                 <AccentText
-                                                    color="accent"
+                                                    color="text"
                                                     size="small"
                                                 >
                                                     Selected exporter doesn't

--- a/querybook/webapp/components/DataDocDAGExporter/DataDocDAGExporterSettings.tsx
+++ b/querybook/webapp/components/DataDocDAGExporter/DataDocDAGExporterSettings.tsx
@@ -11,6 +11,7 @@ import { Button } from 'ui/Button/Button';
 import { FormField, FormSectionHeader } from 'ui/Form/FormField';
 import { SimpleReactSelect } from 'ui/SimpleReactSelect/SimpleReactSelect';
 import { SmartForm } from 'ui/SmartForm/SmartForm';
+import { Tag } from 'ui/Tag/Tag';
 import { ToggleSwitch } from 'ui/ToggleSwitch/ToggleSwitch';
 
 interface IProps {
@@ -47,11 +48,13 @@ export const DataDocDAGExporterSettings: React.FunctionComponent<IProps> = ({
     );
 
     const enginesDOM = exporterEngines && (
-        <ul className="DataDocDAGExporterSettings-engines">
+        <div>
             {exporterEngines.map((engineId) => (
-                <li key={engineId}>{queryEngineById[engineId].name}</li>
+                <Tag key={engineId} mini>
+                    {queryEngineById[engineId].name}
+                </Tag>
             ))}
-        </ul>
+        </div>
     );
 
     return (

--- a/querybook/webapp/components/DataDocDAGExporter/DataDocDAGExporterSettings.tsx
+++ b/querybook/webapp/components/DataDocDAGExporter/DataDocDAGExporterSettings.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import toast from 'react-hot-toast';
+import { useSelector } from 'react-redux';
 
 import { IDataDocDAGExportMeta } from 'const/datadoc';
 import { useExporterSettings } from 'hooks/dag/useExporterSettings';
 import { titleize } from 'lib/utils';
+import { IStoreState } from 'redux/store/types';
 import { AsyncButton } from 'ui/AsyncButton/AsyncButton';
 import { Button } from 'ui/Button/Button';
 import { FormField, FormSectionHeader } from 'ui/Form/FormField';
@@ -12,12 +14,14 @@ import { SmartForm } from 'ui/SmartForm/SmartForm';
 import { ToggleSwitch } from 'ui/ToggleSwitch/ToggleSwitch';
 
 interface IProps {
+    docId: number;
     onExport: (name: string, settings: any) => Promise<any>;
     savedMeta: IDataDocDAGExportMeta;
     onSave: (meta: any, useTemplatedVariables?: boolean) => Promise<any>;
 }
 
 export const DataDocDAGExporterSettings: React.FunctionComponent<IProps> = ({
+    docId,
     onExport,
     savedMeta,
     onSave,
@@ -27,14 +31,27 @@ export const DataDocDAGExporterSettings: React.FunctionComponent<IProps> = ({
         selectedExporter,
         setSelectedExporter,
         settingValues,
+        exporterEngines,
         exporterMeta,
         handleSettingValuesChange,
         useTemplatedVariables,
-    } = useExporterSettings({ savedMeta });
+    } = useExporterSettings({ docId, savedMeta });
+
+    const queryEngineById = useSelector(
+        (state: IStoreState) => state.queryEngine.queryEngineById
+    );
 
     const handleExport = React.useCallback(
         () => onExport(selectedExporter, settingValues),
         [onExport, selectedExporter, settingValues]
+    );
+
+    const enginesDOM = exporterEngines && (
+        <ul className="DataDocDAGExporterSettings-engines">
+            {exporterEngines.map((engineId) => (
+                <li key={engineId}>{queryEngineById[engineId].name}</li>
+            ))}
+        </ul>
     );
 
     return (
@@ -55,6 +72,8 @@ export const DataDocDAGExporterSettings: React.FunctionComponent<IProps> = ({
                     value={selectedExporter}
                     onChange={setSelectedExporter}
                 />
+                <FormSectionHeader>Query Engines Supported</FormSectionHeader>
+                {enginesDOM}
                 <FormSectionHeader>Settings</FormSectionHeader>
                 {exporterMeta && settingValues && (
                     <SmartForm

--- a/querybook/webapp/components/DataDocRightSidebar/DataDocRightSidebar.tsx
+++ b/querybook/webapp/components/DataDocRightSidebar/DataDocRightSidebar.tsx
@@ -142,6 +142,9 @@ export const DataDocRightSidebar: React.FunctionComponent<IProps> = ({
 
 function useExporterExists() {
     const dispatch = useDispatch();
+    const currentEnvironmentId = useSelector(
+        (state: IStoreState) => state.environment.currentEnvironmentId
+    );
     const exporterDataByName = useSelector(
         (state: IStoreState) => state.dataDoc.dagExporterDataByName
     );
@@ -151,11 +154,8 @@ function useExporterExists() {
     );
 
     React.useEffect(() => {
-        if (exporterNames.length === 0) {
-            dispatch(fetchDAGExporters());
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+        dispatch(fetchDAGExporters(currentEnvironmentId));
+    }, [dispatch, currentEnvironmentId]);
 
     const exporterExists = exporterNames.length > 0;
 

--- a/querybook/webapp/const/datadoc.ts
+++ b/querybook/webapp/const/datadoc.ts
@@ -91,7 +91,13 @@ export interface IDataDocDAGExportMeta {
     };
     useTemplatedVariables?: boolean;
 }
+
 export interface IDataDocDAGExport {
+    selectedExporter?: string;
+    savedDAGExport?: IDataDocSavedDAGExport;
+}
+
+export interface IDataDocSavedDAGExport {
     id: number;
     data_doc_id: number;
 
@@ -104,5 +110,6 @@ export interface IDataDocDAGExport {
 
 export interface IDataDocDAGExporter {
     name: string;
+    engines: number[];
     meta: IFormField | IStructFormField | IExpandableFormField;
 }

--- a/querybook/webapp/context/DataDocDAGExporter.ts
+++ b/querybook/webapp/context/DataDocDAGExporter.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { IDataDocDAGExporter } from 'const/datadoc';
+
+export interface IDataDocDAGExporterContextType {
+    docId: number;
+    currentExporter: IDataDocDAGExporter;
+
+    isEngineSupported: (engineId: number) => boolean;
+}
+
+export const DataDocDAGExporterContext =
+    React.createContext<IDataDocDAGExporterContextType>(null);

--- a/querybook/webapp/hooks/dag/useExporterDAG.ts
+++ b/querybook/webapp/hooks/dag/useExporterDAG.ts
@@ -73,11 +73,10 @@ export function useExporterDAG(
             id: cell.id.toString(),
             type: queryCellNode,
             data: {
-                label: cell.meta?.title,
+                queryCell: cell,
                 updated:
                     savedNode?.data?.queryHash &&
                     isQueryUpdated(savedNode?.data?.queryHash, cell.context),
-                query: cell.context,
             },
             position: savedNode?.position ?? initialNodePosition,
             sourcePosition: savedNode.sourcePosition ?? sourcePosition,

--- a/querybook/webapp/hooks/dag/useSavedDAG.ts
+++ b/querybook/webapp/hooks/dag/useSavedDAG.ts
@@ -10,7 +10,8 @@ export function useSavedDAG(docId: number) {
     const dispatch: Dispatch = useDispatch();
 
     const savedDAGExport = useSelector(
-        (state: IStoreState) => state.dataDoc.dagExportByDocId[docId]
+        (state: IStoreState) =>
+            state.dataDoc.dagExportByDocId[docId]?.savedDAGExport
     );
 
     React.useEffect(() => {
@@ -41,7 +42,7 @@ export function useSavedDAG(docId: number) {
                 id: node.id,
                 position: node.position,
                 data: {
-                    queryHash: hashString(node.data.query),
+                    queryHash: hashString(node.data.queryCell.context),
                 },
                 sourcePosition: node.sourcePosition,
                 targetPosition: node.targetPosition,

--- a/querybook/webapp/redux/dataDoc/action.ts
+++ b/querybook/webapp/redux/dataDoc/action.ts
@@ -10,9 +10,9 @@ import {
     IDataCell,
     IDataCellMeta,
     IDataDoc,
-    IDataDocDAGExport,
     IDataDocDAGExporter,
     IDataDocEditor,
+    IDataDocSavedDAGExport,
     IDataTextCell,
     IRawDataDoc,
 } from 'const/datadoc';
@@ -37,6 +37,7 @@ import {
     IReceiveDataDocAction,
     IReceiveDataDocDAGExportAction,
     IReceiveDataDocDAGExportersAction,
+    IReceiveDataDocDAGExporterSelectionAction,
     IReceiveDataDocsAction,
     ISaveDataDocEndAction,
     ISaveDataDocStartAction,
@@ -672,9 +673,22 @@ export function saveDAGExport(
     };
 }
 
+export function selectDAGExporter(
+    docId: number,
+    exporterName: string
+): IReceiveDataDocDAGExporterSelectionAction {
+    return {
+        type: '@@dataDoc/RECEIVE_DATA_DOC_DAG_EXPORTER_SELECTION',
+        payload: {
+            docId,
+            exporterName,
+        },
+    };
+}
+
 export function receiveDAGExport(
     docId: number,
-    DAGExport: IDataDocDAGExport
+    DAGExport: IDataDocSavedDAGExport
 ): IReceiveDataDocDAGExportAction {
     return {
         type: '@@dataDoc/RECEIVE_DATA_DOC_DAG_EXPORT',
@@ -685,9 +699,11 @@ export function receiveDAGExport(
     };
 }
 
-export function fetchDAGExporters(): ThunkResult<Promise<void>> {
+export function fetchDAGExporters(envId: number): ThunkResult<Promise<void>> {
     return async (dispatch) => {
-        const { data: exporters } = await DataDocResource.getDAGExporters();
+        const { data: exporters } = await DataDocResource.getDAGExporters(
+            envId
+        );
 
         dispatch(receiveDAGExporters(exporters));
     };

--- a/querybook/webapp/redux/dataDoc/reducer.ts
+++ b/querybook/webapp/redux/dataDoc/reducer.ts
@@ -448,8 +448,21 @@ function dagExportByDocIdReducer(
 ) {
     return produce(state, (draft) => {
         switch (action.type) {
+            case '@@dataDoc/RECEIVE_DATA_DOC_DAG_EXPORTER_SELECTION': {
+                if (!(action.payload.docId in draft)) {
+                    draft[action.payload.docId] = {};
+                }
+                draft[action.payload.docId].selectedExporter =
+                    action.payload.exporterName;
+                return;
+            }
+
             case '@@dataDoc/RECEIVE_DATA_DOC_DAG_EXPORT': {
-                draft[action.payload.docId] = action.payload.DAGExport;
+                if (!(action.payload.docId in draft)) {
+                    draft[action.payload.docId] = {};
+                }
+                draft[action.payload.docId].savedDAGExport =
+                    action.payload.DAGExport;
                 return;
             }
         }
@@ -457,16 +470,17 @@ function dagExportByDocIdReducer(
 }
 
 function dagExporterDataByNameReducer(
-    state = initialState.dagExportByDocId,
+    state = initialState.dagExporterDataByName,
     action: DataDocAction
 ) {
     return produce(state, (draft) => {
         switch (action.type) {
             case '@@dataDoc/RECEIVE_DATA_DOC_EXPORTERS': {
+                draft = {};
                 action.payload.exporters.forEach((exporter) => {
                     draft[exporter.name] = exporter;
                 });
-                return;
+                return draft;
             }
         }
     });

--- a/querybook/webapp/redux/dataDoc/types.ts
+++ b/querybook/webapp/redux/dataDoc/types.ts
@@ -13,6 +13,7 @@ import {
     IDataDocDAGExport,
     IDataDocDAGExporter,
     IDataDocEditor,
+    IDataDocSavedDAGExport,
     IRawDataDoc,
 } from 'const/datadoc';
 
@@ -248,11 +249,19 @@ export interface IMoveDataDocCursor extends Action {
     };
 }
 
+export interface IReceiveDataDocDAGExporterSelectionAction extends Action {
+    type: '@@dataDoc/RECEIVE_DATA_DOC_DAG_EXPORTER_SELECTION';
+    payload: {
+        docId: number;
+        exporterName: string;
+    };
+}
+
 export interface IReceiveDataDocDAGExportAction extends Action {
     type: '@@dataDoc/RECEIVE_DATA_DOC_DAG_EXPORT';
     payload: {
         docId: number;
-        DAGExport: IDataDocDAGExport;
+        DAGExport: IDataDocSavedDAGExport;
     };
 }
 export interface IReceiveDataDocDAGExportersAction extends Action {
@@ -290,6 +299,7 @@ export type DataDocAction =
     | IReceiveDataDocAccessRequestAction
     | IRemoveDataDocAccessRequestAction
     | IMoveDataDocCursor
+    | IReceiveDataDocDAGExporterSelectionAction
     | IReceiveDataDocDAGExportAction
     | IReceiveDataDocDAGExportersAction;
 

--- a/querybook/webapp/resource/dataDoc.ts
+++ b/querybook/webapp/resource/dataDoc.ts
@@ -4,9 +4,9 @@ import { IAccessRequest } from 'const/accessRequest';
 import type {
     IDataCell,
     IDataCellMeta,
-    IDataDocDAGExport,
     IDataDocDAGExporter,
     IDataDocEditor,
+    IDataDocSavedDAGExport,
     IRawDataDoc,
 } from 'const/datadoc';
 import type {
@@ -102,17 +102,20 @@ export const DataDocResource = {
     unfavorite: (docId: number) => ds.delete(`/favorite_data_doc/${docId}/`),
 
     getDAGExport: (docId: number) =>
-        ds.fetch<IDataDocDAGExport>(`/datadoc/${docId}/dag_export/`),
+        ds.fetch<IDataDocSavedDAGExport>(`/datadoc/${docId}/dag_export/`),
     saveDAGExport: (
         docId: number,
         dag: Record<string, Node[] | Edge[]>,
         meta: Record<string, any>
     ) =>
-        ds.update<IDataDocDAGExport>(`/datadoc/${docId}/dag_export/`, {
+        ds.update<IDataDocSavedDAGExport>(`/datadoc/${docId}/dag_export/`, {
             dag,
             meta,
         }),
-    getDAGExporters: () => ds.fetch<IDataDocDAGExporter[]>(`/dag_exporter/`),
+    getDAGExporters: (envId: number) =>
+        ds.fetch<IDataDocDAGExporter[]>(`/dag_exporter/`, {
+            environment_id: envId,
+        }),
     exportDAG: (docId: number, exporterName: string) =>
         ds.save<string>(`/datadoc/${docId}/dag_export/export/`, {
             exporter_name: exporterName,

--- a/querybook/webapp/ui/FlowGraph/QueryCellNode.scss
+++ b/querybook/webapp/ui/FlowGraph/QueryCellNode.scss
@@ -27,6 +27,12 @@
         }
     }
 
+    .QueryCellNode-tag {
+        padding: 0;
+        margin-right: 4px;
+        font-size: var(--xxxsmall-text-size);
+    }
+
     .QueryCellNode-label {
         cursor: grab;
     }

--- a/querybook/webapp/ui/FlowGraph/QueryCellNode.scss
+++ b/querybook/webapp/ui/FlowGraph/QueryCellNode.scss
@@ -11,7 +11,7 @@
     }
 
     &.selected {
-        border: 1px solid var(--color-accent-light);
+        background-color: var(--color-accent-lightest);
     }
 
     .QueryCellNode-toolbar {
@@ -31,6 +31,7 @@
         padding: 0;
         margin-right: 4px;
         font-size: var(--xxxsmall-text-size);
+        background-color: transparent;
     }
 
     .QueryCellNode-label {


### PR DESCRIPTION
Add query engine validation on both client and server side
 - display supported engine list on the settings panel
 - add warning icons for cells with unsupported engines
 - return error if there is any engine unsupported when exporting

left bar with query cells
![image](https://user-images.githubusercontent.com/8308723/197262273-de0d7338-7057-4239-91ce-96145609374a.png)

query cell node
![image](https://user-images.githubusercontent.com/8308723/196828728-c1a130b7-fe3b-46c2-9232-ab463753a550.png)

query engines
![Snip20221021_50](https://user-images.githubusercontent.com/8308723/197262181-c9f3b8f0-6209-4d4f-9437-18e7f463d952.png)

export result error
![image](https://user-images.githubusercontent.com/8308723/196828784-f4431522-9a56-41fc-b15c-f934e0101c0c.png)
