### PR TITLE
feat: Visualize complex Hive column types v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.15.7",
+    "version": "3.16.0",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/__tests__/lib/utils/complex-types.test.ts
+++ b/querybook/webapp/__tests__/lib/utils/complex-types.test.ts
@@ -1,0 +1,258 @@
+import { parseType, prettyPrintType } from 'lib/utils/complex-types';
+
+test('simple type', () => {
+    expect(parseType('column', 'string')).toEqual({
+        key: 'column',
+        type: 'string',
+    });
+});
+
+test('truncated type', () => {
+    expect(
+        parseType(
+            'column',
+            'struct<date:struct<year:int,month:int,day:int>,hour:int,minute:int,second:int,'
+        )
+    ).toEqual({
+        key: 'column',
+        type: 'struct<date:struct<year:int,month:int,day:int>,hour:int,minute:int,second:int,',
+    });
+
+    // Truncated, but coincidentally matches the regex
+    expect(parseType('column', 'struct<date:struct<hour:int>')).toEqual({
+        key: 'column',
+        type: 'struct<date:struct<hour:int>',
+    });
+});
+
+test('malformed struct type', () => {
+    expect(parseType('column', 'STRUCT <id:string>')).toEqual({
+        key: 'column',
+        type: 'STRUCT <id:string>',
+    });
+});
+
+test('complex type', () => {
+    expect(parseType('column', 'STRUCT<id:string>')).toEqual({
+        key: 'column',
+        type: 'STRUCT<id:string>',
+        children: [
+            {
+                key: 'id',
+                type: 'string',
+            },
+        ],
+    });
+
+    expect(
+        parseType(
+            'column',
+            'struct<date:struct<year:int,month:int,day:int>,hour:int,minute:int,second:int,timeZoneId:string>'
+        )
+    ).toEqual({
+        key: 'column',
+        type: 'struct<date:struct<year:int,month:int,day:int>,hour:int,minute:int,second:int,timeZoneId:string>',
+        children: [
+            {
+                key: 'date',
+                type: 'struct<year:int,month:int,day:int>',
+                children: [
+                    { key: 'year', type: 'int' },
+                    { key: 'month', type: 'int' },
+                    { key: 'day', type: 'int' },
+                ],
+            },
+            { key: 'hour', type: 'int' },
+            { key: 'minute', type: 'int' },
+            { key: 'second', type: 'int' },
+            { key: 'timeZoneId', type: 'string' },
+        ],
+    });
+
+    expect(
+        parseType(
+            'column',
+            'array<struct<size:struct<width:int,height:int,isAspectRatio:boolean>>>'
+        )
+    ).toEqual({
+        key: 'column',
+        type: 'array<struct<size:struct<width:int,height:int,isAspectRatio:boolean>>>',
+        children: [
+            {
+                key: '<element>',
+                type: 'struct<size:struct<width:int,height:int,isAspectRatio:boolean>>',
+                children: [
+                    {
+                        key: 'size',
+                        type: 'struct<width:int,height:int,isAspectRatio:boolean>',
+                        children: [
+                            { key: 'width', type: 'int' },
+                            { key: 'height', type: 'int' },
+                            { key: 'isAspectRatio', type: 'boolean' },
+                        ],
+                    },
+                ],
+            },
+        ],
+    });
+
+    expect(
+        parseType(
+            'column',
+            'struct<purchasePath:string,resultToken:string,sessionId:string,site:struct<eapid:bigint,tpid:bigint>,tests:array<struct<bucketValue:string,experimentId:string,instanceId:string>>,user:struct<guid:string,tuid:string>>'
+        )
+    ).toEqual({
+        key: 'column',
+        type: 'struct<purchasePath:string,resultToken:string,sessionId:string,site:struct<eapid:bigint,tpid:bigint>,tests:array<struct<bucketValue:string,experimentId:string,instanceId:string>>,user:struct<guid:string,tuid:string>>',
+        children: [
+            { key: 'purchasePath', type: 'string' },
+            { key: 'resultToken', type: 'string' },
+            { key: 'sessionId', type: 'string' },
+            {
+                key: 'site',
+                type: 'struct<eapid:bigint,tpid:bigint>',
+                children: [
+                    { key: 'eapid', type: 'bigint' },
+                    { key: 'tpid', type: 'bigint' },
+                ],
+            },
+            {
+                key: 'tests',
+                type: 'array<struct<bucketValue:string,experimentId:string,instanceId:string>>',
+                children: [
+                    {
+                        key: '<element>',
+                        type: 'struct<bucketValue:string,experimentId:string,instanceId:string>',
+                        children: [
+                            { key: 'bucketValue', type: 'string' },
+                            { key: 'experimentId', type: 'string' },
+                            { key: 'instanceId', type: 'string' },
+                        ],
+                    },
+                ],
+            },
+            {
+                key: 'user',
+                type: 'struct<guid:string,tuid:string>',
+                children: [
+                    { key: 'guid', type: 'string' },
+                    { key: 'tuid', type: 'string' },
+                ],
+            },
+        ],
+    });
+
+    expect(parseType('column', 'map<string,float>')).toEqual({
+        key: 'column',
+        type: 'map<string,float>',
+        children: [
+            {
+                key: '<key>',
+                type: 'string',
+            },
+            {
+                key: '<value>',
+                type: 'float',
+            },
+        ],
+    });
+
+    expect(
+        parseType(
+            'column',
+            'map<string,uniontype<string,int,bigint,float,double,struct<year:int,month:int,day:int>>>'
+        )
+    ).toEqual({
+        key: 'column',
+        type: 'map<string,uniontype<string,int,bigint,float,double,struct<year:int,month:int,day:int>>>',
+        children: [
+            {
+                key: '<key>',
+                type: 'string',
+            },
+            {
+                key: '<value>',
+                type: 'uniontype<string,int,bigint,float,double,struct<year:int,month:int,day:int>>',
+                children: [
+                    { key: '<element>', type: 'string' },
+                    { key: '<element>', type: 'int' },
+                    { key: '<element>', type: 'bigint' },
+                    { key: '<element>', type: 'float' },
+                    { key: '<element>', type: 'double' },
+                    {
+                        key: '<element>',
+                        type: 'struct<year:int,month:int,day:int>',
+                        children: [
+                            { key: 'year', type: 'int' },
+                            { key: 'month', type: 'int' },
+                            { key: 'day', type: 'int' },
+                        ],
+                    },
+                ],
+            },
+        ],
+    });
+});
+
+test('prettyPrintType', () => {
+    expect(prettyPrintType('map<string,string>')).toEqual(`map<
+  string,
+  string
+>`);
+
+    expect(
+        prettyPrintType(
+            'struct<ids:array<string>,data:uniontype<int,float,string>>'
+        )
+    ).toEqual(`struct<
+  ids: array<
+    string
+  >,
+  data: uniontype<
+    int,
+    float,
+    string
+  >
+>`);
+
+    expect(
+        prettyPrintType(
+            'struct<ids:array<string>,comment:string,data:map<int,int>>'
+        )
+    ).toEqual(`struct<
+  ids: array<
+    string
+  >,
+  comment: string,
+  data: map<
+    int,
+    int
+  >
+>`);
+
+    expect(
+        prettyPrintType(
+            'map<struct<ids:array<string>,comment:string,data:map<int,int>>,struct<data:array<string>,event:map<int,int>>>'
+        )
+    ).toEqual(`map<
+  struct<
+    ids: array<
+      string
+    >,
+    comment: string,
+    data: map<
+      int,
+      int
+    >
+  >,
+  struct<
+    data: array<
+      string
+    >,
+    event: map<
+      int,
+      int
+    >
+  >
+>`);
+});

