### PR TITLE
feat: a bunch of small ui fixes and improvements

### DIFF
--- a/querybook/webapp/components/DataDoc/DataDoc.tsx
+++ b/querybook/webapp/components/DataDoc/DataDoc.tsx
@@ -831,7 +831,12 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
             // during this time we will focus the new inserted cell
             const cellLengthChanged = cells.length !== previousCells.length;
             if (cellLengthChanged && this.focusCellIndexAfterInsert != null) {
-                this.focusCellAt(this.focusCellIndexAfterInsert);
+                const cellIndexToFocus = this.focusCellIndexAfterInsert;
+                setImmediate(() => {
+                    // setting focus cell during componentDidUpdate would not
+                    // actually focus the cell, we need to do it in another thread
+                    this.focusCellAt(cellIndexToFocus);
+                });
                 this.focusCellIndexAfterInsert = null;
             }
         }

--- a/querybook/webapp/components/DataDoc/DataDoc.tsx
+++ b/querybook/webapp/components/DataDoc/DataDoc.tsx
@@ -834,7 +834,7 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
                 const cellIndexToFocus = this.focusCellIndexAfterInsert;
                 setImmediate(() => {
                     // setting focus cell during componentDidUpdate would not
-                    // actually focus the cell, we need to do it in another thread
+                    // actually focus the cell, we need to do it in another event loop
                     this.focusCellAt(cellIndexToFocus);
                 });
                 this.focusCellIndexAfterInsert = null;

--- a/querybook/webapp/components/DataDocNavigator/DataDocGridItem.scss
+++ b/querybook/webapp/components/DataDocNavigator/DataDocGridItem.scss
@@ -1,5 +1,5 @@
 .DataDocGridItem {
-    .delete-grid-item-button {
+    .IconButton.delete-grid-item-button {
         display: none;
         padding: 0px;
     }

--- a/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.tsx
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.tsx
@@ -29,6 +29,7 @@ export const DataTableColumnCard: React.FunctionComponent<IProps> = ({
         <EditableTextField
             value={column.description as ContentState}
             onSave={updateDataColumnDescription.bind(null, column.id)}
+            placeholder="No user comments yet for column."
         />
     );
     return (

--- a/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
+++ b/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
@@ -115,6 +115,7 @@ export const DataTableViewOverview: React.FC<
         <EditableTextField
             value={table.description as DraftJs.ContentState}
             onSave={onDescriptionSave}
+            placeholder="No description for this table yet."
         />
     ) : null;
 

--- a/querybook/webapp/components/DataTableViewQueryExample/DataTableViewQueryExamples.scss
+++ b/querybook/webapp/components/DataTableViewQueryExample/DataTableViewQueryExamples.scss
@@ -10,6 +10,12 @@
         position: relative;
         margin-top: 24px;
 
+        .DataTableViewQueryExamples-header {
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+            align-items: flex-start;
+        }
         .DataTableViewQueryExamples-query {
             height: auto;
             max-height: 360px;

--- a/querybook/webapp/components/DataTableViewQueryExample/DataTableViewQueryExamples.scss
+++ b/querybook/webapp/components/DataTableViewQueryExample/DataTableViewQueryExamples.scss
@@ -28,12 +28,6 @@
                 font-weight: var(--bold-font);
             }
         }
-
-        .Button {
-            position: absolute;
-            top: 0px;
-            right: 20px;
-        }
     }
 }
 

--- a/querybook/webapp/components/DataTableViewQueryExample/DataTableViewQueryExamples.tsx
+++ b/querybook/webapp/components/DataTableViewQueryExample/DataTableViewQueryExamples.tsx
@@ -297,29 +297,28 @@ const QueryExamplesList: React.FC<{
         }
 
         const queryExamplesDOM = queryExamples
