### PR TITLE
fix: sidebar search should use relevance instead of alphabetical

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
                 - prettier@2.7.1
                 # - '@trivago/prettier-plugin-sort-imports@3.2.0' # removing it since pre-commit install fails
 
-    - repo: https://gitlab.com/pycqa/flake8
+    - repo: https://github.com/PyCQA/flake8
       rev: 3.9.2
       hooks:
           - id: flake8

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.14.2",
+    "version": "3.14.3",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/components/DataTableNavigator/DataTableNavigatorSearch.tsx
+++ b/querybook/webapp/components/DataTableNavigator/DataTableNavigatorSearch.tsx
@@ -129,18 +129,16 @@ export const DataTableNavigatorSearch: React.FC<{
                 <OrderByButton
                     className="mr4"
                     asc={sortTableAsc}
-                    hideAscToggle={sortTableKey === 'importance_score'}
+                    hideAscToggle={sortTableKey === 'relevance'}
                     orderByField={startCase(sortTableKey)}
-                    orderByFieldSymbol={sortTableKey === 'name' ? 'Aa' : 'Is'}
+                    orderByFieldSymbol={sortTableKey === 'name' ? 'Aa' : 'Rl'}
                     onAscToggle={() => {
                         dispatch(updateTableSort(null, !sortTableAsc));
                     }}
                     onOrderByFieldToggle={() => {
                         dispatch(
                             updateTableSort(
-                                sortTableKey === 'name'
-                                    ? 'importance_score'
-                                    : 'name'
+                                sortTableKey === 'name' ? 'relevance' : 'name'
                             )
                         );
                     }}

--- a/querybook/webapp/components/DataTableNavigator/SchemaTableView/SchemaTableItem.tsx
+++ b/querybook/webapp/components/DataTableNavigator/SchemaTableView/SchemaTableItem.tsx
@@ -87,15 +87,13 @@ export const SchemaTableItem: React.FC<{
                 </div>
                 <OrderByButton
                     asc={sortOrder.asc}
-                    hideAscToggle={sortOrder.key === 'importance_score'}
+                    hideAscToggle={sortOrder.key === 'relevance'}
                     orderByField={startCase(sortOrder.key)}
-                    orderByFieldSymbol={sortOrder.key === 'name' ? 'Aa' : 'Is'}
+                    orderByFieldSymbol={sortOrder.key === 'name' ? 'Aa' : 'Rl'}
                     onAscToggle={() => onSortChanged(null, !sortOrder.asc)}
                     onOrderByFieldToggle={() =>
                         onSortChanged(
-                            sortOrder.key === 'name'
-                                ? 'importance_score'
-                                : 'name'
+                            sortOrder.key === 'name' ? 'relevance' : 'name'
                         )
                     }
                 />

--- a/querybook/webapp/const/metastore.ts
+++ b/querybook/webapp/const/metastore.ts
@@ -192,6 +192,6 @@ export interface ITableColumnStats {
 }
 
 export type SchemaSortKey = 'name' | 'table_count';
-export type SchemaTableSortKey = 'name' | 'importance_score';
+export type SchemaTableSortKey = 'name' | 'relevance';
 export const tableNameDraggableType = 'TableName-';
 export const tableNameDataTransferName = 'tableName';

--- a/querybook/webapp/redux/dataTableSearch/action.ts
+++ b/querybook/webapp/redux/dataTableSearch/action.ts
@@ -97,7 +97,7 @@ function searchDataTable(): ThunkResult<Promise<ITableSearchResult[]>> {
                 const tableSortAsc = tableSort.asc ? 'asc' : 'desc';
                 search['sort_key'] = ['schema', 'name'];
                 search['sort_order'] = [tableSortAsc, tableSortAsc];
-            } else if (tableSort.key === 'importance_score') {
+            } else if (tableSort.key === 'relevance') {
                 search['sort_key'] = '_score';
                 search['sort_order'] = 'desc';
             }
@@ -201,10 +201,8 @@ export function searchTableBySchema(
                         schema: schemaName,
                     },
                 }),
-                sort_key:
-                    orderBy.key === 'importance_score' ? '_score' : orderBy.key,
-                sort_order:
-                    orderBy.key === 'importance_score' ? 'desc' : sortOrder,
+                sort_key: orderBy.key === 'relevance' ? '_score' : orderBy.key,
+                sort_order: orderBy.key === 'relevance' ? 'desc' : sortOrder,
                 offset: resultsCount,
             });
             dispatch({

--- a/querybook/webapp/redux/dataTableSearch/const.ts
+++ b/querybook/webapp/redux/dataTableSearch/const.ts
@@ -14,3 +14,9 @@ export const defaultSortSchemaTableBy: SchemaSortByIds[keyof SchemaSortByIds] =
         asc: true,
         key: 'name',
     };
+
+export const defaultSortSearchTableBy: SchemaSortByIds[keyof SchemaSortByIds] =
+    {
+        key: 'importance_score',
+        asc: true,
+    };

--- a/querybook/webapp/redux/dataTableSearch/const.ts
+++ b/querybook/webapp/redux/dataTableSearch/const.ts
@@ -18,5 +18,5 @@ export const defaultSortSchemaTableBy: SchemaSortByIds[keyof SchemaSortByIds] =
 export const defaultSortSearchTableBy: SchemaSortByIds[keyof SchemaSortByIds] =
     {
         key: 'relevance',
-        asc: true,
+        asc: true, // Ignored for relevance, but when user switch to name asc would be true
     };

--- a/querybook/webapp/redux/dataTableSearch/const.ts
+++ b/querybook/webapp/redux/dataTableSearch/const.ts
@@ -17,6 +17,6 @@ export const defaultSortSchemaTableBy: SchemaSortByIds[keyof SchemaSortByIds] =
 
 export const defaultSortSearchTableBy: SchemaSortByIds[keyof SchemaSortByIds] =
     {
-        key: 'importance_score',
+        key: 'relevance',
         asc: true,
     };

--- a/querybook/webapp/redux/dataTableSearch/reducer.ts
+++ b/querybook/webapp/redux/dataTableSearch/reducer.ts
@@ -1,6 +1,10 @@
 import { produce } from 'immer';
 
-import { defaultSortSchemaBy, defaultSortSchemaTableBy } from './const';
+import {
+    defaultSortSchemaBy,
+    defaultSortSearchTableBy,
+    defaultSortSchemaTableBy,
+} from './const';
 import {
     DataTableSearchAction,
     IDataTableSearchPaginationState,
@@ -25,7 +29,7 @@ const initialState: IDataTableSearchState = {
     searchString: '',
     searchRequest: null,
     metastoreId: null,
-    sortTablesBy: defaultSortSchemaTableBy,
+    sortTablesBy: defaultSortSearchTableBy,
     ...initialResultState,
 };
 


### PR DESCRIPTION
several users reported that the search results are getting less relevant, this is because the search is defaulted to sort by alphabetical instead of relevancy.
- renamed importance score to relevance 
- For search, changed the default ordering to be by relevance