### PR TITLE
fix: Add disabled indicators to Schedules list

### DIFF
--- a/querybook/webapp/components/DataDocScheduleList/DataDocScheduleItem.tsx
+++ b/querybook/webapp/components/DataDocScheduleList/DataDocScheduleItem.tsx
@@ -38,7 +38,12 @@ export const DataDocScheduleItem: React.FC<IDataDocScheduleItemProps> = ({
                         Runs <HumanReadableCronSchedule cron={schedule.cron} />
                     </StyledText>
                     <StyledText color="light" className="mt4">
-                        Next Run: <NextRun cron={schedule.cron} />
+                        Next Run:{' '}
+                        {schedule.enabled ? (
+                            <NextRun cron={schedule.cron} />
+                        ) : (
+                            'Disabled'
+                        )}
                     </StyledText>
                 </div>
                 {lastRecord && (
@@ -99,7 +104,11 @@ export const DataDocScheduleItem: React.FC<IDataDocScheduleItemProps> = ({
                 <div className="flex-row">
                     <Link to={getWithinEnvUrl(`/datadoc/${doc.id}/`)}>
                         {doc.title ? (
-                            <AccentText weight="bold" size="med">
+                            <AccentText
+                                weight="bold"
+                                size="med"
+                                color={schedule.enabled ? 'text' : 'lightest'}
+                            >
                                 {doc.title}
                             </AccentText>
                         ) : (


### PR DESCRIPTION
This PR provides some visual cues for disabled schedules in the Schedules list: 

- Shows `Next Run: Disabled` instead of the would-be timestamp (if it was enabled)
- The DataDoc name heading is lightened

![Screenshot 2023-01-09 at 16-34-18 Querybook](https://user-images.githubusercontent.com/3084806/211412765-27165f17-b9fd-4b90-b332-0a25a451daf4.png)
