### PR TITLE
feat: add search box to hide columns popup

### DIFF
--- a/querybook/webapp/components/DataDocStatementExecution/StatementResult.scss
+++ b/querybook/webapp/components/DataDocStatementExecution/StatementResult.scss
@@ -61,19 +61,4 @@
 .StatementResult-column-toggle-menu {
     max-height: 200px;
     overflow-y: auto;
-    .hide-column-search-bar-wrapper {
-        .SearchBar {
-            display: flex;
-            flex-direction: row;
-            .DebouncedInput {
-                flex: 9;
-            }
-            .SearchIcon {
-                flex: 1;
-            }
-            .Button{
-                flex: 1;
-            }
-        }
-    }
 }

--- a/querybook/webapp/components/DataDocStatementExecution/StatementResult.scss
+++ b/querybook/webapp/components/DataDocStatementExecution/StatementResult.scss
@@ -61,4 +61,19 @@
 .StatementResult-column-toggle-menu {
     max-height: 200px;
     overflow-y: auto;
+    .hide-column-search-bar-wrapper {
+        .SearchBar {
+            display: flex;
+            flex-direction: row;
+            .DebouncedInput {
+                flex: 9;
+            }
+            .SearchIcon {
+                flex: 1;
+            }
+            .Button{
+                flex: 1;
+            }
+        }
+    }
 }

--- a/querybook/webapp/components/DataDocStatementExecution/StatementResult.tsx
+++ b/querybook/webapp/components/DataDocStatementExecution/StatementResult.tsx
@@ -416,13 +416,17 @@ const ColumnToggleMenuButton: React.FC<{
 
     const getPopoverContent = () => (
         <div className="StatementResult-column-toggle-menu">
-            <div key="hide-column-search" onClick={stopPropagation}>
+            <div
+                className="hide-column-search-bar-wrapper"
+                onClick={stopPropagation}
+            >
                 <SearchBar
                     value={keyword}
                     onSearch={updateKeyword}
                     placeholder="Search"
                     transparent
                     delayMethod="throttle"
+                    hasClearSearch={true}
                 />
             </div>
             <div key="all">

--- a/querybook/webapp/components/DataDocStatementExecution/StatementResult.tsx
+++ b/querybook/webapp/components/DataDocStatementExecution/StatementResult.tsx
@@ -399,30 +399,25 @@ const ColumnToggleMenuButton: React.FC<{
 }> = ({ columnNames, columnVisibility, toggleVisibility }) => {
     const buttonRef = React.useRef<HTMLAnchorElement>();
     const [showPopover, _, toggleShowPopover] = useToggleState(false);
-    const [filteredColumnNames, setFilteredColumnNames] = useState(columnNames);
     const [keyword, setKeyword] = useState('');
+    const filteredColumnNames = useMemo(
+        () =>
+            columnNames.filter((names) =>
+                names.toLowerCase().includes(keyword.toLowerCase())
+            ),
+        [columnNames, keyword]
+    );
     const isAllSelected = useMemo(
         () => columnNames.every((columnName) => columnVisibility[columnName]),
         [columnNames, columnVisibility]
     );
 
-    const updateKeyword = (keyword: string) => {
-        const filtered = columnNames.filter((names) => {
-            return `${names.toLowerCase()}`.includes(keyword.toLowerCase());
-        });
-        setKeyword(keyword);
-        setFilteredColumnNames(filtered);
-    };
-
     const getPopoverContent = () => (
         <div className="StatementResult-column-toggle-menu">
-            <div
-                className="hide-column-search-bar-wrapper"
-                onClick={stopPropagation}
-            >
+            <div onClick={stopPropagation}>
                 <SearchBar
                     value={keyword}
-                    onSearch={updateKeyword}
+                    onSearch={setKeyword}
                     placeholder="Search"
                     transparent
                     delayMethod="throttle"

--- a/querybook/webapp/ui/SearchBar/SearchBar.scss
+++ b/querybook/webapp/ui/SearchBar/SearchBar.scss
@@ -24,4 +24,16 @@
         border-left: var(--border);
         height: 20px;
     }
+
+    &.clear-search {
+        .DebouncedInput {
+            flex: 9;
+        }
+        .SearchIcon {
+            flex: 1;
+        }
+        .Button{
+            flex: 1;
+        }
+    }
 }

--- a/querybook/webapp/ui/SearchBar/SearchBar.tsx
+++ b/querybook/webapp/ui/SearchBar/SearchBar.tsx
@@ -74,6 +74,7 @@ export const SearchBar: React.FunctionComponent<ISearchBarProps> = ({
         SearchBar: true,
         [className]: Boolean(className),
         transparent,
+        'clear-search': hasClearSearch,
     });
 
     const clearSearchButton =


### PR DESCRIPTION
Adds a search bar to the hide columns popup to allow searching table column names with a keyword. Can select or hide all columns found with keyword. 

![Screen Shot 2023-01-18 at 11 09 31 AM](https://user-images.githubusercontent.com/72165460/213273965-874cdc2d-e7a2-4f9a-8c5a-b1340445294b.png)

![Screen Shot 2023-01-18 at 11 09 51 AM](https://user-images.githubusercontent.com/72165460/213273976-74d47fcc-8bcd-4130-b178-a7fa6c21d124.png)

![Screen Shot 2023-01-18 at 11 24 07 AM](https://user-images.githubusercontent.com/72165460/213275335-67625ca2-5566-4ae3-a304-d4cf664cedd5.png)

![Screen Shot 2023-01-18 at 11 24 27 AM](https://user-images.githubusercontent.com/72165460/213275363-6b32ea92-e140-4f08-8ae5-758d2c5194d5.png)

