### PR TITLE
feat: Add shortcut for toggle ToC, update datadoc short cuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.15.1",
+    "version": "3.15.2",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/components/DataDocChartCell/DataDocChartCell.tsx
+++ b/querybook/webapp/components/DataDocChartCell/DataDocChartCell.tsx
@@ -33,7 +33,6 @@ interface IProps {
     onBlur?: () => any;
     onUpKeyPressed?: () => any;
     onDownKeyPressed?: () => any;
-    onDeleteKeyPressed?: () => any;
 }
 
 export const DataDocChartCell = React.memo<IProps>(

--- a/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
+++ b/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
@@ -1,9 +1,11 @@
 import clsx from 'clsx';
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { DataTableViewMini } from 'components/DataTableViewMini/DataTableViewMini';
 import { IDataCell } from 'const/datadoc';
+import { useEvent } from 'hooks/useEvent';
+import { getShortcutSymbols, KeyMap, matchKeyMap } from 'lib/utils/keyboard';
 import { setSidebarTableId } from 'redux/querybookUI/action';
 import { IStoreState } from 'redux/store/types';
 import { IconButton } from 'ui/Button/IconButton';
@@ -20,6 +22,7 @@ interface IProps {
 }
 
 type LeftSidebarContentState = 'contents' | 'table' | 'default';
+const TOGGLE_TOC_SHORTCUT = getShortcutSymbols(KeyMap.dataDoc.toggleToC.key);
 
 export const DataDocLeftSidebar: React.FunctionComponent<IProps> = ({
     docId,
@@ -33,6 +36,22 @@ export const DataDocLeftSidebar: React.FunctionComponent<IProps> = ({
 
     const [contentState, setContentState] =
         React.useState<LeftSidebarContentState>('default');
+
+    useEvent(
+        'keydown',
+        useCallback((evt: KeyboardEvent) => {
+            if (matchKeyMap(evt, KeyMap.dataDoc.toggleToC)) {
+                setContentState((contentState) => {
+                    if (contentState !== 'contents') {
+                        return 'contents';
+                    }
+                    return 'default';
+                });
+                evt.stopPropagation();
+                evt.preventDefault();
+            }
+        }, [])
+    );
 
     useEffect(
         () => () => {
@@ -60,7 +79,9 @@ export const DataDocLeftSidebar: React.FunctionComponent<IProps> = ({
                         onClick={() => setContentState('default')}
                     />
                     <div className="flex-row">
-                        <span className="mr4">contents</span>
+                        <span className="mr4">
+                            contents ({TOGGLE_TOC_SHORTCUT})
+                        </span>
                         <InfoButton layout={['right', 'top']}>
                             Click to jump to the corresponding cell. Drag cells
                             to reorder them.

--- a/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
+++ b/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
@@ -110,7 +110,7 @@ export const DataDocLeftSidebar: React.FunctionComponent<IProps> = ({
                     color="light"
                     invertCircle
                     size={20}
-                    tooltip="Table of Contents"
+                    tooltip={`Table of Contents (${TOGGLE_TOC_SHORTCUT})`}
                     tooltipPos="right"
                 />
             </div>

--- a/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
+++ b/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
@@ -88,7 +88,6 @@ interface IOwnProps {
     onBlur?: () => any;
     onUpKeyPressed?: () => any;
     onDownKeyPressed?: () => any;
-    onDeleteKeyPressed?: () => any;
     toggleFullScreen: () => any;
 }
 type IProps = IOwnProps & StateProps & DispatchProps;
@@ -192,7 +191,6 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
     public _keyMapMemo(engines: IQueryEngine[]) {
         const keyMap = {
             [KeyMap.queryEditor.runQuery.key]: this.clickOnRunButton,
-            [KeyMap.queryEditor.deleteCell.key]: this.props.onDeleteKeyPressed,
         };
 
         for (const [index, engine] of engines.entries()) {

--- a/querybook/webapp/components/DataDocTextCell/DataDocTextCell.tsx
+++ b/querybook/webapp/components/DataDocTextCell/DataDocTextCell.tsx
@@ -30,7 +30,6 @@ interface IProps {
         context?: string | DraftJs.ContentState;
         meta?: IDataCellMetaBase;
     }) => any;
-    onDeleteKeyPressed?: () => any;
     onFocus?: () => any;
     onBlur?: () => any;
     onUpKeyPressed?: () => any;
@@ -45,7 +44,6 @@ export const DataDocTextCell = React.memo<IProps>(
         isEditable,
         shouldFocus,
         onChange,
-        onDeleteKeyPressed,
         onFocus,
         onBlur,
         onUpKeyPressed,
@@ -139,9 +137,6 @@ export const DataDocTextCell = React.memo<IProps>(
                         onDownKeyPressed();
                         handled = true;
                     }
-                } else if (matchKeyMap(event, KeyMap.richText.deleteCell)) {
-                    onDeleteKeyPressed?.();
-                    handled = true;
                 } else if (matchKeyMap(event, KeyMap.dataDoc.openSearch)) {
                     searchContext.showSearchAndReplace();
                     handled = true;
@@ -152,7 +147,7 @@ export const DataDocTextCell = React.memo<IProps>(
 
                 return handled;
             },
-            [onUpKeyPressed, onDownKeyPressed, onDeleteKeyPressed]
+            [onUpKeyPressed, onDownKeyPressed]
         );
 
         const className = clsx({

--- a/querybook/webapp/const/keyMap.ts
+++ b/querybook/webapp/const/keyMap.ts
@@ -43,16 +43,20 @@ const DEFAULT_KEY_MAP = {
             name: 'Go to next cell',
         },
         copyCell: {
-            key: 'Alt-Shift-C',
+            key: 'Alt-C',
             name: 'Copy current cell',
         },
         pasteCell: {
-            key: 'Alt-Shift-V',
+            key: 'Alt-V',
             name: 'Paste below current cell',
         },
         deleteCell: {
-            key: 'Alt-Shift-D',
+            key: 'Alt-D',
             name: 'Delete current cell',
+        },
+        toggleToC: {
+            key: 'Alt-T',
+            name: 'Toggle Table of Contents',
         },
     },
     richText: {

--- a/querybook/webapp/context/DataDoc.ts
+++ b/querybook/webapp/context/DataDoc.ts
@@ -15,6 +15,7 @@ export interface IDataDocContextType {
     updateCell: (cellId: number, fields: DataCellUpdateFields) => Promise<any>;
     copyCellAt: (index: number, cut: boolean) => void;
     pasteCellAt: (pasteIndex: number) => Promise<void>;
+    deleteCellAt: (index: number) => Promise<void>;
     fullScreenCellAt: (index: number) => void;
 
     defaultCollapse: boolean;

--- a/querybook/webapp/lib/data-doc/data-doc-utils.ts
+++ b/querybook/webapp/lib/data-doc/data-doc-utils.ts
@@ -1,3 +1,5 @@
+import { IDataCell } from 'const/datadoc';
+import { ContentState } from 'draft-js';
 import scrollIntoView from 'smooth-scroll-into-view-if-needed';
 
 export async function scrollToCell(
@@ -53,3 +55,14 @@ export const hashString = (str: string) => {
     }
     return hash;
 };
+
+export function isCellEmpty(cell: IDataCell): boolean {
+    const cellType = cell.cell_type;
+    if (cellType === 'query') {
+        return cell.context === '';
+    } else if (cellType === 'text') {
+        return !(cell.context as ContentState).hasText();
+    }
+
+    return false;
+}


### PR DESCRIPTION
- Added Alt+T to toggle ToC within a DataDoc
- Changed copy/paste/delete shortcut from `Alt-Shift` to just Alt