### PR TITLE
feat: add logout event hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.15.0",
+    "version": "3.15.1",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/app/auth/__init__.py
+++ b/querybook/server/app/auth/__init__.py
@@ -39,6 +39,11 @@ def load_auth():
 
 
 def logout():
+    global auth
+    has_logout = hasattr(auth, "on_logout_user")
+    if has_logout:
+        auth.on_logout_user()
+
     logout_user()
 
 

--- a/querybook/server/lib/event_logger/__init__.py
+++ b/querybook/server/lib/event_logger/__init__.py
@@ -29,9 +29,10 @@ class EventLogger:
 
     def log_api_request(self, route: str, method: str, params: dict):
         try:
-            self.logger.log_api_request(
-                uid=current_user.id, route=route, method=method, params=params
-            )
+            if current_user.is_authenticated:
+                self.logger.log_api_request(
+                    uid=current_user.id, route=route, method=method, params=params
+                )
         except Exception as e:
             LOG.error(e, exc_info=True)
 

--- a/querybook/webapp/components/SessionExpirationNotice/SessionExpirationNotice.tsx
+++ b/querybook/webapp/components/SessionExpirationNotice/SessionExpirationNotice.tsx
@@ -1,11 +1,17 @@
 import React, { useCallback } from 'react';
 
 import { useGlobalState } from 'hooks/redux/useGlobalState';
+import { UserResource } from 'resource/user';
 import { Title } from 'ui/Title/Title';
 
 export const SessionExpirationNotice: React.FC = () => {
     const [sessionExpired] = useGlobalState('sessionExpired', false);
-    const refreshPage = useCallback(() => window.location.reload(), []);
+    const refreshPage = useCallback(() => {
+        // Try to logout in case it wasn't shown correctly
+        UserResource.logout().finally(() => {
+            window.location.reload();
+        });
+    }, []);
     return sessionExpired ? (
         <div
             className="flex-center"


### PR DESCRIPTION
when user logs out, allow auth module to provide additional callback before actually logging them out via flask_login
also fixed a bug where current_user.id is used for unauth endpoints