### PR TITLE
feat: add datadoc retry with delay on failure

### DIFF
--- a/querybook/server/lib/scheduled_datadoc/validator.py
+++ b/querybook/server/lib/scheduled_datadoc/validator.py
@@ -10,10 +10,11 @@ class InvalidScheduleException(Exception):
     pass
 
 
-valid_schedule_config_keys = ["exports", "notifications"]
+valid_schedule_config_keys = ["exports", "notifications", "retry"]
 valid_export_config_keys = ["exporter_cell_id", "exporter_name", "exporter_params"]
 valid_notification_keys = ["with", "on", "config"]
 valid_notification_config_keys = ["to", "to_user"]
+valid_retry_config_keys = ["enabled", "max_retries", "delay_sec"]
 
 
 def validate_datadoc_schedule_config(schedule_config):
@@ -21,6 +22,7 @@ def validate_datadoc_schedule_config(schedule_config):
         validate_dict_keys(schedule_config, valid_schedule_config_keys)
         validate_notifications_config(schedule_config.get("notifications", []))
         validate_exporters_config(schedule_config.get("exports", []))
+        validate_retry_config(schedule_config.get("retry", {}))
     except InvalidScheduleException as e:
         return False, str(e)
     return True, ""
@@ -81,3 +83,10 @@ def _get_exporter(export_config):
         return get_exporter(exporter_name)
     except ValueError:
         raise InvalidScheduleException(f"Invalid exporter {exporter_name}")
+
+
+def validate_retry_config(retry_config):
+    if not retry_config:
+        return
+
+    validate_dict_keys(retry_config, valid_retry_config_keys)

--- a/querybook/server/tasks/run_query.py
+++ b/querybook/server/tasks/run_query.py
@@ -29,17 +29,21 @@ LOG = get_task_logger(__name__)
     acks_late=True,
 )
 def run_query_task(
-    self, query_execution_id, execution_type=QueryExecutionType.ADHOC.value
+    self,
+    query_execution_id,
+    execution_type=QueryExecutionType.ADHOC.value,
+    celery_task=None,
 ):
     executor = None
     error_message = None
     query_execution_status = QueryExecutionStatus.INITIALIZED
+    celery_task = celery_task if celery_task is not None else self
 
     try:
         executor = create_executor_from_execution(
-            query_execution_id, celery_task=self, execution_type=execution_type
+            query_execution_id, celery_task=celery_task, execution_type=execution_type
         )
-        run_executor_until_finish(self, executor)
+        run_executor_until_finish(celery_task, executor)
     except SoftTimeLimitExceeded:
         # SoftTimeLimitExceeded
         # This exception happens when query has been running for more than

--- a/querybook/webapp/const/schedule.ts
+++ b/querybook/webapp/const/schedule.ts
@@ -74,6 +74,11 @@ export interface IDataDocScheduleNotification {
     };
 }
 
+export interface IDataDocScheduleRetry {
+    enabled: boolean;
+    max_retries?: number;
+    delay_sec?: number;
+}
 export interface IDataDocScheduleKwargs {
     doc_id?: number;
     user_id?: number;
@@ -83,6 +88,7 @@ export interface IDataDocScheduleKwargs {
         exporter_name?: string;
         exporter_params?: Record<string, any>;
     }>;
+    retry?: IDataDocScheduleRetry;
 }
 
 export interface IDataDocTaskSchedule extends ITaskSchedule {


### PR DESCRIPTION
Adds an option to enable retrying running a Datadoc cell on the event of a failure. Can set the max number of times a cell will retry, and the delay in seconds between each attempt. Retries are performed per-cell, but whenever any cell reaches the max retries limit, the DataDoc is marked failed.

This feature is disabled by default, and all existing schedules continue to work as before.

![Screen Shot 2022-12-08 at 11 30 48 AM](https://user-images.githubusercontent.com/72165460/206508281-64520c5b-dc5a-4bfc-a9b0-2e57b53a0188.png)

![Screen Shot 2022-12-08 at 11 07 00 AM](https://user-images.githubusercontent.com/72165460/206545245-47e63c18-06b9-45dc-ac9b-ebb610540f3a.png)
