### PR TITLE
feat: Visualize complex Hive column types

### DIFF
--- a/querybook/webapp/__tests__/lib/utils/complex-types.test.ts
+++ b/querybook/webapp/__tests__/lib/utils/complex-types.test.ts
@@ -1,0 +1,79 @@
+import { parseType } from 'lib/utils/complex-types';
+
+test('parseType', () => {
+    expect(
+        parseType(
+            'struct<date:struct<year:int,month:int,day:int>,hour:int,minute:int,second:int,timeZoneId:string>'
+        )
+    ).toEqual({
+        date: {
+            year: 'int',
+            month: 'int',
+            day: 'int',
+        },
+        hour: 'int',
+        minute: 'int',
+        second: 'int',
+        timeZoneId: 'string',
+    });
+
+    expect(
+        parseType(
+            'array<struct<size:struct<width:int,height:int,isAspectRatio:boolean>>>'
+        )
+    ).toEqual([
+        {
+            size: {
+                width: 'int',
+                height: 'int',
+                isAspectRatio: 'boolean',
+            },
+        },
+    ]);
+
+    expect(
+        parseType(
+            'struct<purchasePath:string,resultToken:string,sessionId:string,site:struct<eapid:bigint,tpid:bigint>,tests:array<struct<bucketValue:string,experimentId:string,instanceId:string>>,user:struct<guid:string,tuid:string>>'
+        )
+    ).toEqual({
+        purchasePath: 'string',
+        resultToken: 'string',
+        sessionId: 'string',
+        site: {
+            eapid: 'bigint',
+            tpid: 'bigint',
+        },
+        tests: [
+            {
+                bucketValue: 'string',
+                experimentId: 'string',
+                instanceId: 'string',
+            },
+        ],
+        user: {
+            guid: 'string',
+            tuid: 'string',
+        },
+    });
+
+    expect(parseType('map<string,string>')).toEqual({
+        key: 'string',
+        value: 'string',
+    });
+
+    expect(
+        parseType(
+            'map<string,uniontype<string,int,bigint,float,double,struct<year:int,month:int,day:int>>>'
+        )
+    ).toEqual({
+        key: 'string',
+        value: [
+            'string',
+            'int',
+            'bigint',
+            'float',
+            'double',
+            { year: 'int', month: 'int', day: 'int' },
+        ],
+    });
+});

--- a/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.tsx
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.tsx
@@ -3,9 +3,11 @@ import * as React from 'react';
 
 import { DataTableColumnStats } from 'components/DataTableStats/DataTableColumnStats';
 import { IDataColumn } from 'const/metastore';
+import { parseType } from 'lib/utils/complex-types';
 import { Card } from 'ui/Card/Card';
 import { EditableTextField } from 'ui/EditableTextField/EditableTextField';
 import { Icon } from 'ui/Icon/Icon';
+import { Json } from 'ui/Json/Json';
 import { KeyContentDisplay } from 'ui/KeyContentDisplay/KeyContentDisplay';
 import { AccentText, StyledText } from 'ui/StyledText/StyledText';
 
