### PR TITLE
feat: auto add quotes for table/columns

### DIFF
--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -559,13 +559,11 @@ export const QueryEditor: React.FC<
 
         const handleOnFocus = useCallback(
             (editor: CodeMirror.Editor, event) => {
-                autoCompleter.registerHelper();
-
                 if (onFocus) {
                     onFocus(editor, event);
                 }
             },
-            [onFocus, autoCompleter]
+            [onFocus]
         );
 
         const handleOnKeyUp = useCallback(

--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -130,7 +130,7 @@ export const QueryEditor: React.FC<
             language,
             query: value,
         });
-        const autoCompleter = useAutoComplete(
+        const { autoCompleter, autoCompleterRef } = useAutoComplete(
             metastoreId,
             autoCompleteType,
             language,
@@ -559,11 +559,16 @@ export const QueryEditor: React.FC<
 
         const handleOnFocus = useCallback(
             (editor: CodeMirror.Editor, event) => {
+                // This is needed because we could have multiple QueryEditor
+                // instances on the same page
+                // Note that we are using ref here because ReactCodeMirror doesn't
+                // use the new handleOnFocus - it only uses the one on mount
+                autoCompleterRef.current.registerHelper();
                 if (onFocus) {
                     onFocus(editor, event);
                 }
             },
-            [onFocus]
+            [onFocus, autoCompleterRef]
         );
 
         const handleOnKeyUp = useCallback(

--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -130,7 +130,7 @@ export const QueryEditor: React.FC<
             language,
             query: value,
         });
-        const { autoCompleter, autoCompleterRef } = useAutoComplete(
+        const autoCompleterRef = useAutoComplete(
             metastoreId,
             autoCompleteType,
             language,

--- a/querybook/webapp/hooks/queryEditor/useAutoComplete.ts
+++ b/querybook/webapp/hooks/queryEditor/useAutoComplete.ts
@@ -1,5 +1,5 @@
 import CodeMirror from 'lib/codemirror';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import {
     AutoCompleteType,
     SqlAutoCompleter,
@@ -12,20 +12,21 @@ export function useAutoComplete(
     language: string,
     codeAnalysis: ICodeAnalysis
 ) {
-    const autoCompleter = useMemo(
-        () =>
-            new SqlAutoCompleter(
-                CodeMirror,
-                language,
-                metastoreId,
-                autoCompleteType
-            ),
-        [language, metastoreId, autoCompleteType]
-    );
+    const autoCompleterRef = useRef<SqlAutoCompleter>();
+    const autoCompleter = useMemo(() => {
+        const completer = new SqlAutoCompleter(
+            CodeMirror,
+            language,
+            metastoreId,
+            autoCompleteType
+        );
+        autoCompleterRef.current = completer;
+        return completer;
+    }, [language, metastoreId, autoCompleteType]);
 
     useEffect(() => {
         autoCompleter.updateCodeAnalysis(codeAnalysis);
     }, [codeAnalysis, autoCompleter]);
 
-    return autoCompleter;
+    return { autoCompleter, autoCompleterRef };
 }

--- a/querybook/webapp/hooks/queryEditor/useAutoComplete.ts
+++ b/querybook/webapp/hooks/queryEditor/useAutoComplete.ts
@@ -28,5 +28,5 @@ export function useAutoComplete(
         autoCompleter.updateCodeAnalysis(codeAnalysis);
     }, [codeAnalysis, autoCompleter]);
 
-    return { autoCompleter, autoCompleterRef };
+    return autoCompleterRef;
 }

--- a/querybook/webapp/lib/sql-helper/sql-autocompleter.ts
+++ b/querybook/webapp/lib/sql-helper/sql-autocompleter.ts
@@ -106,7 +106,6 @@ function findLast(arr: Array<[number, any]>, num: number) {
 function checkNameNeedsEscape(name: string) {
     return !name.match(/^\w+$/);
 }
-
 interface IAutoCompleteResult {
     list: ICompletionRow[];
     from: CodeMirror.Position;
@@ -121,6 +120,7 @@ export class SqlAutoCompleter {
     private Pos: CodeMirror.PositionConstructor;
     private codeAnalysis?: ICodeAnalysis;
     private metastoreId?: number;
+    private language: string;
     private languageSetting: ILanguageSetting;
     private keywords?: string[];
     private type: AutoCompleteType;
@@ -137,7 +137,9 @@ export class SqlAutoCompleter {
 
         this.Pos = this.codeMirrorInstance.Pos;
         this.codeAnalysis = null;
-        this.languageSetting = getLanguageSetting(language);
+
+        this.language = language;
+        this.languageSetting = getLanguageSetting(this.language);
 
         this.registerHelper();
     }

--- a/querybook/webapp/lib/sql-helper/sql-setting.ts
+++ b/querybook/webapp/lib/sql-helper/sql-setting.ts
@@ -1,12 +1,13 @@
 // https://github.com/codemirror/CodeMirror/blob/master/mode/sql/sql.js
 // Language Setting
-interface ILanguageSetting {
+export interface ILanguageSetting {
     keywords: Set<string>;
     type: Set<string>;
     bool: Set<string>;
     operatorChars: RegExp;
     punctuationChars: RegExp;
     placeholderVariable?: RegExp;
+    quoteChars?: [quoteStart: string, quoteEnd: string];
 }
 
 const SQL_KEYWORDS =
@@ -30,6 +31,7 @@ const SettingsByLanguage: Record<string, ILanguageSetting> = {
         operatorChars: /^[*+\-%<>!=&|^~]/,
         punctuationChars: /^[/:.]/,
         placeholderVariable: /^\${.*?}/,
+        quoteChars: ['`', '`'],
         // These are code mirror specific
         // dateSQL: new Set("date timestamp".split(" ")),
         // support: new Set("ODBCdotTable doubleQuote binaryNumber hexNumber".split(" "))
@@ -49,6 +51,7 @@ const SettingsByLanguage: Record<string, ILanguageSetting> = {
         bool: new Set('false true null'.split(' ')),
         operatorChars: /^[*+\-%<>!=|]/,
         punctuationChars: /^[/:.]/,
+        quoteChars: ['"', '"'],
     },
     mysql: {
         keywords: new Set(
@@ -65,6 +68,7 @@ const SettingsByLanguage: Record<string, ILanguageSetting> = {
         bool: new Set('false true null'.split(' ')),
         operatorChars: /^[*+\-%<>!=&|^~]/,
         punctuationChars: /^[/:.]/,
+        quoteChars: ['`', '`'],
     },
     trino: {
         keywords: new Set(
@@ -81,6 +85,7 @@ const SettingsByLanguage: Record<string, ILanguageSetting> = {
         bool: new Set('false true null'.split(' ')),
         operatorChars: /^[*+\-%<>!=|]/,
         punctuationChars: /^[/:.]/,
+        quoteChars: ['"', '"'],
     },
 };
 SettingsByLanguage['sparksql'] = SettingsByLanguage['hive'];


### PR DESCRIPTION
If a column is like "foo/bar" then querybook would auto add quotes around the column names, similarly for tables.

For Presto
![image](https://user-images.githubusercontent.com/8283407/209026429-a859ce35-15b2-43b2-96ad-a9a5cd29b335.png)

For MySQL
![image](https://user-images.githubusercontent.com/8283407/209027604-e0ffcc74-8de1-4534-af6f-e5f802074b05.png)

also 2 bug fixes:
- If column name has upper case, still match prefix
- make sure getSQLHint always goes to the latest language type