### PR TITLE
Feat: add enable and list filters for Scheds

### DIFF
--- a/querybook/server/logic/schedule.py
+++ b/querybook/server/logic/schedule.py
@@ -11,6 +11,7 @@ from models.schedule import (
     TaskRunRecord,
 )
 from models.datadoc import DataDoc
+from models.board import BoardItem
 
 DATADOC_SCHEDULE_PREFIX = "run_data_doc_"
 
@@ -193,6 +194,14 @@ def get_scheduled_data_docs_by_user(
 
     if "name" in filters:
         query = query.filter(DataDoc.title.contains(filters.get("name")))
+
+    if filters.get("status") is not None:
+        query = query.filter(TaskSchedule.enabled == filters.get("status"))
+
+    if filters.get("board_ids"):
+        query = query.join(BoardItem, BoardItem.data_doc_id == DataDoc.id).filter(
+            BoardItem.parent_board_id.in_(filters.get("board_ids"))
+        )
 
     count = query.count()
     docs_with_schedules = query.offset(offset).limit(limit).all()

--- a/querybook/webapp/components/AppAdmin/components/EnvironmentSelection/EnvironmentSelection.tsx
+++ b/querybook/webapp/components/AppAdmin/components/EnvironmentSelection/EnvironmentSelection.tsx
@@ -2,12 +2,7 @@ import { useField, useFormikContext } from 'formik';
 import React, { useMemo } from 'react';
 
 import { SimpleField } from 'ui/FormikField/SimpleField';
-
-interface OptionsType {
-    value: string;
-    key: string;
-    hidden?: boolean;
-}
+import { OptionsType } from 'const/options';
 
 export const EnvironmentSelection = ({
     options = [],

--- a/querybook/webapp/components/DataDocScheduleList/DataDocBoardsSelect.tsx
+++ b/querybook/webapp/components/DataDocScheduleList/DataDocBoardsSelect.tsx
@@ -1,0 +1,56 @@
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { IStoreState } from 'redux/store/types';
+import { SimpleField } from 'ui/FormikField/SimpleField';
+import { IBoard } from 'const/board';
+import { IOption } from 'lib/utils/react-select';
+import { OptionTypeBase } from 'react-select';
+
+export interface IDataDocBoardsSelectProps {
+    onChange: (params: OptionTypeBase[]) => void;
+    value: IOption<number>[];
+    label?: string;
+    name: string;
+}
+
+export const DataDocBoardsSelect: React.FC<IDataDocBoardsSelectProps> = ({
+    onChange,
+    value,
+    label,
+    name,
+}) => {
+    const boardById: Record<string, IBoard> = useSelector(
+        (state: IStoreState) => state.board.boardById
+    );
+
+    const boardOptions: IOption<number>[] = useMemo(() => {
+        return Object.values(boardById).map((board) => ({
+            value: board.id,
+            label: board.name,
+        }));
+    }, [boardById]);
+
+    const selectedBoards: IOption<number>[] = useMemo(
+        () =>
+            boardOptions.filter((board) =>
+                value.map((v) => v.value).includes(board.value)
+            ),
+        []
+    );
+
+    return (
+        <SimpleField
+            label={label}
+            name={name}
+            value={value}
+            defaultValue={selectedBoards}
+            options={boardOptions}
+            onChange={onChange}
+            optionSelector={(v: IOption<number>) => v}
+            closeMenuOnSelect={false}
+            hideSelectedOptions={false}
+            isMulti
+            type="react-select"
+        />
+    );
+};

--- a/querybook/webapp/components/DataDocScheduleList/DataDocSchedsFilters.tsx
+++ b/querybook/webapp/components/DataDocScheduleList/DataDocSchedsFilters.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect } from 'react';
+import { Formik } from 'formik';
+import { debounce } from 'lodash';
+import { useDispatch } from 'react-redux';
+import { OptionTypeBase } from 'react-select';
+import { Popover } from 'ui/Popover/Popover';
+import { SimpleField } from 'ui/FormikField/SimpleField';
+import { DataDocBoardsSelect } from './DataDocBoardsSelect';
+import { IScheduledDocFilters } from 'redux/scheduledDataDoc/types';
+import { fetchBoards } from 'redux/board/action';
+import { UpdateFiltersType, StatusType } from 'const/schedFiltersType';
+
+const enabledOptions = [
+    { key: 'all', value: 'All' },
+    { key: 'enabled', value: 'Enabled' },
+    { key: 'disabled', value: 'Disabled' },
+];
+
+export const DataDocSchedsFilters: React.FC<{
+    setShowSearchFilter: (arg: boolean) => void;
+    updateFilters: (arg: UpdateFiltersType) => void;
+    filterButton: HTMLAnchorElement | null;
+    filters: IScheduledDocFilters;
+}> = ({ setShowSearchFilter, filters, updateFilters, filterButton }) => {
+    const dispatch = useDispatch();
+    useEffect(() => {
+        dispatch(fetchBoards());
+    }, []);
+    const handleUpdateStatus = React.useCallback((value: StatusType) => {
+        updateFilters({
+            key: 'status',
+            value,
+        });
+    }, []);
+
+    const handleUpdateList = React.useCallback(
+        debounce((params: OptionTypeBase[]) => {
+            updateFilters({
+                key: 'board_ids',
+                value: params,
+            });
+        }, 500),
+        []
+    );
+    return (
+        <Popover
+            layout={['bottom', 'right']}
+            onHide={() => {
+                setShowSearchFilter(false);
+            }}
+            anchor={filterButton}
+        >
+            <div className="DataTableNavigatorSearchFilter">
+                <div className="DataDocScheduleList_select-wrapper">
+                    <Formik
+                        initialValues={{
+                            status: '',
+                            board_ids: [],
+                        }}
+                        onSubmit={() => undefined} // Just for fixing ts
+                    >
+                        {({}) => {
+                            return (
+                                <>
+                                    <SimpleField
+                                        label="Status"
+                                        type="select"
+                                        name="status"
+                                        options={enabledOptions}
+                                        onChange={handleUpdateStatus}
+                                        value={filters.status}
+                                    />
+                                    <DataDocBoardsSelect
+                                        label="Lists"
+                                        name="board_ids"
+                                        value={filters.board_ids}
+                                        onChange={handleUpdateList}
+                                    />
+                                </>
+                            );
+                        }}
+                    </Formik>
+                </div>
+            </div>
+        </Popover>
+    );
+};

--- a/querybook/webapp/const/options.tsx
+++ b/querybook/webapp/const/options.tsx
@@ -1,0 +1,5 @@
+export interface OptionsType {
+    value: string;
+    key: string;
+    hidden?: boolean;
+}

--- a/querybook/webapp/const/schedFiltersType.ts
+++ b/querybook/webapp/const/schedFiltersType.ts
@@ -1,0 +1,8 @@
+import { OptionTypeBase } from 'react-select';
+
+export type StatusType = 'all' | 'enabled' | 'disabled';
+
+export type UpdateFiltersType =
+    | { key: 'status'; value: StatusType }
+    | { key: 'scheduled_only'; value: boolean }
+    | { key: 'board_ids'; value: OptionTypeBase[] };

--- a/querybook/webapp/redux/scheduledDataDoc/action.ts
+++ b/querybook/webapp/redux/scheduledDataDoc/action.ts
@@ -1,6 +1,24 @@
 import { DataDocScheduleResource } from 'resource/dataDoc';
+import { IOption } from 'lib/utils/react-select';
 
 import { IScheduledDoc, IScheduledDocFilters, ThunkResult } from './types';
+import { StatusType } from 'const/schedFiltersType';
+
+function reformatBoardIds(boardIds: IOption<number>[]): number[] | null {
+    if (boardIds.length) {
+        return boardIds.map((board) => board.value);
+    }
+
+    return null;
+}
+
+function reformatStatus(status: StatusType): boolean | null {
+    if (status === 'all') {
+        return null;
+    }
+
+    return status === 'enabled';
+}
 
 export function getScheduledDocs({
     paginationPage,
@@ -25,7 +43,11 @@ export function getScheduledDocs({
             envId,
             limit: pageSize,
             offset: page * pageSize,
-            filters,
+            filters: {
+                ...filters,
+                status: reformatStatus(filters.status),
+                board_ids: reformatBoardIds(filters.board_ids),
+            },
         });
 
         dispatch({

--- a/querybook/webapp/redux/scheduledDataDoc/reducer.ts
+++ b/querybook/webapp/redux/scheduledDataDoc/reducer.ts
@@ -8,6 +8,7 @@ const initialState: Readonly<IScheduledDataDocState> = {
     pageSize: 20,
     numberOfResults: 0,
     filters: {
+        status: 'all',
         scheduled_only: true,
     },
 };

--- a/querybook/webapp/redux/scheduledDataDoc/types.ts
+++ b/querybook/webapp/redux/scheduledDataDoc/types.ts
@@ -8,11 +8,25 @@ import { IDataDoc } from 'const/datadoc';
 import { ITaskSchedule, ITaskStatusRecord } from 'const/schedule';
 
 import { IStoreState } from '../store/types';
+import { IOption } from 'lib/utils/react-select';
+import { StatusType } from 'const/schedFiltersType';
 
-export interface IScheduledDocFilters {
+interface IBasicScheduledDocFilters {
     name?: string;
     scheduled_only?: boolean;
 }
+
+export interface IScheduledDocFilters extends IBasicScheduledDocFilters {
+    status?: StatusType;
+    board_ids?: IOption<number>[];
+}
+
+export interface ITransformedScheduledDocFilters
+    extends IBasicScheduledDocFilters {
+    board_ids?: number[];
+    status?: boolean;
+}
+
 export interface IScheduledDoc {
     doc: IDataDoc;
     last_record?: ITaskStatusRecord;

--- a/querybook/webapp/resource/dataDoc.ts
+++ b/querybook/webapp/resource/dataDoc.ts
@@ -18,7 +18,7 @@ import dataDocSocket from 'lib/data-doc/datadoc-socketio';
 import ds from 'lib/datasource';
 import {
     IScheduledDoc,
-    IScheduledDocFilters,
+    ITransformedScheduledDocFilters,
 } from 'redux/scheduledDataDoc/types';
 
 export const DataDocResource = {
@@ -188,7 +188,7 @@ export const DataDocScheduleResource = {
         envId: number;
         limit: number;
         offset: number;
-        filters: IScheduledDocFilters;
+        filters: ITransformedScheduledDocFilters;
     }) =>
         ds.fetch<{ docs: IScheduledDoc[]; count: number }>(
             '/datadoc/scheduled/',

--- a/querybook/webapp/ui/SimpleReactSelect/SimpleReactSelect.tsx
+++ b/querybook/webapp/ui/SimpleReactSelect/SimpleReactSelect.tsx
@@ -5,6 +5,7 @@ import Creatable from 'react-select/creatable';
 import { makeReactSelectStyle } from 'lib/utils/react-select';
 import { overlayRoot } from 'ui/Overlay/Overlay';
 import { AccentText } from 'ui/StyledText/StyledText';
+import { IOption } from 'lib/utils/react-select';
 
 export interface ISelectOption<T> {
     value: T;
@@ -19,6 +20,11 @@ export interface ISimpleReactSelectProps<T> {
     isDisabled?: boolean;
     creatable?: boolean;
     selectProps?: Partial<ReactSelectProps<T>>;
+    closeMenuOnSelect?: boolean;
+    hideSelectedOptions?: boolean;
+    isMulti?: boolean;
+    optionSelector?: (o: ISelectOption<T>) => any;
+    defaultValue?: any;
 
     // Clear selection user picks value
     clearAfterSelect?: boolean;
@@ -36,6 +42,8 @@ export function SimpleReactSelect<T>({
     selectProps = {},
     withDeselect = false,
     clearAfterSelect = false,
+    optionSelector = (val) => val?.value,
+    ...otherParams
 }: ISimpleReactSelectProps<T>) {
     const overrideSelectProps = useMemo(() => {
         const override: Partial<ReactSelectProps<T>> = {};
@@ -65,7 +73,7 @@ export function SimpleReactSelect<T>({
     );
 
     const onSelectChange = useCallback(
-        (val: ISelectOption<T>) => onChange(val?.value),
+        (val: ISelectOption<T>) => onChange(optionSelector(val)),
         [onChange]
     );
 
@@ -88,7 +96,7 @@ export function SimpleReactSelect<T>({
             {creatable ? (
                 <Creatable {...componentProps} />
             ) : (
-                <Select {...componentProps} />
+                <Select {...componentProps} {...otherParams} />
             )}
         </AccentText>
     );


### PR DESCRIPTION
This commit adds a bunch of filters for Scheds page.
There are two filters - filter by status and public user lists.
Filter by status has three options: All (default), Enabled and Disabled. A user can choose only one option.
Filter by user lists contains all custom-created lists and a user can select any of them. A user also can choose more than one list.
<img width="1164" alt="snap1" src="https://user-images.githubusercontent.com/59963571/201133030-d0148d80-a2d5-43f3-9c68-dd2244033311.png">
