### PR TITLE
fix: Wrap or truncate long column types

### DIFF
--- a/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.scss
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.scss
@@ -9,10 +9,12 @@
             .DataTableColumnCard-left {
                 display: flex;
                 flex-direction: row;
-                align-items: baseline;
+                align-items: center;
+                max-width: 95%;
 
                 .column-type {
                     min-width: 80px;
+                    word-break: break-all;
                 }
             }
         }

--- a/querybook/webapp/components/DataTableViewMini/TablePanelView.tsx
+++ b/querybook/webapp/components/DataTableViewMini/TablePanelView.tsx
@@ -142,6 +142,9 @@ const StyledColumnRow = styled.div<IStyledColumnRowProps>`
         font-size: var(--xxsmall-text-size);
         color: var(--text-light);
         white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 50%;
     }
 
     ${({ selected }) =>


### PR DESCRIPTION
We use lots of long struct types, which cause some display problems.  This PR includes two fixes: 

1. In the table sidebar, long types are truncated, since users can click to view the full type in the ColumnPanelView:

![Screen Shot 2022-11-04 at 9 48 40 AM](https://user-images.githubusercontent.com/3084806/200003453-23baf316-d4da-4f99-bf27-0a1abf2d888e.png) ![Screen Shot 2022-11-04 at 9 48 47 AM](https://user-images.githubusercontent.com/3084806/200003493-846d0ac9-a2e5-40cd-9ffb-4d487fde5fc7.png)

2. In the Column tab of the table view, long types are wrapped so the entire contents can be veiwed:

![Screen Shot 2022-11-04 at 9 49 13 AM](https://user-images.githubusercontent.com/3084806/200003738-36584417-9aae-4a5a-801a-b5547eec5233.png) ![Screen Shot 2022-11-04 at 10 46 39 AM](https://user-images.githubusercontent.com/3084806/200003837-32de11a4-6f65-422e-91e9-8d3d45aace49.png)