--- a/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.scss
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.scss
@@ -29,3 +29,20 @@
         }
     }
 }
+
+.DataTableColumnCardNestedType {
+
+    .column-type {
+        min-width: 80px;
+        word-break: break-all;
+    }
+
+    .nested-indent {
+        margin-left: 32px;
+    }
+
+    .expand-icon {
+        margin-left: -32px;
+        padding: 0 8px;
+    }
+}

--- a/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.tsx
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.tsx
@@ -1,13 +1,17 @@
 import { ContentState } from 'draft-js';
-import * as React from 'react';
+import React, { useMemo } from 'react';
 
 import { DataTableColumnStats } from 'components/DataTableStats/DataTableColumnStats';
 import { IDataColumn } from 'const/metastore';
+import { useToggleState } from 'hooks/useToggleState';
+import { parseType } from 'lib/utils/complex-types';
 import { Card } from 'ui/Card/Card';
 import { EditableTextField } from 'ui/EditableTextField/EditableTextField';
 import { Icon } from 'ui/Icon/Icon';
 import { KeyContentDisplay } from 'ui/KeyContentDisplay/KeyContentDisplay';
 import { AccentText, StyledText } from 'ui/StyledText/StyledText';
+
+import { DataTableColumnCardNestedType } from './DataTableColumnCardNestedType';
 
 import './DataTableColumnCard.scss';
 
