### PR TITLE
fix: boost table score for exact match when searching table

### DIFF
--- a/querybook/server/lib/elasticsearch/search_table.py
+++ b/querybook/server/lib/elasticsearch/search_table.py
@@ -27,6 +27,8 @@ def _match_table_phrase_queries(fields, keywords):
             phrase_queries.append(
                 {"match_phrase": {"full_name": {"query": keywords, "boost": 10}}}
             )
+            # boost score for table name exact match
+            phrase_queries.append({"match": {"name": {"query": keywords, "boost": 10}}})
         elif field == "column":
             phrase_queries.append({"match_phrase": {"columns": {"query": keywords}}})
     return phrase_queries

--- a/querybook/server/lib/elasticsearch/search_table.py
+++ b/querybook/server/lib/elasticsearch/search_table.py
@@ -56,11 +56,11 @@ def construct_tables_query(
 ):
     keywords_query = {}
     if keywords:
+        should_clause = _match_table_phrase_queries(fields, keywords)
+
         table_schema, table_name = _get_potential_exact_schema_table_name(keywords)
         if table_schema:
             filters.append(["schema", table_schema])
-
-        should_clause = _match_table_phrase_queries(fields, keywords)
 
         # boost score for table name exact match
         if table_name:

--- a/querybook/server/lib/elasticsearch/search_table.py
+++ b/querybook/server/lib/elasticsearch/search_table.py
@@ -6,6 +6,14 @@ from lib.elasticsearch.query_utils import (
 )
 
 
+def _get_potential_exact_table_name(keywords):
+    dot_index = keywords.find(".")
+    if dot_index == -1:
+        return keywords
+
+    return keywords[dot_index + 1 :]
+
+
 def _match_table_word_fields(fields):
     search_fields = []
     for field in fields:
@@ -28,7 +36,10 @@ def _match_table_phrase_queries(fields, keywords):
                 {"match_phrase": {"full_name": {"query": keywords, "boost": 10}}}
             )
             # boost score for table name exact match
-            phrase_queries.append({"match": {"name": {"query": keywords, "boost": 10}}})
+            table_name = _get_potential_exact_table_name(keywords)
+            phrase_queries.append(
+                {"match": {"name": {"query": table_name, "boost": 10}}}
+            )
         elif field == "column":
             phrase_queries.append({"match_phrase": {"columns": {"query": keywords}}})
     return phrase_queries

--- a/querybook/server/lib/elasticsearch/search_table.py
+++ b/querybook/server/lib/elasticsearch/search_table.py
@@ -123,8 +123,5 @@ def construct_tables_query(
             }
         )
     )
-    import json
-
-    print("######################", json.dumps(query, indent=2))
 
     return query

--- a/querybook/webapp/redux/dataTableSearch/action.ts
+++ b/querybook/webapp/redux/dataTableSearch/action.ts
@@ -28,11 +28,6 @@ function mapStateToSearch(state: IDataTableSearchState) {
         ([_, filterValue]) => filterValue != null
     );
 
-    const matchSchemaName = searchString.match(/(\w+)\.(\w*)/);
-    if (matchSchemaName) {
-        filters.push(['schema', matchSchemaName[1]]);
-    }
-
     const searchParam = {
         metastore_id: state.metastoreId,
         keywords: searchString,


### PR DESCRIPTION
The previous tuning of https://github.com/pinterest/querybook/pull/631/files will boost score for all phrase match, not limited to exact match. e.g.

query: `default.hello_world`

candidate 1: `default.hello_world`
candidate 2: `default.hello_world_v2`


both candidate 1 and 2 will have the phrase match, while candidate 1 is the exact match. 

This change will boost another score for the exact match of candidate 1.