### PR TITLE
fix: disable some api reqests from event logging

### DIFF
--- a/querybook/server/app/auth/__init__.py
+++ b/querybook/server/app/auth/__init__.py
@@ -54,14 +54,14 @@ def get_login_config():
         has_oauth_url = hasattr(auth, "oauth_authorization_url")
 
         if has_login:
-            register("/login/", methods=["POST"], require_auth=False)(
-                auth.login_user_endpoint
-            )
+            register(
+                "/login/", methods=["POST"], require_auth=False, api_logging=False
+            )(auth.login_user_endpoint)
 
         if has_signup:
-            register("/signup/", methods=["POST"], require_auth=False)(
-                auth.signup_user_endpoint
-            )
+            register(
+                "/signup/", methods=["POST"], require_auth=False, api_logging=False
+            )(auth.signup_user_endpoint)
 
         if has_oauth_url:
             oauth_url = auth.oauth_authorization_url()

--- a/querybook/server/app/datasource.py
+++ b/querybook/server/app/datasource.py
@@ -61,8 +61,8 @@ def register(
             try:
                 kwargs.update(params)
 
-                # api event logging
-                if api_logging:
+                # api event logging. Ignore admin api endpoints
+                if api_logging and not url.startswith("/admin"):
                     event_logger.log_api_request(
                         method=flask.request.method,
                         route=url,

--- a/querybook/server/app/datasource.py
+++ b/querybook/server/app/datasource.py
@@ -65,7 +65,7 @@ def register(
                 if api_logging:
                     event_logger.log_api_request(
                         method=flask.request.method,
-                        route=f"{DS_PATH}{url}",
+                        route=url,
                         params=kwargs,
                     )
 

--- a/querybook/server/datasources/user.py
+++ b/querybook/server/datasources/user.py
@@ -71,7 +71,7 @@ def get_user_environment_ids():
     return [visible_environments, user_environment_ids]
 
 
-@register("/user/setting/<key>/", methods=["POST"])
+@register("/user/setting/<key>/", methods=["POST"], api_logging=False)
 def set_user_setting(key, value=None):
     return logic.create_or_update_user_setting(
         uid=current_user.id, key=key, value=value

--- a/querybook/server/lib/event_logger/__init__.py
+++ b/querybook/server/lib/event_logger/__init__.py
@@ -30,7 +30,7 @@ class EventLogger:
             LOG.error(e, exc_info=True)
 
     def log_api_request(self, route: str, method: str, params: dict):
-        """Log an API request. Admin api requests will not be logged.
+        """Log an API request.
 
         Args:
             method (str): request method, e.g. GET, POST
@@ -38,10 +38,6 @@ class EventLogger:
             params (dict): params of the request, includes path params,
                 query strings and post body
         """
-        # Skip admin apis
-        if route.startswith("/admin"):
-            return
-
         params = self.__prune_api_request_params(params)
         event_data = {"method": method, "route": route, "params": params}
         self.log(event_type=EventType.API, event_data=event_data)

--- a/querybook/server/lib/event_logger/__init__.py
+++ b/querybook/server/lib/event_logger/__init__.py
@@ -30,7 +30,7 @@ class EventLogger:
             LOG.error(e, exc_info=True)
 
     def log_api_request(self, route: str, method: str, params: dict):
-        """Log an API request
+        """Log an API request. Admin api requests will not be logged.
 
         Args:
             method (str): request method, e.g. GET, POST
@@ -38,6 +38,10 @@ class EventLogger:
             params (dict): params of the request, includes path params,
                 query strings and post body
         """
+        # Skip admin apis
+        if route.startswith("/admin"):
+            return
+
         params = self.__prune_api_request_params(params)
         event_data = {"method": method, "route": route, "params": params}
         self.log(event_type=EventType.API, event_data=event_data)


### PR DESCRIPTION
some api endpoints may have sensitive like password. here we'll disable the logging for all the admin api and login/signup endpoints