@@ -31,6 +33,9 @@ export const DataTableColumnCard: React.FunctionComponent<IProps> = ({
             onSave={updateDataColumnDescription.bind(null, column.id)}
         />
     );
+
+    const parsedType = parseType(column.type);
+
     return (
         <div className="DataTableColumnCard">
             <Card key={column.id} alignLeft>
@@ -56,6 +61,13 @@ export const DataTableColumnCard: React.FunctionComponent<IProps> = ({
                             <KeyContentDisplay keyString="Definition">
                                 {column.comment}
                             </KeyContentDisplay>
+                        )}
+                        {parsedType !== column.type && (
+                            <>
+                                <KeyContentDisplay keyString="Complex Type">
+                                    <Json json={parsedType} />
+                                </KeyContentDisplay>
+                            </>
                         )}
                         <KeyContentDisplay keyString="User Comments">
                             {userCommentsContent}

--- a/querybook/webapp/components/DataTableViewMini/ColumnPanelView.tsx
+++ b/querybook/webapp/components/DataTableViewMini/ColumnPanelView.tsx
@@ -2,7 +2,9 @@ import { ContentState } from 'draft-js';
 import React from 'react';
 import { useSelector } from 'react-redux';
 
+import { parseType } from 'lib/utils/complex-types';
 import { IStoreState } from 'redux/store/types';
+import { Json } from 'ui/Json/Json';
 
 import { PanelSection, SubPanelSection } from './PanelSection';
 
@@ -18,6 +20,8 @@ export const ColumnPanelView: React.FunctionComponent<
     const column = useSelector(
         (state: IStoreState) => state.dataSources.dataColumnsById[columnId]
     );
+
+    const parsedType = parseType(column.type);
 
     const overviewPanel = (
         <PanelSection title="column">
@@ -39,11 +43,19 @@ export const ColumnPanelView: React.FunctionComponent<
         <PanelSection title="type info">{typeInfo}</PanelSection>
     ) : null;
 
+    const complexTypePanel =
+        parsedType !== column.type ? (
+            <PanelSection title="complex type">
+                <Json json={parsedType} />
+            </PanelSection>
+        ) : null;
+
     return (
         <>
             {overviewPanel}
             {descriptionPanel}
             {typeInfoPanel}
+            {complexTypePanel}
         </>
     );
 };

--- a/querybook/webapp/lib/query-result/transformer.tsx
+++ b/querybook/webapp/lib/query-result/transformer.tsx
@@ -1,6 +1,5 @@
 import JSONBig from 'json-bigint';
 import React from 'react';
-import ReactJson, { ThemeObject } from 'react-json-view';
 
 import {
     formatNumber,
@@ -8,30 +7,12 @@ import {
     isNumeric,
     roundNumberToDecimal,
 } from 'lib/utils/number';
+import { Json } from 'ui/Json/Json';
 import { Link } from 'ui/Link/Link';
 
 import { IColumnTransformer } from './types';
 
 const JSONBigString = JSONBig({ storeAsString: true });
-
-const ReactJsonTheme: ThemeObject = {
-    base00: 'transparent', // background
-    base01: 'var(--text)', // not used
-    base02: 'var(--color-accent-dark)', // vertical lines, null value frame
-    base03: 'var(--text)', // not used
-    base04: 'var(--text-light)', // number of items
-    base05: 'var(--text)', // not used
-    base06: 'var(--text)', // not used
-    base07: 'var(--color-accent-dark)', // struct keys, curly brackets, colon
-    base08: 'var(--text)', // not used
-    base09: 'var(--text)', // string value, ellipsis
-    base0A: 'var(--color-accent-lightest)', // null value text
-    base0B: 'var(--text)', // not used
-    base0C: 'var(--color-accent-dark)', // array indices
-    base0D: 'var(--color-accent-dark)', // collapse
-    base0E: 'var(--color-accent-dark)', // expand
-    base0F: 'var(--text)', // int value
-};
 
 const queryResultTransformers: IColumnTransformer[] = [
     {
@@ -104,17 +85,7 @@ const queryResultTransformers: IColumnTransformer[] = [
                 if (!json || typeof json !== 'object') {
                     return v;
                 }
-                return (
-                    <ReactJson
-                        collapsed={1} // keep first level expanded by default
-                        displayDataTypes={false}
-                        enableClipboard={false}
-                        name={false}
-                        quotesOnKeys={false}
-                        src={json}
-                        theme={ReactJsonTheme}
-                    />
-                );
+                return <Json json={json} />;
             } catch (e) {
                 console.error(e);
                 return v;

--- a/querybook/webapp/lib/utils/complex-types.ts
+++ b/querybook/webapp/lib/utils/complex-types.ts
@@ -1,0 +1,153 @@
+/**
+ * Convert a complex Hive type string to a nested JSON object
+ *
+ * Example: 'struct<date:struct<year:int,month:int,day:int>,hour:int,minute:int,second:int,timeZoneId:string>'
+ * Output: {
+        date: {
+            year: 'int',
+            month: 'int',
+            day: 'int',
+        },
+        hour: 'int',
+        minute: 'int',
+        second: 'int',
+        timeZoneId: 'string',
+    }
+ */
+export function parseType(type: string): any | string {
+    if (type.startsWith('struct<')) {
+        return parseStructType(type);
+    } else if (type.startsWith('array<')) {
+        return parseArrayType(type);
+    } else if (type.startsWith('map<')) {
+        return parseMapType(type);
+    } else if (type.startsWith('uniontype<')) {
+        return parseUnionType(type);
+    } else {
+        return type;
+    }
+}
+
+export function parseStructType(type: string): Record<string, any> | string {
+    const structRegex = /struct<(.*)>/;
+    const structMatch = type.match(structRegex);
+    if (!structMatch) {
+        return type;
+    }
+
+    const structStr = structMatch[1];
+    const structObj: Record<string, any> = {};
+    let currentKey = '';
+    let currentVal = '';
+    let depth = 0;
+
+    for (const char of structStr) {
+        if (char === ':') {
+            if (depth > 0) {
+                currentVal += char;
+            } else {
+                currentKey = currentVal;
+                currentVal = '';
+            }
+        } else if (char === ',') {
+            if (depth === 0) {
+                structObj[currentKey] = parseType(currentVal);
+                currentKey = '';
+                currentVal = '';
+            } else {
+                currentVal += char;
+            }
+        } else if (char === '<') {
+            depth += 1;
+            currentVal += char;
+        } else if (char === '>') {
+            depth -= 1;
+            currentVal += char;
+        } else {
+            currentVal += char;
+        }
+    }
+
+    structObj[currentKey] = parseType(currentVal);
+    return structObj;
+}
+
+export function parseMapType(type: string): Record<string, any> | string {
+    const mapRegex = /map<(.*)>/;
+    const mapMatch = type.match(mapRegex);
+    if (!mapMatch) {
+        return type;
+    }
+
+    const mapStr = mapMatch[1];
+    const mapObj: Record<string, any> = {};
+    let currentKey = '';
+    let currentVal = '';
+    let depth = 0;
+
+    for (const char of mapStr) {
+        if (char === ',') {
+            if (depth > 0) {
+                currentVal += char;
+            } else {
+                currentKey = currentVal;
+                currentVal = '';
+            }
+        } else if (char === '<') {
+            depth += 1;
+            currentVal += char;
+        } else if (char === '>') {
+            depth -= 1;
+            currentVal += char;
+        } else {
+            currentVal += char;
+        }
+    }
+
+    mapObj.key = parseType(currentKey);
+    mapObj.value = parseType(currentVal);
+    return mapObj;
+}
+
+export function parseUnionType(type: string): Record<string, any> | string {
+    const unionRegex = /uniontype<(.*)>/;
+    const unionMatch = type.match(unionRegex);
+    if (!unionMatch) {
+        return type;
+    }
+
+    const unionStr = unionMatch[1];
+    const unionList: string[] = [];
+    let currentVal = '';
+    let depth = 0;
+
+    for (const char of unionStr) {
+        if (char === ',') {
+            if (depth > 0) {
+                currentVal += char;
+            } else {
+                unionList.push(currentVal);
+                currentVal = '';
+            }
+        } else if (char === '<') {
+            depth += 1;
+            currentVal += char;
+        } else if (char === '>') {
+            depth -= 1;
+            currentVal += char;
+        } else {
+            currentVal += char;
+        }
+    }
+    unionList.push(currentVal);
+
+    return unionList.map((t) => parseType(t));
+}
+
+export function parseArrayType(type: string): Record<string, any> | string {
+    if (type.startsWith('array<')) {
+        const array = type.substring('array<'.length, type.length - 1);
+        return [parseType(array)];
+    }
+    return type;
+}

--- a/querybook/webapp/ui/Json/Json.tsx
+++ b/querybook/webapp/ui/Json/Json.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import ReactJson, { ReactJsonViewProps, ThemeObject } from 'react-json-view';
+
+const ReactJsonTheme: ThemeObject = {
+    base00: 'transparent', // background
+    base01: 'var(--text)', // not used
+    base02: 'var(--color-accent-dark)', // vertical lines, null value frame
+    base03: 'var(--text)', // not used
+    base04: 'var(--text-light)', // number of items
+    base05: 'var(--text)', // not used
+    base06: 'var(--text)', // not used
+    base07: 'var(--color-accent-dark)', // struct keys, curly brackets, colon
+    base08: 'var(--text)', // not used
+    base09: 'var(--text)', // string value, ellipsis
+    base0A: 'var(--color-accent-lightest)', // null value text
+    base0B: 'var(--text)', // not used
+    base0C: 'var(--color-accent-dark)', // array indices
+    base0D: 'var(--color-accent-dark)', // collapse
+    base0E: 'var(--color-accent-dark)', // expand
+    base0F: 'var(--text)', // int value
+};
+
+interface IProps {
+    json: any;
+}
+
+export const Json: React.FC<IProps & Partial<ReactJsonViewProps>> = ({
+    json,
+    ...props
+}) => (
+    <ReactJson
+        collapsed={1} // keep first level expanded by default
+        displayDataTypes={false}
+        enableClipboard={false}
+        name={false}
+        quotesOnKeys={false}
+        src={json}
+        theme={ReactJsonTheme}
+        {...props}
+    />
+);


### PR DESCRIPTION
This change makes it easier to understand complex Hive types, including `array<>`, `map<>`, `struct<>`, and `uniontype<>`.  It adds a parser that detects these types and converts them into a representative JSON object, which is then visualized using the [react-json-view](https://www.npmjs.com/package/react-json-view) library added in #991.

Currently it only works on these Hive types.  If it's too specific/niche to merge that's fine, we'll maintain it internally on our side.  Just wanted to throw it out there in case it would be useful to anyone else.

<img width="360" alt="Screen Shot 2022-11-04 at 4 25 55 PM" src="https://user-images.githubusercontent.com/3084806/200067994-e14d1113-7aac-43a8-b4e5-1c59d04e7c5a.png"> <img width="328" alt="Screen Shot 2022-11-04 at 4 19 28 PM" src="https://user-images.githubusercontent.com/3084806/200066960-b252c589-4416-434d-9e04-d23828948098.png">

<img width="1158" alt="Screen Shot 2022-11-04 at 3 57 14 PM" src="https://user-images.githubusercontent.com/3084806/200066678-ca8f84fd-5a61-4a79-99ce-55b03ec77970.png">
<img width="1154" alt="Screen Shot 2022-11-04 at 4 18 58 PM" src="https://user-images.githubusercontent.com/3084806/200066890-cf5610fe-a04a-49e5-86e0-8b16208a93da.png">

