### PR TITLE
fix: json-bigint hasOwnProperty undefined issue

### DIFF
--- a/querybook/webapp/lib/query-result/transformer.tsx
+++ b/querybook/webapp/lib/query-result/transformer.tsx
@@ -1,4 +1,5 @@
 import JSONBig from 'json-bigint';
+import { cloneDeep } from 'lodash';
 import React from 'react';
 import ReactJson, { ThemeObject } from 'react-json-view';
 
@@ -107,7 +108,7 @@ const queryResultTransformers: IColumnTransformer[] = [
 
                 // This is a workaround for https://github.com/sidorares/json-bigint/issues/38
                 // to make sure it is of `Object` prototype when passed over to <ReactJson />
-                const jsonSrc = JSON.parse(JSON.stringify(json));
+                const jsonSrc = cloneDeep(json);
 
                 return (
                     <ReactJson

--- a/querybook/webapp/lib/query-result/transformer.tsx
+++ b/querybook/webapp/lib/query-result/transformer.tsx
@@ -107,7 +107,7 @@ const queryResultTransformers: IColumnTransformer[] = [
 
                 // This is a workaround for https://github.com/sidorares/json-bigint/issues/38
                 // to make sure it is of `Object` prototype when passed over to <ReactJson />
-                const jsonSrc = { ...json };
+                const jsonSrc = JSON.parse(JSON.stringify(json));
 
                 return (
                     <ReactJson


### PR DESCRIPTION
This is the same issue which #1103 tried to fix, while it only fixed the top level, but not nested objects.  Here is another workaround by stringify and parse it again with builtin JSON module.