### PR TITLE
fix: hasOwnProperty is not a function issue from json-big

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.14.3",
+    "version": "3.14.4",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/lib/query-result/transformer.tsx
+++ b/querybook/webapp/lib/query-result/transformer.tsx
@@ -104,6 +104,11 @@ const queryResultTransformers: IColumnTransformer[] = [
                 if (!json || typeof json !== 'object') {
                     return v;
                 }
+
+                // This is a workaround for https://github.com/sidorares/json-bigint/issues/38
+                // to make sure it is of `Object` prototype when passed over to <ReactJson />
+                const jsonSrc = { ...json };
+
                 return (
                     <ReactJson
                         collapsed={1} // keep first level expanded by default
@@ -111,7 +116,7 @@ const queryResultTransformers: IColumnTransformer[] = [
                         enableClipboard={false}
                         name={false}
                         quotesOnKeys={false}
-                        src={json}
+                        src={jsonSrc}
                         theme={ReactJsonTheme}
                     />
                 );


### PR DESCRIPTION
**Issue**
The json column transformer somehow didn't work with error 
```
Uncaught TypeError: e.hasOwnProperty is not a function
    at vendors-node_modules_lodash_sampleSize_js-node_modules_react-json-view_dist_main_js.1fa9e63d206dc9b137e1.js:209:107637
    at Array.forEach (<anonymous>)
    at a.renderObjectContents (vendors-node_modules_lodash_sampleSize_js-node_modules_react-json-view_dist_main_js.1fa9e63d206dc9b137e1.js:209:107544)
```

**Cause**
The parsed json object doesn't has functions like `hasOwnProperty` from the `Object` prototype.

**Fix**
As a workaround, we'll use object spread to copy the parsed json over to a plain Javascript object.