-            .map((queryExample) => {
-                const query = queryExample.queryExecution;
-                const queryTitle = queryExample.cellTitle;
-
+            .map(({ queryExecution, cellTitle }) => {
                 const language =
-                    queryEngineById[query.engine_id]?.language ?? 'presto';
-                const formattedQuery = format(query.query, language, {
+                    queryEngineById[queryExecution.engine_id]?.language ??
+                    'presto';
+                const formattedQuery = format(queryExecution.query, language, {
                     case: 'upper',
                 });
                 return (
                     <div
                         className="DataTableViewQueryExamples-item"
-                        key={query.id}
+                        key={queryExecution.id}
                     >
-                        <div className="horizontal-space-between mb4">
-                            <Title size="med" untitled={!queryTitle}>
-                                {queryTitle || 'Untitled Execution'}
+                        <div className="DataTableViewQueryExamples-header mb4">
+                            <Title size="med" untitled={!cellTitle}>
+                                {cellTitle || 'Untitled Execution'}
                             </Title>
                             <TextButton
                                 icon="ArrowRight"
                                 title="Open Execution"
-                                className="mt8"
-                                onClick={() => openDisplayModal(query.id)}
+                                onClick={() =>
+                                    openDisplayModal(queryExecution.id)
+                                }
                             />
                         </div>
 
@@ -329,7 +328,7 @@ const QueryExamplesList: React.FC<{
                         />
                         <div className="DataTableViewQueryExamples-info">
                             <span>by </span>
-                            <UserName uid={query.uid} />
+                            <UserName uid={queryExecution.uid} />
                         </div>
                     </div>
                 );

--- a/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentAppSidebar.tsx
+++ b/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentAppSidebar.tsx
@@ -7,6 +7,8 @@ import { DataDocSchemaNavigator } from 'components/DataDocSchemaNavigator/DataDo
 import { QuerySnippetNavigator } from 'components/QuerySnippetNavigator/QuerySnippetNavigator';
 import { QueryViewNavigator } from 'components/QueryViewNavigator/QueryViewNavigator';
 import { useEvent } from 'hooks/useEvent';
+import { useLocalStoreState } from 'hooks/useLocalStoreState';
+import { SIDEBAR_ENTITY } from 'lib/local-store/const';
 import { KeyMap, matchKeyMap } from 'lib/utils/keyboard';
 import { navigateWithinEnv } from 'lib/utils/query-string';
 import { currentEnvironmentSelector } from 'redux/environment/selector';
@@ -30,7 +32,10 @@ export const EnvironmentAppSidebar: React.FunctionComponent = () => {
         (state: IStoreState) => state.querybookUI.isEnvCollapsed
     );
     const dispatch: Dispatch = useDispatch();
-    const [entity, setEntity] = React.useState<Entity>('datadoc');
+    const [entity, setEntity] = useLocalStoreState<Entity>({
+        storeKey: SIDEBAR_ENTITY,
+        defaultValue: 'datadoc',
+    });
 
     const currentEnvironment = useSelector(currentEnvironmentSelector);
 
@@ -47,7 +52,7 @@ export const EnvironmentAppSidebar: React.FunctionComponent = () => {
                 return newEntity;
             });
         },
-        [dispatch, collapsed]
+        [dispatch, collapsed, setEntity]
     );
 
     const scrollToCollapseSidebar = React.useCallback(

--- a/querybook/webapp/const/chartColors.ts
+++ b/querybook/webapp/const/chartColors.ts
@@ -8,7 +8,11 @@ export const ColorPalette: IColorPalette[] = [
     { name: 'pink', color: '#ff3975', fillColor: 'rgba(255, 57, 117, 0.25)' },
     { name: 'grey', color: '#bfbfbf', fillColor: 'rgba(191, 191, 191, 0.25)' },
     { name: 'gold', color: '#ffca00', fillColor: 'rgba(255, 202, 0, 0.25)' },
-    { name: 'blue', color: '#529dce', fillColor: 'rgba(82, 157, 206, 0.25)' },
+    {
+        name: 'picton blue',
+        color: '#529dce',
+        fillColor: 'rgba(82, 157, 206, 0.25)',
+    },
     { name: 'orange', color: '#ff9f42', fillColor: 'rgba(255, 159, 66, 0.25)' },
     {
         name: 'creamy forest green',

--- a/querybook/webapp/hooks/chart/useChartSource.ts
+++ b/querybook/webapp/hooks/chart/useChartSource.ts
@@ -95,7 +95,7 @@ export function useChartSource(
             getCellQueryExecutions(cellId);
         } else if (cellId == null && executionId) {
             dispatch(
-                queryExecutionsActions.fetchDataDocInfoByQueryExecutionId(
+                queryExecutionsActions.fetchDataDocInfoByQueryExecutionIdIfNeeded(
                     executionId
                 )
             ).then(({ cell_id: newCellId }) => {

--- a/querybook/webapp/hooks/useLocalStoreState.ts
+++ b/querybook/webapp/hooks/useLocalStoreState.ts
@@ -1,0 +1,38 @@
+import localStore from 'lib/local-store';
+import { Nullable } from 'lib/typescript';
+import { isFunction } from 'lodash';
+import { useCallback, useEffect, useState } from 'react';
+
+export function useLocalStoreState<T>({
+    storeKey,
+    defaultValue,
+}: {
+    storeKey: string;
+    defaultValue: Nullable<T | (() => T)>;
+}) {
+    const [state, setState] = useState<T>(defaultValue);
+
+    useEffect(() => {
+        localStore.get<T>(storeKey).then((storedVal) => {
+            if (storedVal != null) {
+                // if the val is retrieved
+                setState(storedVal);
+            }
+        });
+    }, [storeKey]);
+
+    const syncedSetState = useCallback(
+        (newValOrFunc: T | ((old: T) => T)) => {
+            setState((oldVal) => {
+                const newVal = isFunction(newValOrFunc)
+                    ? newValOrFunc(oldVal)
+                    : newValOrFunc;
+                localStore.set(storeKey, newVal);
+                return newVal;
+            });
+        },
+        [storeKey]
+    );
+
+    return [state, syncedSetState] as const;
+}

--- a/querybook/webapp/lib/local-store/const.ts
+++ b/querybook/webapp/lib/local-store/const.ts
@@ -1,4 +1,5 @@
-import { IAdhocQuery } from 'const/adhocQuery';
+import type { Entity } from 'components/EnvironmentAppSidebar/types';
+import type { IAdhocQuery } from 'const/adhocQuery';
 
 export const DISMISSED_ANNOUNCEMENT_KEY = 'dismissed_announcement_ids';
 export type DismissedAnnouncementValue = number[];
@@ -14,3 +15,6 @@ export type DataDocNavSectionValue = Record<string, boolean>;
 
 export const ADHOC_QUERY_KEY = 'adhoc_query_editor';
 export type AdhocQueryValue = IAdhocQuery;
+
+export const SIDEBAR_ENTITY = 'sidebar_entity';
+export type TSidebarEntity = Entity;

--- a/querybook/webapp/redux/queryExecutions/action.ts
+++ b/querybook/webapp/redux/queryExecutions/action.ts
@@ -240,7 +240,7 @@ export function fetchQueryExecutionsByCell(
     };
 }
 
-export function fetchDataDocInfoByQueryExecutionId(
+export function fetchDataDocInfoByQueryExecutionIdIfNeeded(
     executionId: number
 ): ThunkResult<
     Promise<{
@@ -249,7 +249,16 @@ export function fetchDataDocInfoByQueryExecutionId(
         cell_title: string;
     }>
 > {
-    return async (dispatch) => {
+    return async (dispatch, getState) => {
+        const state = getState().queryExecutions.queryExecutionIdToCellInfo;
+        if (executionId in state) {
+            return {
+                cell_id: state[executionId].cellId,
+                doc_id: state[executionId].docId,
+                cell_title: state[executionId].cellTitle,
+            };
+        }
+
         const { data: result } = await QueryExecutionResource.getDataDoc(
             executionId
         );
@@ -259,6 +268,8 @@ export function fetchDataDocInfoByQueryExecutionId(
             payload: {
                 executionId,
                 cellId: result.cell_id,
+                cellTitle: result.cell_title,
+                docId: result.doc_id,
             },
         });
         return result;

--- a/querybook/webapp/redux/queryExecutions/reducer.ts
+++ b/querybook/webapp/redux/queryExecutions/reducer.ts
@@ -10,7 +10,9 @@ import { IQueryExecutionState, QueryExecutionAction } from './types';
 const initialState: IQueryExecutionState = {
     queryExecutionById: {},
     statementExecutionById: {},
+
     dataCellIdQueryExecution: {},
+    queryExecutionIdToCellInfo: {},
 
     statementResultById: {},
     statementResultLoadingById: {},
@@ -22,6 +24,26 @@ const initialState: IQueryExecutionState = {
     viewersByExecutionIdUserId: {},
     accessRequestsByExecutionIdUserId: {},
 };
+
+function queryExecutionIdToCellInfoReducer(
+    state = initialState.queryExecutionIdToCellInfo,
+    action: QueryExecutionAction
+) {
+    return produce(state, (draft) => {
+        switch (action.type) {
+            case '@@queryExecutions/RECEIVE_QUERY_CELL_ID_FROM_EXECUTION': {
+                const { executionId, cellId, cellTitle, docId } =
+                    action.payload;
+                draft[executionId] = {
+                    cellId,
+                    cellTitle,
+                    docId,
+                };
+                return;
+            }
+        }
+    });
+}
 
 function dataCellIdQueryExecutionReducer(
     state = initialState.dataCellIdQueryExecution,
@@ -414,6 +436,8 @@ function statementExportersReducer(
 
 export default combineReducers({
     dataCellIdQueryExecution: dataCellIdQueryExecutionReducer,
+    queryExecutionIdToCellInfo: queryExecutionIdToCellInfoReducer,
+
     statementExecutionById: statementExecutionByIdReducer,
     queryExecutionById: queryExecutionByIdReducer,
 

--- a/querybook/webapp/redux/queryExecutions/types.ts
+++ b/querybook/webapp/redux/queryExecutions/types.ts
@@ -111,6 +111,8 @@ export interface IReceiveQueryCellIdFromExecution extends Action {
     payload: {
         executionId: number;
         cellId: number;
+        cellTitle: string;
+        docId: number;
     };
 }
 
@@ -184,7 +186,16 @@ export type QueryExecutionAction =
 export interface IQueryExecutionState {
     queryExecutionById: Record<number, IQueryExecution>;
     statementExecutionById: Record<number, IStatementExecution>;
+
     dataCellIdQueryExecution: Record<number, Set<number>>;
+    queryExecutionIdToCellInfo: Record<
+        number,
+        {
+            cellId: number;
+            cellTitle: string;
+            docId: number;
+        }
+    >;
 
     queryErrorById: Record<number, IQueryError>;
     statementResultById: Record<number, IStatementResult>;

--- a/querybook/webapp/ui/EditableTextField/EditableTextField.tsx
+++ b/querybook/webapp/ui/EditableTextField/EditableTextField.tsx
@@ -13,11 +13,12 @@ export interface IEditableTextFieldProps {
     onSave: (content: DraftJs.ContentState) => Promise<any>;
     className?: string;
     readonly?: boolean;
+    placeholder?: string;
 }
 
 export const EditableTextField: React.FunctionComponent<
     IEditableTextFieldProps
-> = ({ value, onSave, className, readonly = false }) => {
+> = ({ value, onSave, className, placeholder, readonly = false }) => {
     const [editMode, setEditMode] = React.useState(false);
     const editorRef = React.useRef<RichTextEditor>(null);
 
@@ -73,6 +74,7 @@ export const EditableTextField: React.FunctionComponent<
                 value={value}
                 readOnly={readonly || !editMode}
                 ref={editorRef}
+                placeholder={placeholder}
             />
             {toggleEditModeButton}
         </div>

--- a/querybook/webapp/ui/Link/ListLink.tsx
+++ b/querybook/webapp/ui/Link/ListLink.tsx
@@ -39,7 +39,10 @@ export const ListLink: React.FunctionComponent<IProps> = React.memo(
                         {title}
                     </StyledText>
                 ) : noPlaceHolder ? null : (
-                    <UntitledText size="small" />
+                    <UntitledText
+                        className="ListLinkPlaceholder"
+                        size="small"
+                    />
                 )}
                 {icon && <Icon name={icon} size={16} />}
                 {children}

--- a/querybook/webapp/ui/RichTextEditor/RichTextEditor.tsx
+++ b/querybook/webapp/ui/RichTextEditor/RichTextEditor.tsx
@@ -26,6 +26,7 @@ export interface IRichTextEditorProps {
     className?: string;
     readOnly?: boolean;
     value: DraftJs.ContentState;
+    placeholder?: string;
 
     onChange?: (editorState: DraftJs.EditorState) => any;
     onKeyDown?: (
@@ -550,7 +551,8 @@ export class RichTextEditor extends React.PureComponent<
     }
 
     public render() {
-        const { className, onFocus, onBlur, readOnly } = this.props;
+        const { className, onFocus, onBlur, readOnly, placeholder } =
+            this.props;
 
         const { editorState, toolBarStyle } = this.state;
         const toolBar = readOnly ? null : (
@@ -567,6 +569,7 @@ export class RichTextEditor extends React.PureComponent<
         const editor = (
             <DraftJs.Editor
                 editorState={editorState}
+                placeholder={placeholder}
                 keyBindingFn={this.keyBindingFn}
                 handleKeyCommand={this.handleKeyCommand}
                 onChange={this.onChange}


### PR DESCRIPTION
Features:
- added placeholder for table description
![image](https://user-images.githubusercontent.com/8283407/209407443-dbee02c8-468e-4aaf-94a7-f7a8fea6527e.png)
- added cell title for query examples
![image](https://user-images.githubusercontent.com/8283407/209407473-dcd1e864-75ac-4c4d-bbe1-418019b01720.png)
- querybook would now memoize the sidebar being selected

Fixes:
- Adding a new query cell would now trigger auto focus
- hovering over datadocs in favorite section would not cause the row to expand
- the x buton for untitled doc in favorite section would be right aligned
- renamed the second blue in chart series color to "picton blue" to avoid duplicate naming