### PR TITLE
fix: load announcements only if the tab is active

### DIFF
--- a/querybook/webapp/components/Announcements/Announcements.tsx
+++ b/querybook/webapp/components/Announcements/Announcements.tsx
@@ -24,7 +24,12 @@ export const Announcements: React.FunctionComponent = () => {
         dispatch(querybookUIActions.loadDismissedAnnouncements());
     }, []);
 
-    useInterval(loadAnnouncements, 300000);
+    useInterval(() => {
+        // load announcements only if the tab is active
+        if (document.hasFocus()) {
+            loadAnnouncements();
+        }
+    }, 300000);
 
     if (announcements.length === 0) {
         return null;

--- a/querybook/webapp/components/Announcements/Announcements.tsx
+++ b/querybook/webapp/components/Announcements/Announcements.tsx
@@ -14,8 +14,12 @@ import './Announcements.scss';
 export const Announcements: React.FunctionComponent = () => {
     const announcements = useAnnouncements();
     const dispatch: Dispatch = useDispatch();
-    const loadAnnouncements = () =>
-        dispatch(querybookUIActions.loadAnnouncements());
+    const loadAnnouncements = () => {
+        // load announcements only if the tab is active
+        if (document.hasFocus()) {
+            dispatch(querybookUIActions.loadAnnouncements());
+        }
+    };
     const dismissAnnouncement = (id: number) =>
         dispatch(querybookUIActions.dismissAnnouncement(id));
 
@@ -24,12 +28,7 @@ export const Announcements: React.FunctionComponent = () => {
         dispatch(querybookUIActions.loadDismissedAnnouncements());
     }, []);
 
-    useInterval(() => {
-        // load announcements only if the tab is active
-        if (document.hasFocus()) {
-            loadAnnouncements();
-        }
-    }, 300000);
+    useInterval(loadAnnouncements, 300000);
 
     if (announcements.length === 0) {
         return null;

--- a/querybook/webapp/hooks/useInterval.ts
+++ b/querybook/webapp/hooks/useInterval.ts
@@ -1,21 +1,22 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export const useInterval = (
     func: () => any,
     freq: number,
     disabled: boolean = false
 ) => {
+    const savedFunc = useRef(func);
+
+    useEffect(() => {
+        savedFunc.current = func;
+    }, [func]);
+
     useEffect(() => {
         let interval: number = null;
         if (!disabled) {
-            interval = setInterval(func, freq);
+            interval = setInterval(() => savedFunc.current(), freq);
         }
 
-        return () => {
-            if (interval) {
-                clearInterval(interval);
-                interval = null;
-            }
-        };
-    }, [disabled, func, freq]);
+        return () => clearInterval(interval);
+    }, [disabled, freq]);
 };


### PR DESCRIPTION
Found there are a lot of api calls of `/announcement/`, which is about more than 1/3 of total api calls. Here we change it to only call it when the tab is active.