@@ -23,7 +27,8 @@ export const DataTableColumnCard: React.FunctionComponent<IProps> = ({
     column,
     updateDataColumnDescription,
 }) => {
-    const [expanded, setExpanded] = React.useState(false);
+    const [expanded, , toggleExpanded] = useToggleState(false);
+    const parsedType = useMemo(() => parseType('', column.type), [column.type]);
 
     const userCommentsContent = (
         <EditableTextField
@@ -37,7 +42,7 @@ export const DataTableColumnCard: React.FunctionComponent<IProps> = ({
             <Card key={column.id} alignLeft>
                 <div
                     className="DataTableColumnCard-top horizontal-space-between"
-                    onClick={() => setExpanded(!expanded)}
+                    onClick={() => toggleExpanded()}
                     aria-label={
                         expanded ? 'click to collapse' : 'click to expand'
                     }
@@ -53,6 +58,13 @@ export const DataTableColumnCard: React.FunctionComponent<IProps> = ({
                 </div>
                 {expanded ? (
                     <div className="mt16">
+                        {parsedType.children && (
+                            <KeyContentDisplay keyString="Type Detail">
+                                <DataTableColumnCardNestedType
+                                    complexType={parsedType}
+                                />
+                            </KeyContentDisplay>
+                        )}
                         {column.comment && (
                             <KeyContentDisplay keyString="Definition">
                                 {column.comment}

--- a/querybook/webapp/components/DataTableViewColumn/DataTableColumnCardNestedType.tsx
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableColumnCardNestedType.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+
+import { ComplexType } from 'lib/utils/complex-types';
+import { IconButton } from 'ui/Button/IconButton';
+import { AccentText, StyledText } from 'ui/StyledText/StyledText';
+
+interface IDataTableColumnCardNestedTypeProps {
+    complexType: ComplexType;
+}
+export const DataTableColumnCardNestedType: React.FunctionComponent<
+    IDataTableColumnCardNestedTypeProps
+> = ({ complexType }) => {
+    const hasChildren = complexType.children?.length > 0;
+    const [expanded, setExpanded] = React.useState(false);
+
+    const rowProps: React.HTMLAttributes<HTMLDivElement> = {
+        className: 'flex-row',
+    };
+
+    if (hasChildren) {
+        rowProps['onClick'] = () => setExpanded(!expanded);
+        rowProps['aria-label'] = expanded
+            ? 'click to collapse'
+            : 'click to expand';
+        rowProps['data-balloon-pos'] = 'down-left';
+    }
+
+    return (
+        <div className="DataTableColumnCardNestedType">
+            <div {...rowProps}>
+                {hasChildren && (
+                    <IconButton
+                        icon={expanded ? 'Minus' : 'Plus'}
+                        size="16"
+                        noPadding={true}
+                        className="expand-icon"
+                    />
+                )}
+                <AccentText weight="extra" className="mr12">
+                    {complexType.key}
+                </AccentText>
+                <StyledText
+                    color="light"
+                    className={`column-type ${!hasChildren && 'nested-indent'}`}
+                >
+                    {complexType.type}
+                </StyledText>
+            </div>
+            {hasChildren &&
+                expanded &&
+                complexType.children.map((child) => (
+                    <div className="nested-indent m16" key={child.key}>
+                        <DataTableColumnCardNestedType complexType={child} />
+                    </div>
+                ))}
+        </div>
+    );
+};

--- a/querybook/webapp/components/DataTableViewMini/ColumnPanelView.tsx
+++ b/querybook/webapp/components/DataTableViewMini/ColumnPanelView.tsx
@@ -2,6 +2,7 @@ import { ContentState } from 'draft-js';
 import React from 'react';
 import { useSelector } from 'react-redux';
 
+import { prettyPrintType } from 'lib/utils/complex-types';
 import { IStoreState } from 'redux/store/types';
 
 import { PanelSection, SubPanelSection } from './PanelSection';
@@ -22,7 +23,11 @@ export const ColumnPanelView: React.FunctionComponent<
     const overviewPanel = (
         <PanelSection title="column">
             <SubPanelSection title="name">{column.name}</SubPanelSection>
-            <SubPanelSection title="type">{column.type}</SubPanelSection>
+            <SubPanelSection title="type">
+                <div className="preformatted">
+                    {prettyPrintType(column.type)}
+                </div>
+            </SubPanelSection>
         </PanelSection>
     );
 

--- a/querybook/webapp/lib/utils/complex-types.ts
+++ b/querybook/webapp/lib/utils/complex-types.ts
@@ -1,0 +1,247 @@
+export interface ComplexType {
+    key: string;
+    type: string;
+    children?: ComplexType[];
+}
+
+const INDENT = '  ';
+
+/**
+ * Convert a complex Hive type string to a nested JSON object
+ *
+ * Example: 'column', 'struct<date:struct<year:int,month:int,day:int>,hour:int,minute:int,second:int,timeZoneId:string>'
+ * Output: {
+        key: 'column',
+        type: 'struct<date:struct<year:int,month:int,day:int>,hour:int,minute:int,second:int,timeZoneId:string>',
+        children: [
+            {
+                key: 'date',
+                type: 'struct<year:int,month:int,day:int>',
+                children: [
+                    { key: 'year', type: 'int' },
+                    { key: 'month', type: 'int' },
+                    { key: 'day', type: 'int' },
+                ],
+            },
+            { key: 'hour', type: 'int' },
+            { key: 'minute', type: 'int' },
+            { key: 'second', type: 'int' },
+            { key: 'timeZoneId', type: 'string' },
+        ],
+    }
+ */
+export function parseType(key: string, type: string): ComplexType {
+    const regex = /^(struct|array|map|uniontype)<(.*)>$/i;
+    const matches = type.match(regex);
+
+    if (!matches || matches.length < 3) {
+        return { key, type };
+    }
+
+    const [_, typeName, typeContents] = matches;
+
+    switch (typeName.toLowerCase()) {
+        case 'struct':
+            return parseStructType(key, type, typeContents);
+        case 'array':
+            return parseArrayType(key, type, typeContents);
+        case 'map':
+            return parseMapType(key, type, typeContents);
+        case 'uniontype':
+            return parseUnionType(key, type, typeContents);
+        default:
+            return { key, type };
+    }
+}
+
+export function parseStructType(
+    key: string,
+    type: string,
+    typeContents: string
+): ComplexType {
+    const children = [];
+    let currentKey = '';
+    let currentVal = '';
+    let depth = 0;
+
+    for (const char of typeContents) {
+        if (char === ':') {
+            if (depth > 0) {
+                currentVal += char;
+            } else {
+                currentKey = currentVal;
+                currentVal = '';
+            }
+        } else if (char === ',') {
+            if (depth === 0) {
+                children.push(parseType(currentKey, currentVal));
+                currentKey = '';
+                currentVal = '';
+            } else {
+                currentVal += char;
+            }
+        } else if (char === '<') {
+            depth += 1;
+            currentVal += char;
+        } else if (char === '>') {
+            depth -= 1;
+            currentVal += char;
+        } else {
+            currentVal += char;
+        }
+    }
+
+    if (depth > 0) {
+        // Truncated or malformed type, return as-is
+        return { key, type };
+    }
+
+    children.push(parseType(currentKey, currentVal));
+
+    const structType: ComplexType = {
+        key,
+        type,
+        children,
+    };
+
+    return structType;
+}
+
+export function parseMapType(
+    key: string,
+    type: string,
+    typeContents: string
+): ComplexType {
+    const children: ComplexType[] = [];
+    let currentKey = '';
+    let currentVal = '';
+    let depth = 0;
+
+    for (const char of typeContents) {
+        if (char === ',') {
+            if (depth > 0) {
+                currentVal += char;
+            } else {
+                currentKey = currentVal;
+                currentVal = '';
+            }
+        } else if (char === '<') {
+            depth += 1;
+            currentVal += char;
+        } else if (char === '>') {
+            depth -= 1;
+            currentVal += char;
+        } else {
+            currentVal += char;
+        }
+    }
+
+    if (depth > 0) {
+        // Truncated or malformed type, return as-is
+        return { key, type };
+    }
+
+    children.push(parseType('<key>', currentKey));
+    children.push(parseType('<value>', currentVal));
+
+    const mapType: ComplexType = {
+        key,
+        type,
+        children,
+    };
+
+    return mapType;
+}
+
+export function parseUnionType(
+    key: string,
+    type: string,
+    typeContents: string
+): ComplexType {
+    const children: ComplexType[] = [];
+    let currentVal = '';
+    let depth = 0;
+
+    for (const char of typeContents) {
+        if (char === ',') {
+            if (depth > 0) {
+                currentVal += char;
+            } else {
+                children.push(parseType('<element>', currentVal));
+                currentVal = '';
+            }
+        } else if (char === '<') {
+            depth += 1;
+            currentVal += char;
+        } else if (char === '>') {
+            depth -= 1;
+            currentVal += char;
+        } else {
+            currentVal += char;
+        }
+    }
+
+    if (depth > 0) {
+        // Truncated or malformed type, return as-is
+        return { key, type };
+    }
+
+    children.push(parseType('<element>', currentVal));
+
+    const unionType: ComplexType = {
+        key,
+        type,
+        children,
+    };
+
+    return unionType;
+}
+
+export function parseArrayType(
+    key: string,
+    type: string,
+    typeContents: string
+): ComplexType {
+    const regex = /array<(.*)>/;
+    const matches = type.match(regex);
+
+    if (!matches) {
+        return { key, type };
+    }
+
+    return {
+        key,
+        type,
+        children: [parseType('<element>', typeContents)],
+    };
+}
+
+/**
+ * Pretty-print a complex Hive type string using newlines and 2-space indentation.
+ */
+export function prettyPrintType(type: string): string {
+    let prettyString = '';
+    let depth = 0;
+
+    for (const char of type) {
+        if (char === '<') {
+            prettyString += '<\n';
+            depth += 1;
+            prettyString += INDENT.repeat(depth);
+        } else if (char === '>') {
+            prettyString += '\n';
+            depth -= 1;
+            prettyString += INDENT.repeat(depth);
+            prettyString += '>';
+        } else if (char === ',') {
+            prettyString += ',\n';
+            prettyString += INDENT.repeat(depth);
+        } else if (char === ':') {
+            prettyString += ': ';
+        } else {
+            prettyString += char;
+        }
+    }
+
+    return prettyString;
+}

--- a/querybook/webapp/stylesheets/_utilities.scss
+++ b/querybook/webapp/stylesheets/_utilities.scss
@@ -87,6 +87,11 @@
     background-color: transparent;
 }
 
+.preformatted {
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
 /* force scrollbar to appear on Mac & -webkit (Chrome, Safari) despite user 'hide' preference */
 .force-scrollbar-x {
     overflow-x: scroll !important;


### PR DESCRIPTION
This is an alternate version of #1072, replacing the JSON viewer with a more natural-looking nested type drilldown.  I've also addressed some issues with the original version.

Compared to #1072, the parser is more consistent and does a better job of handling certain types than before.  To support the nesting, it always creates nodes with optional children.  Now `array<>` and `uniontype<>` types will create placeholder `<element>` nodes underneath them, and `map<>` types create placeholder `<key>` and `<value>` nodes.

Complex type parsing is case-insensitive (e.g. struct vs STRUCT) but otherwise case is preserved.

There are three main features:
1. Columns with complex types can be expanded directly in the TablePanelView to see a nested representation (initially collapsed).

![Screen Shot 2022-12-01 at 4 55 50 PM](https://user-images.githubusercontent.com/3084806/205167362-843765a4-6a87-4106-9131-7c6c23a2da20.png) ![Screen Shot 2022-12-01 at 4 56 10 PM](https://user-images.githubusercontent.com/3084806/205167375-5d1d20b9-777a-4381-9f0d-13885bce2ac4.png)

2. The type displayed on the ColumnPanelView is pretty-printed with simple line breaks/indents.

![Screen Shot 2022-12-01 at 4 56 35 PM](https://user-images.githubusercontent.com/3084806/205167421-862373a6-75c1-4ea6-a880-e72952474ad5.png)

3. The DataTableColumnCard shows a similar nested visualization after expanding a column (initially collapsed).

![Screen Shot 2022-12-01 at 4 58 06 PM](https://user-images.githubusercontent.com/3084806/205167683-8f081cde-dfef-42e4-ac64-d94b575dcf78.png)
