### PR TITLE
fix: react-table version

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "react-redux": "7.2.4",
         "react-router-dom": "5.1.2",
         "react-select": "4.3.1",
-        "react-table": "^6.8.6",
+        "react-table": "6.8.6",
         "react-virtualized": "9.22.3",
         "reactflow": "^11.3.0",
         "reactour": "^1.18.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5764,13 +5764,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-table@^6.8.5":
-  version "6.8.9"
-  resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-6.8.9.tgz#0925879352e4c15b9b9a7087481ac4268bf8e5ae"
-  integrity sha512-fVQXjy/EYDbgraScgjDONA291McKqGrw0R0NeK639fx2bS4T19TnXMjg3FjOPlkI3qYTQtFTPADlRYysaQIMpA==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-transition-group@*":
   version "2.0.16"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.0.16.tgz#2dcb9e396ab385ee19c4af1c9caa469a14cd042f"
@@ -16207,14 +16200,12 @@ react-shallow-renderer@^16.13.1:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0"
 
-react-table@^6.8.6:
-  version "6.11.5"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-6.11.5.tgz#84e52885db426a07a6c4ce2c7e942f2cd4e2aa58"
-  integrity sha512-LM+AS9v//7Y7lAlgTWW/cW6Sn5VOb3EsSkKQfQTzOW8FngB1FUskLLNEVkAYsTX9LjOWR3QlGjykJqCE6eXT/g==
+react-table@6.8.6:
+  version "6.8.6"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-6.8.6.tgz#a0ad8b4839319052d5befc012603fb161e52ede3"
+  integrity sha512-vqo10kd6sHm39DuTa+lfMpa+dVZYfZDBDscw6gNn/ilR9QRZbmpaiteNWnyn5XxLcK+1V7UuJ3+yQvTdTsdWKQ==
   dependencies:
-    "@types/react-table" "^6.8.5"
     classnames "^2.2.5"
-    react-is "^16.8.1"
 
 react-test-renderer@^17.0.0:
   version "17.0.2"


### PR DESCRIPTION
The react-table package version upgrade in #1123 will cause exception when there are empty rows in the execution result. here we're reverting the version change