### PR TITLE
chore: bump version to 3.14.2 for CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.14.1",
+    "version": "3.14.2",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {


### PR DESCRIPTION
This is a dummy change to make a new version release for the CVE fix 
See changes here: https://github.com/pinterest/querybook/commit/88a7f10495bf5ed1a556ade51a2f2794e403c063