### PR TITLE
fix: template variable type change and big numbers

### DIFF
--- a/querybook/webapp/components/DataDocTemplateButton/DataDocTemplateVarForm.tsx
+++ b/querybook/webapp/components/DataDocTemplateButton/DataDocTemplateVarForm.tsx
@@ -8,6 +8,7 @@ import { IconButton } from 'ui/Button/IconButton';
 import { SimpleField } from 'ui/FormikField/SimpleField';
 
 import {
+    getVariableValueByType,
     detectVariableType,
     SUPPORTED_TYPES,
     TTemplateVariableDict,
@@ -71,17 +72,6 @@ export const DataDocTemplateVarForm: React.FunctionComponent<
         [defaultTemplatedVariables, templatedVariables]
     );
 
-    const getValueByType = (value, valueType) => {
-        if (value !== null) {
-            if (valueType === 'number') {
-                value = Number(value);
-            } else if (valueType === 'string') {
-                value = value.toString();
-            }
-        }
-        return value;
-    };
-
     return (
         <Formik
             enableReinitialize
@@ -90,7 +80,7 @@ export const DataDocTemplateVarForm: React.FunctionComponent<
             onSubmit={({ variables }) =>
                 onSave(
                     variables.reduce((hash, { name, valueType, value }) => {
-                        hash[name] = getValueByType(value, valueType);
+                        hash[name] = getVariableValueByType(value, valueType);
                         return hash;
                     }, {})
                 )

--- a/querybook/webapp/components/DataDocTemplateButton/DataDocTemplateVarForm.tsx
+++ b/querybook/webapp/components/DataDocTemplateButton/DataDocTemplateVarForm.tsx
@@ -51,6 +51,18 @@ export const DataDocTemplateVarForm: React.FunctionComponent<
         }),
         [defaultTemplatedVariables, templatedVariables]
     );
+
+    const getValueByType = (value, valueType) => {
+        if (value !== null) {
+            if (valueType === 'number') {
+                value = Number(value);
+            } else if (valueType === 'string') {
+                value = value.toString();
+            }
+        }
+        return value;
+    };
+
     return (
         <Formik
             enableReinitialize
@@ -58,8 +70,8 @@ export const DataDocTemplateVarForm: React.FunctionComponent<
             initialValues={initialValue}
             onSubmit={({ variables }) =>
                 onSave(
-                    variables.reduce((hash, [name, _, value]) => {
-                        hash[name] = value;
+                    variables.reduce((hash, [name, valueType, value]) => {
+                        hash[name] = getValueByType(value, valueType);
                         return hash;
                     }, {})
                 )

--- a/querybook/webapp/components/DataDocTemplateButton/DataDocTemplateVarForm.tsx
+++ b/querybook/webapp/components/DataDocTemplateButton/DataDocTemplateVarForm.tsx
@@ -96,15 +96,7 @@ export const DataDocTemplateVarForm: React.FunctionComponent<
                 )
             }
         >
-            {({
-                handleSubmit,
-                isSubmitting,
-                isValid,
-                values,
-                dirty,
-                errors,
-                touched,
-            }) => {
+            {({ handleSubmit, isSubmitting, isValid, values, dirty }) => {
                 const variablesField = (
                     <FieldArray
                         name="variables"

--- a/querybook/webapp/components/DataDocTemplateButton/helpers.ts
+++ b/querybook/webapp/components/DataDocTemplateButton/helpers.ts
@@ -15,3 +15,17 @@ export function detectVariableType(value: any): TSupportedTypes {
     }
     return 'string';
 }
+
+export function getVariableValueByType(
+    value: any,
+    valueType: TSupportedTypes
+): any {
+    if (value !== null) {
+        if (valueType === 'number') {
+            value = Number(value);
+        } else if (valueType === 'string') {
+            value = value.toString();
+        }
+    }
+    return value;
+}


### PR DESCRIPTION
**Issue**
1. when changing the var type from string to number or vice versa, the type will actually not get updated after refreshing the page.
2. for number type with really big values, it will be rounded

**Cause**
1. when only changing the `valueType`, but not update the value field, the value field will not get re-rendered so that the value will not be re-evaluated. So when clicking save, it will still have the old type.
2. The maximum number Javascript supports is `Number.MAX_SAFE_INTEGER` (2^53-1 )

**Fix**
* evaluate the value according to the type when saving
* update the `Yup` shcema validation for numbers bigger than `Number.MAX_SAFE_INTEGER`  to ask user to use string type instead
* use `SimpleField` with `type={'input'}` for both `string` and `number` type. 
  * The reason of this change is currently `number` type is using `NumberInput` and it will do a conversion from string to number `onChange(value === '' ? null : Number(value));` , which will result in the rounding issue when user input a big number first and then change the type to string. 

![Snip20221020_49](https://user-images.githubusercontent.com/8308723/197087762-655a488e-6e24-472f-98a7-622d82cb5aa3.png)
