### PR TITLE
fix: update /event_log api path

### DIFF
--- a/querybook/server/datasources/event_log.py
+++ b/querybook/server/datasources/event_log.py
@@ -3,7 +3,7 @@ from const.event_log import EventType, FrontendEvent
 from lib.event_logger import event_logger
 
 
-@register("/event_log/", methods=["POST"], api_logging=False)
+@register("/context_log/", methods=["POST"], api_logging=False)
 def log_frontend_event(events: list[FrontendEvent]):
     """Log a list of frontend events.
 

--- a/querybook/webapp/resource/analytics.ts
+++ b/querybook/webapp/resource/analytics.ts
@@ -2,5 +2,5 @@ import { AnalyticsEvent } from 'const/analytics';
 import ds from 'lib/datasource';
 
 export const AnalyticsResource = {
-    create: (events: AnalyticsEvent[]) => ds.save(`/event_log/`, { events }),
+    create: (events: AnalyticsEvent[]) => ds.save(`/context_log/`, { events }),
 };


### PR DESCRIPTION
The `/event_log/` api will be blocked by chrome adblocker extension. In the blocking log, it shows the `/event_log/*` will be blocked, here we change the path name to `/context_log/`