### PR TITLE
feat: add metastore loader config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.16.1",
+    "version": "3.17.0",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/const/metastore.py
+++ b/querybook/server/const/metastore.py
@@ -4,3 +4,29 @@ from enum import Enum
 class DataTableWarningSeverity(Enum):
     WARNING = 0
     ERROR = 1
+
+
+class MetadataType(Enum):
+    TABLE_DESCRIPTION = "table_description"
+    COLUMN_DESCRIPTION = "column_description"
+    OWNER = "owner"
+    TAG = "tag"
+    DOMAIN = "domain"
+
+
+class MetadataMode(Enum):
+    READ_ONLY = "read_only"  # metadata will be read-only on Querybook UI
+    WRITE_BACK = "write_back"  # metadata will be written back to metastore on saving
+
+
+class MetastoreLoaderConfig:
+    """Config to control if the metadata can be edited or written back to metastore.
+    The default behavior of a metadata type (not specifed in the config) is that
+    it will be editable and only saved in qurybook db.
+    """
+
+    def __init__(self, config: dict[MetadataType, MetadataMode]):
+        self._config = config
+
+    def to_dict(self):
+        return {key.value: value.value for (key, value) in self._config.items()}

--- a/querybook/server/const/metastore.py
+++ b/querybook/server/const/metastore.py
@@ -11,25 +11,31 @@ class MetadataType(Enum):
     COLUMN_DESCRIPTION = "column_description"
     OWNER = "owner"
     TAG = "tag"
-    DOMAIN = "domain"
 
 
 class MetadataMode(Enum):
     # Metadata will be read-only on Querybook UI and it will redirect to the metastore link for editing.
     READ_ONLY = "read_only"
 
-    # On saving, metadata will only be written back querybook db. This is the default mode if not specified.
-    WRITE_BACK = "write_back"
+    # On saving, metadata will only be written to querybook db. This is the default mode if not specified.
+    WRITE_LOCAL = "write_local"
 
     # On saving, metadata will be written back to metastore, as well as querybook db
-    WRITE_THROUGH = "write_through"
+    WRITE_BACK = "write_back"
 
 
 class MetastoreLoaderConfig:
     """Config to set the read/write mode (MetadataMode) for each metadata."""
 
+    _default_config = {
+        MetadataType.TABLE_DESCRIPTION: MetadataMode.WRITE_LOCAL,
+        MetadataType.COLUMN_DESCRIPTION: MetadataMode.WRITE_LOCAL,
+        MetadataType.OWNER: MetadataMode.WRITE_LOCAL,
+        MetadataType.TAG: MetadataMode.WRITE_LOCAL,
+    }
+
     def __init__(self, config: dict[MetadataType, MetadataMode]):
-        self._config = config
+        self._config = {**self._default_config, **config}
 
     def to_dict(self):
         return {key.value: value.value for (key, value) in self._config.items()}

--- a/querybook/server/const/metastore.py
+++ b/querybook/server/const/metastore.py
@@ -15,15 +15,18 @@ class MetadataType(Enum):
 
 
 class MetadataMode(Enum):
-    READ_ONLY = "read_only"  # metadata will be read-only on Querybook UI
-    WRITE_BACK = "write_back"  # metadata will be written back to metastore on saving
+    # Metadata will be read-only on Querybook UI and it will redirect to the metastore link for editing.
+    READ_ONLY = "read_only"
+
+    # On saving, metadata will only be written back querybook db. This is the default mode if not specified.
+    WRITE_BACK = "write_back"
+
+    # On saving, metadata will be written back to metastore, as well as querybook db
+    WRITE_THROUGH = "write_through"
 
 
 class MetastoreLoaderConfig:
-    """Config to control if the metadata can be edited or written back to metastore.
-    The default behavior of a metadata type (not specifed in the config) is that
-    it will be editable and only saved in qurybook db.
-    """
+    """Config to set the read/write mode (MetadataMode) for each metadata."""
 
     def __init__(self, config: dict[MetadataType, MetadataMode]):
         self._config = config

--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -87,19 +87,18 @@ def get_table_metastore_link(
     table_id,
     metadata_type,
 ):
-    with DBSession() as session:
-        verify_data_table_permission(table_id, session=session)
+    verify_data_table_permission(table_id)
 
-        table = logic.get_table_by_id(table_id, session=session)
-        schema = table.data_schema
-        metastore_id = schema.metastore_id
-        metastore_loader = get_metastore_loader(metastore_id, session=session)
+    table = logic.get_table_by_id(table_id)
+    schema = table.data_schema
+    metastore_id = schema.metastore_id
+    metastore_loader = get_metastore_loader(metastore_id)
 
-        return metastore_loader.get_metastore_link(
-            metadata_type=MetadataType(metadata_type),
-            schema_name=schema.name,
-            table_name=table.name,
-        )
+    return metastore_loader.get_metastore_link(
+        metadata_type=MetadataType(metadata_type),
+        schema_name=schema.name,
+        table_name=table.name,
+    )
 
 
 @register("/table_name/<schema_name>/<table_name>/", methods=["GET"])

--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -82,6 +82,26 @@ def get_table(table_id, with_schema=True, with_column=True, with_warnings=True):
         return result
 
 
+@register("/table/<int:table_id>/metastore_link/", methods=["GET"])
+def get_table_metastore_link(
+    table_id,
+    metadata_type,
+):
+    with DBSession() as session:
+        verify_data_table_permission(table_id, session=session)
+
+        table = logic.get_table_by_id(table_id, session=session)
+        schema = table.data_schema
+        metastore_id = schema.metastore_id
+        metastore_loader = get_metastore_loader(metastore_id, session=session)
+
+        return metastore_loader.get_metastore_link(
+            metadata_type=MetadataType(metadata_type),
+            schema_name=schema.name,
+            table_name=table.name,
+        )
+
+
 @register("/table_name/<schema_name>/<table_name>/", methods=["GET"])
 def get_table_by_name(
     schema_name,
@@ -100,23 +120,6 @@ def get_table_by_name(
         table_dict = table.to_dict(with_schema, with_column, with_warnings)
 
     return table_dict
-
-
-@register("/table_name/<schema_name>/<table_name>/metastore_link/", methods=["GET"])
-def get_table_metastore_link(
-    schema_name,
-    table_name,
-    metastore_id,
-    metadata_type,
-):
-    verify_metastore_permission(metastore_id)
-    metastore_loader = get_metastore_loader(metastore_id)
-
-    return metastore_loader.get_metastore_link(
-        metadata_type=MetadataType(metadata_type),
-        schema_name=schema_name,
-        table_name=table_name,
-    )
 
 
 @register("/table_name/<schema_name>/<table_name>/exists/", methods=["GET"])

--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -13,7 +13,7 @@ from app.db import DBSession
 from app.datasource import register, api_assert, with_impression, admin_only
 from app.flask_app import cache, limiter
 from const.impression import ImpressionItemType
-from const.metastore import DataTableWarningSeverity
+from const.metastore import DataTableWarningSeverity, MetadataType
 from const.time import seconds_in_a_day
 from lib.lineage.utils import lineage
 from lib.metastore.utils import DataTableFinder
@@ -100,6 +100,23 @@ def get_table_by_name(
         table_dict = table.to_dict(with_schema, with_column, with_warnings)
 
     return table_dict
+
+
+@register("/table_name/<schema_name>/<table_name>/metastore_link/", methods=["GET"])
+def get_table_metastore_link(
+    schema_name,
+    table_name,
+    metastore_id,
+    metadata_type,
+):
+    verify_metastore_permission(metastore_id)
+    metastore_loader = get_metastore_loader(metastore_id)
+
+    return metastore_loader.get_metastore_link(
+        metadata_type=MetadataType(metadata_type),
+        schema_name=schema_name,
+        table_name=table_name,
+    )
 
 
 @register("/table_name/<schema_name>/<table_name>/exists/", methods=["GET"])

--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -5,7 +5,7 @@ from typing import NamedTuple, List, Dict, Tuple, Optional
 import traceback
 
 from app.db import DBSession, with_session
-from const.metastore import MetadataType, MetastoreLoaderConfig
+from const.metastore import MetadataMode, MetadataType, MetastoreLoaderConfig
 from lib.logger import get_logger
 
 from lib.form import AllFormField
@@ -78,7 +78,7 @@ class DataColumn(NamedTuple):
 
 
 class BaseMetastoreLoader(metaclass=ABCMeta):
-    loader_config: MetastoreLoaderConfig = {}
+    loader_config: MetastoreLoaderConfig = MetastoreLoaderConfig({})
 
     def __init__(self, metastore_dict: Dict):
         self.metastore_id = metastore_dict["id"]

--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -5,7 +5,7 @@ from typing import NamedTuple, List, Dict, Tuple, Optional
 import traceback
 
 from app.db import DBSession, with_session
-from const.metastore import MetadataMode, MetadataType, MetastoreLoaderConfig
+from const.metastore import MetadataType, MetastoreLoaderConfig
 from lib.logger import get_logger
 
 from lib.form import AllFormField

--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -5,6 +5,7 @@ from typing import NamedTuple, List, Dict, Tuple, Optional
 import traceback
 
 from app.db import DBSession, with_session
+from const.metastore import MetadataType, MetastoreLoaderConfig
 from lib.logger import get_logger
 
 from lib.form import AllFormField
@@ -77,9 +78,27 @@ class DataColumn(NamedTuple):
 
 
 class BaseMetastoreLoader(metaclass=ABCMeta):
+    loader_config: MetastoreLoaderConfig = {}
+
     def __init__(self, metastore_dict: Dict):
         self.metastore_id = metastore_dict["id"]
         self.acl_checker = MetastoreTableACLChecker(metastore_dict["acl_control"])
+
+    @classmethod
+    def get_metastore_link(
+        cls, metadata_type: MetadataType, schema_name: str, table_name: str
+    ) -> str:
+        """Return the external metastore link of the table metadata if it has an accessible page for the given type.
+
+        Args:
+            metadata_type (MetadataType): metadata type
+            schema_name (str): table schema name
+            table_name (str): table name
+
+        Returns:
+            str: external metastore link of the table metadata.
+        """
+        return None
 
     @with_session
     def sync_table(

--- a/querybook/server/models/admin.py
+++ b/querybook/server/models/admin.py
@@ -157,7 +157,14 @@ class QueryMetastore(CRUDMixin, Base):
     acl_control = sql.Column(sql.JSON, default={}, nullable=False)
 
     def to_dict(self):
-        return {"id": self.id, "name": self.name}
+        from lib.metastore import get_metastore_loader_class_by_name
+
+        loader_class = get_metastore_loader_class_by_name(self.loader)
+        return {
+            "id": self.id,
+            "name": self.name,
+            "config": loader_class.loader_config.to_dict(),
+        }
 
     def to_dict_admin(self):
         return {

--- a/querybook/webapp/components/DataTableView/DataTableView.tsx
+++ b/querybook/webapp/components/DataTableView/DataTableView.tsx
@@ -138,20 +138,20 @@ class DataTableViewComponent extends React.PureComponent<
     }
 
     @bind
-    public getOnEditMetadata(metadataType: MetadataType) {
-        const { table, schema, metastore } = this.props;
-        const onEditMetadata = async () => {
-            const { data: link } = await TableResource.getMetastoreLink(
-                metastore.id,
-                schema.name,
-                table.name,
-                metadataType
-            );
-            window.open(link, '_blank');
-        };
+    public async onEditMetadata(metadataType: MetadataType) {
+        const { table } = this.props;
+        const { data: link } = await TableResource.getMetastoreLink(
+            table.id,
+            metadataType
+        );
+        window.open(link, '_blank');
+    }
 
+    @bind
+    public getOnEditMetadata(metadataType: MetadataType) {
+        const { metastore } = this.props;
         return metastore.config[metadataType] === MetadataMode.READ_ONLY
-            ? onEditMetadata
+            ? this.onEditMetadata.bind(this, metadataType)
             : undefined;
     }
 
@@ -181,7 +181,6 @@ class DataTableViewComponent extends React.PureComponent<
     @bind
     public makeOverviewDOM() {
         const { table, tableName, tableColumns, tableWarnings } = this.props;
-        console.log(this.props);
 
         return (
             <DataTableViewOverview
@@ -192,7 +191,7 @@ class DataTableViewComponent extends React.PureComponent<
                 onTabSelected={this.onTabSelected}
                 updateDataTableDescription={this.updateDataTableDescription}
                 onExampleFilter={this.handleExampleFilter}
-                onEditMetadata={this.getOnEditMetadata(
+                onEditTableDescription={this.getOnEditMetadata(
                     MetadataType.TABLE_DESCRIPTION
                 )}
             />
@@ -209,7 +208,7 @@ class DataTableViewComponent extends React.PureComponent<
                 tableColumns={tableColumns}
                 numberOfRows={numberOfRows}
                 updateDataColumnDescription={updateDataColumnDescription}
-                onEditMetadata={this.getOnEditMetadata(
+                onEditColumnDescription={this.getOnEditMetadata(
                     MetadataType.COLUMN_DESCRIPTION
                 )}
             />

--- a/querybook/webapp/components/DataTableView/DataTableView.tsx
+++ b/querybook/webapp/components/DataTableView/DataTableView.tsx
@@ -15,7 +15,11 @@ import { DataTableViewSamples } from 'components/DataTableViewSamples/DataTableV
 import { DataTableViewSourceQuery } from 'components/DataTableViewSourceQuery/DataTableViewSourceQuery';
 import { DataTableViewWarnings } from 'components/DataTableViewWarnings/DataTableViewWarnings';
 import { ComponentType, ElementType } from 'const/analytics';
-import { IPaginatedQuerySampleFilters } from 'const/metastore';
+import {
+    IPaginatedQuerySampleFilters,
+    MetadataMode,
+    MetadataType,
+} from 'const/metastore';
 import { trackClick, trackView } from 'lib/analytics';
 import { setBrowserTitle } from 'lib/querybookUI';
 import history from 'lib/router-history';
@@ -26,6 +30,7 @@ import { getQueryString, replaceQueryString } from 'lib/utils/query-string';
 import * as dataSourcesActions from 'redux/dataSources/action';
 import { fullTableSelector } from 'redux/dataSources/selector';
 import { Dispatch, IStoreState } from 'redux/store/types';
+import { TableResource } from 'resource/table';
 import { Container } from 'ui/Container/Container';
 import { ErrorPage } from 'ui/ErrorPage/ErrorPage';
 import { FourOhFour } from 'ui/ErrorPage/FourOhFour';
@@ -133,6 +138,24 @@ class DataTableViewComponent extends React.PureComponent<
     }
 
     @bind
+    public getOnEditMetadata(metadataType: MetadataType) {
+        const { table, schema, metastore } = this.props;
+        const onEditMetadata = async () => {
+            const { data: link } = await TableResource.getMetastoreLink(
+                metastore.id,
+                schema.name,
+                table.name,
+                metadataType
+            );
+            window.open(link, '_blank');
+        };
+
+        return metastore.config[metadataType] === MetadataMode.READ_ONLY
+            ? onEditMetadata
+            : undefined;
+    }
+
+    @bind
     public onTabSelected(key) {
         const elementType = tabDefinitions.find(
             (t) => t.key === key
@@ -158,6 +181,7 @@ class DataTableViewComponent extends React.PureComponent<
     @bind
     public makeOverviewDOM() {
         const { table, tableName, tableColumns, tableWarnings } = this.props;
+        console.log(this.props);
 
         return (
             <DataTableViewOverview
@@ -168,6 +192,9 @@ class DataTableViewComponent extends React.PureComponent<
                 onTabSelected={this.onTabSelected}
                 updateDataTableDescription={this.updateDataTableDescription}
                 onExampleFilter={this.handleExampleFilter}
+                onEditMetadata={this.getOnEditMetadata(
+                    MetadataType.TABLE_DESCRIPTION
+                )}
             />
         );
     }
@@ -182,6 +209,9 @@ class DataTableViewComponent extends React.PureComponent<
                 tableColumns={tableColumns}
                 numberOfRows={numberOfRows}
                 updateDataColumnDescription={updateDataColumnDescription}
+                onEditMetadata={this.getOnEditMetadata(
+                    MetadataType.COLUMN_DESCRIPTION
+                )}
             />
         );
     }
@@ -381,7 +411,7 @@ function mapStateToProps(state: IStoreState, ownProps) {
 
     const { tableId } = ownProps;
 
-    const { table, schema, tableName, tableColumns, tableWarnings } =
+    const { table, schema, tableName, tableColumns, tableWarnings, metastore } =
         fullTableSelector(state, tableId);
 
     return {
@@ -395,6 +425,7 @@ function mapStateToProps(state: IStoreState, ownProps) {
         dataJobMetadataById,
         dataSchemasById,
         tableWarnings,
+        metastore,
 
         userInfo: state.user.myUserInfo,
     };

--- a/querybook/webapp/components/DataTableView/DataTableView.tsx
+++ b/querybook/webapp/components/DataTableView/DataTableView.tsx
@@ -191,7 +191,7 @@ class DataTableViewComponent extends React.PureComponent<
                 onTabSelected={this.onTabSelected}
                 updateDataTableDescription={this.updateDataTableDescription}
                 onExampleFilter={this.handleExampleFilter}
-                onEditTableDescription={this.getOnEditMetadata(
+                onEditTableDescriptionRedirect={this.getOnEditMetadata(
                     MetadataType.TABLE_DESCRIPTION
                 )}
             />
@@ -201,14 +201,13 @@ class DataTableViewComponent extends React.PureComponent<
     @bind
     public makeColumnsDOM(numberOfRows = null) {
         const { table, tableColumns, updateDataColumnDescription } = this.props;
-
         return (
             <DataTableViewColumn
                 table={table}
                 tableColumns={tableColumns}
                 numberOfRows={numberOfRows}
                 updateDataColumnDescription={updateDataColumnDescription}
-                onEditColumnDescription={this.getOnEditMetadata(
+                onEditColumnDescriptionRedirect={this.getOnEditMetadata(
                     MetadataType.COLUMN_DESCRIPTION
                 )}
             />

--- a/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.tsx
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.tsx
@@ -18,7 +18,7 @@ import './DataTableColumnCard.scss';
 
 interface IProps {
     column: IDataColumn;
-    onEditColumnDescription?: Nullable<() => Promise<void>>;
+    onEditColumnDescriptionRedirect?: Nullable<() => Promise<void>>;
     updateDataColumnDescription: (
         columnId: number,
         description: ContentState
@@ -27,7 +27,7 @@ interface IProps {
 
 export const DataTableColumnCard: React.FunctionComponent<IProps> = ({
     column,
-    onEditColumnDescription,
+    onEditColumnDescriptionRedirect,
     updateDataColumnDescription,
 }) => {
     const [expanded, , toggleExpanded] = useToggleState(false);
@@ -38,7 +38,7 @@ export const DataTableColumnCard: React.FunctionComponent<IProps> = ({
             value={column.description as ContentState}
             onSave={updateDataColumnDescription.bind(null, column.id)}
             placeholder="No user comments yet for column."
-            onEdit={onEditColumnDescription}
+            onEditRedirect={onEditColumnDescriptionRedirect}
         />
     );
     return (

--- a/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.tsx
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from 'react';
 import { DataTableColumnStats } from 'components/DataTableStats/DataTableColumnStats';
 import { IDataColumn } from 'const/metastore';
 import { useToggleState } from 'hooks/useToggleState';
+import { Nullable } from 'lib/typescript';
 import { parseType } from 'lib/utils/complex-types';
 import { Card } from 'ui/Card/Card';
 import { EditableTextField } from 'ui/EditableTextField/EditableTextField';
@@ -17,7 +18,7 @@ import './DataTableColumnCard.scss';
 
 interface IProps {
     column: IDataColumn;
-    onEdit: () => void;
+    onEditColumnDescription?: Nullable<() => Promise<void>>;
     updateDataColumnDescription: (
         columnId: number,
         description: ContentState
@@ -26,7 +27,7 @@ interface IProps {
 
 export const DataTableColumnCard: React.FunctionComponent<IProps> = ({
     column,
-    onEdit,
+    onEditColumnDescription,
     updateDataColumnDescription,
 }) => {
     const [expanded, , toggleExpanded] = useToggleState(false);
@@ -37,7 +38,7 @@ export const DataTableColumnCard: React.FunctionComponent<IProps> = ({
             value={column.description as ContentState}
             onSave={updateDataColumnDescription.bind(null, column.id)}
             placeholder="No user comments yet for column."
-            onEdit={onEdit}
+            onEdit={onEditColumnDescription}
         />
     );
     return (

--- a/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.tsx
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.tsx
@@ -17,6 +17,7 @@ import './DataTableColumnCard.scss';
 
 interface IProps {
     column: IDataColumn;
+    onEdit: () => void;
     updateDataColumnDescription: (
         columnId: number,
         description: ContentState
@@ -25,6 +26,7 @@ interface IProps {
 
 export const DataTableColumnCard: React.FunctionComponent<IProps> = ({
     column,
+    onEdit,
     updateDataColumnDescription,
 }) => {
     const [expanded, , toggleExpanded] = useToggleState(false);
@@ -35,6 +37,7 @@ export const DataTableColumnCard: React.FunctionComponent<IProps> = ({
             value={column.description as ContentState}
             onSave={updateDataColumnDescription.bind(null, column.id)}
             placeholder="No user comments yet for column."
+            onEdit={onEdit}
         />
     );
     return (

--- a/querybook/webapp/components/DataTableViewColumn/DataTableViewColumn.tsx
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableViewColumn.tsx
@@ -15,6 +15,7 @@ export interface IDataTableViewColumnProps {
         columnId: number,
         description: ContentState
     ) => any;
+    onEditMetadata: () => void;
 }
 
 export const DataTableViewColumn: React.FunctionComponent<
@@ -24,6 +25,7 @@ export const DataTableViewColumn: React.FunctionComponent<
     table = null,
     tableColumns = [],
     numberOfRows = null,
+    onEditMetadata,
 }) => {
     const [filterString, setFilterString] = React.useState('');
 
@@ -60,6 +62,7 @@ export const DataTableViewColumn: React.FunctionComponent<
             column={col}
             updateDataColumnDescription={updateDataColumnDescription}
             key={col.id}
+            onEdit={onEditMetadata}
         />
     ));
 

--- a/querybook/webapp/components/DataTableViewColumn/DataTableViewColumn.tsx
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableViewColumn.tsx
@@ -16,7 +16,7 @@ export interface IDataTableViewColumnProps {
         columnId: number,
         description: ContentState
     ) => any;
-    onEditColumnDescription?: Nullable<() => Promise<void>>;
+    onEditColumnDescriptionRedirect?: Nullable<() => Promise<void>>;
 }
 
 export const DataTableViewColumn: React.FunctionComponent<
@@ -26,7 +26,7 @@ export const DataTableViewColumn: React.FunctionComponent<
     table = null,
     tableColumns = [],
     numberOfRows = null,
-    onEditColumnDescription,
+    onEditColumnDescriptionRedirect,
 }) => {
     const [filterString, setFilterString] = React.useState('');
 
@@ -63,7 +63,7 @@ export const DataTableViewColumn: React.FunctionComponent<
             column={col}
             updateDataColumnDescription={updateDataColumnDescription}
             key={col.id}
-            onEditColumnDescription={onEditColumnDescription}
+            onEditColumnDescriptionRedirect={onEditColumnDescriptionRedirect}
         />
     ));
 

--- a/querybook/webapp/components/DataTableViewColumn/DataTableViewColumn.tsx
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableViewColumn.tsx
@@ -2,6 +2,7 @@ import { ContentState } from 'draft-js';
 import React from 'react';
 
 import { IDataColumn, IDataTable } from 'const/metastore';
+import { Nullable } from 'lib/typescript';
 import { Loading } from 'ui/Loading/Loading';
 import { SearchBar } from 'ui/SearchBar/SearchBar';
 
@@ -15,7 +16,7 @@ export interface IDataTableViewColumnProps {
         columnId: number,
         description: ContentState
     ) => any;
-    onEditMetadata: () => void;
+    onEditColumnDescription?: Nullable<() => Promise<void>>;
 }
 
 export const DataTableViewColumn: React.FunctionComponent<
@@ -25,7 +26,7 @@ export const DataTableViewColumn: React.FunctionComponent<
     table = null,
     tableColumns = [],
     numberOfRows = null,
-    onEditMetadata,
+    onEditColumnDescription,
 }) => {
     const [filterString, setFilterString] = React.useState('');
 
@@ -62,7 +63,7 @@ export const DataTableViewColumn: React.FunctionComponent<
             column={col}
             updateDataColumnDescription={updateDataColumnDescription}
             key={col.id}
-            onEdit={onEditMetadata}
+            onEditColumnDescription={onEditColumnDescription}
         />
     ));
 

--- a/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
+++ b/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
@@ -86,6 +86,7 @@ export interface IQuerybookTableViewOverviewProps {
     tableColumns: IDataColumn[];
     tableWarnings: IDataTableWarning[];
 
+    onEditMetadata: () => void;
     onTabSelected: (key: string) => any;
     updateDataTableDescription: (
         tableId: number,
@@ -102,6 +103,7 @@ export const DataTableViewOverview: React.FC<
     tableWarnings,
     onExampleFilter,
     updateDataTableDescription,
+    onEditMetadata,
 }) => {
     const onDescriptionSave = useCallback(
         (description: DraftJs.ContentState) =>
@@ -116,6 +118,7 @@ export const DataTableViewOverview: React.FC<
             value={table.description as DraftJs.ContentState}
             onSave={onDescriptionSave}
             placeholder="No description for this table yet."
+            onEdit={onEditMetadata}
         />
     ) : null;
 

--- a/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
+++ b/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
@@ -24,6 +24,7 @@ import {
     IPaginatedQuerySampleFilters,
 } from 'const/metastore';
 import { useMounted } from 'hooks/useMounted';
+import { Nullable } from 'lib/typescript';
 import { titleize } from 'lib/utils';
 import { generateFormattedDate } from 'lib/utils/datetime';
 import { getAppName } from 'lib/utils/global';
@@ -86,7 +87,7 @@ export interface IQuerybookTableViewOverviewProps {
     tableColumns: IDataColumn[];
     tableWarnings: IDataTableWarning[];
 
-    onEditMetadata: () => void;
+    onEditTableDescription?: Nullable<() => Promise<void>>;
     onTabSelected: (key: string) => any;
     updateDataTableDescription: (
         tableId: number,
@@ -103,7 +104,7 @@ export const DataTableViewOverview: React.FC<
     tableWarnings,
     onExampleFilter,
     updateDataTableDescription,
-    onEditMetadata,
+    onEditTableDescription,
 }) => {
     const onDescriptionSave = useCallback(
         (description: DraftJs.ContentState) =>
@@ -118,7 +119,7 @@ export const DataTableViewOverview: React.FC<
             value={table.description as DraftJs.ContentState}
             onSave={onDescriptionSave}
             placeholder="No description for this table yet."
-            onEdit={onEditMetadata}
+            onEdit={onEditTableDescription}
         />
     ) : null;
 

--- a/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
+++ b/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
@@ -87,7 +87,7 @@ export interface IQuerybookTableViewOverviewProps {
     tableColumns: IDataColumn[];
     tableWarnings: IDataTableWarning[];
 
-    onEditTableDescription?: Nullable<() => Promise<void>>;
+    onEditTableDescriptionRedirect?: Nullable<() => Promise<void>>;
     onTabSelected: (key: string) => any;
     updateDataTableDescription: (
         tableId: number,
@@ -104,7 +104,7 @@ export const DataTableViewOverview: React.FC<
     tableWarnings,
     onExampleFilter,
     updateDataTableDescription,
-    onEditTableDescription,
+    onEditTableDescriptionRedirect,
 }) => {
     const onDescriptionSave = useCallback(
         (description: DraftJs.ContentState) =>
@@ -119,7 +119,7 @@ export const DataTableViewOverview: React.FC<
             value={table.description as DraftJs.ContentState}
             onSave={onDescriptionSave}
             placeholder="No description for this table yet."
-            onEdit={onEditTableDescription}
+            onEditRedirect={onEditTableDescriptionRedirect}
         />
     ) : null;
 

--- a/querybook/webapp/const/metastore.ts
+++ b/querybook/webapp/const/metastore.ts
@@ -13,11 +13,12 @@ export enum MetadataType {
 export enum MetadataMode {
     READ_ONLY = 'read_only',
     WRITE_BACK = 'write_back',
+    WRITE_THROUGH = 'write_through',
 }
 export interface IQueryMetastore {
     id: number;
     name: string;
-    config: { [key in MetadataType]: MetadataMode };
+    config: Record<MetadataType, MetadataMode>;
 }
 
 export interface IDataSchema {

--- a/querybook/webapp/const/metastore.ts
+++ b/querybook/webapp/const/metastore.ts
@@ -1,8 +1,23 @@
 import type { ContentState } from 'draft-js';
 
+// Keep it in sync with MetadataType in server/const/metastore.py
+export enum MetadataType {
+    TABLE_DESCRIPTION = 'table_description',
+    COLUMN_DESCRIPTION = 'column_description',
+    OWNER = 'owner',
+    TAG = 'tag',
+    DOMAIN = 'domain',
+}
+
+// Keep it in sync with MetadataMode in server/const/metastore.py
+export enum MetadataMode {
+    READ_ONLY = 'read_only',
+    WRITE_BACK = 'write_back',
+}
 export interface IQueryMetastore {
     id: number;
     name: string;
+    config: { [key in MetadataType]: MetadataMode };
 }
 
 export interface IDataSchema {

--- a/querybook/webapp/const/metastore.ts
+++ b/querybook/webapp/const/metastore.ts
@@ -12,8 +12,8 @@ export enum MetadataType {
 // Keep it in sync with MetadataMode in server/const/metastore.py
 export enum MetadataMode {
     READ_ONLY = 'read_only',
+    WRITE_LOCAL = 'write_local',
     WRITE_BACK = 'write_back',
-    WRITE_THROUGH = 'write_through',
 }
 export interface IQueryMetastore {
     id: number;

--- a/querybook/webapp/redux/dataSources/selector.ts
+++ b/querybook/webapp/redux/dataSources/selector.ts
@@ -34,11 +34,13 @@ export const fullTableSelector = createSelector(
     (state: IStoreState) => state.dataSources.dataSchemasById,
     (state: IStoreState) => state.dataSources.dataColumnsById,
     (state: IStoreState) => state.dataSources.dataTableWarningById,
+    (state: IStoreState) => state.dataSources.queryMetastoreById,
     (
         tableFromState,
         dataSchemasById,
         dataColumnsById,
-        dataTableWarningById
+        dataTableWarningById,
+        queryMetastoreById
     ) => {
         const schemaFromState = tableFromState
             ? dataSchemasById[tableFromState.schema]
@@ -64,6 +66,7 @@ export const fullTableSelector = createSelector(
             tableWarnings: (tableFromState?.warnings ?? [])
                 .map((id) => dataTableWarningById[id])
                 .filter((warning) => warning),
+            metastore: queryMetastoreById[schemaFromState.metastore_id],
         };
     }
 );

--- a/querybook/webapp/resource/table.ts
+++ b/querybook/webapp/resource/table.ts
@@ -20,6 +20,7 @@ import type {
     ITopQueryConcurrences,
     ITopQueryUser,
     IUpdateTableParams,
+    MetadataType,
 } from 'const/metastore';
 import type { ITag } from 'const/tag';
 import ds from 'lib/datasource';
@@ -130,6 +131,20 @@ export const TableResource = {
         ds.fetch<IDataTable>(`/table_name/${schemaName}/${tableName}/`, {
             metastore_id: metastoreId,
         }),
+
+    getMetastoreLink: (
+        metastoreId: number,
+        schemaName: string,
+        tableName: string,
+        metadataType: MetadataType
+    ) =>
+        ds.fetch<string>(
+            `/table_name/${schemaName}/${tableName}/metastore_link/`,
+            {
+                metastore_id: metastoreId,
+                metadata_type: metadataType,
+            }
+        ),
 
     checkIfExists: (
         metastoreId: number,

--- a/querybook/webapp/resource/table.ts
+++ b/querybook/webapp/resource/table.ts
@@ -132,19 +132,10 @@ export const TableResource = {
             metastore_id: metastoreId,
         }),
 
-    getMetastoreLink: (
-        metastoreId: number,
-        schemaName: string,
-        tableName: string,
-        metadataType: MetadataType
-    ) =>
-        ds.fetch<string>(
-            `/table_name/${schemaName}/${tableName}/metastore_link/`,
-            {
-                metastore_id: metastoreId,
-                metadata_type: metadataType,
-            }
-        ),
+    getMetastoreLink: (tableId: number, metadataType: MetadataType) =>
+        ds.fetch<string>(`/table/${tableId}/metastore_link/`, {
+            metadata_type: metadataType,
+        }),
 
     checkIfExists: (
         metastoreId: number,

--- a/querybook/webapp/ui/EditableTextField/EditableTextField.tsx
+++ b/querybook/webapp/ui/EditableTextField/EditableTextField.tsx
@@ -17,11 +17,12 @@ export interface IEditableTextFieldProps {
     className?: string;
     readonly?: boolean;
     placeholder?: string;
+    onEdit?: () => void;
 }
 
 export const EditableTextField: React.FunctionComponent<
     IEditableTextFieldProps
-> = ({ value, onSave, className, placeholder, readonly = false }) => {
+> = ({ value, onSave, className, placeholder, readonly = false, onEdit }) => {
     const [editMode, setEditMode] = React.useState(false);
     const editorRef = React.useRef<IRichTextEditorHandles>(null);
 
@@ -66,7 +67,7 @@ export const EditableTextField: React.FunctionComponent<
             <TextButton
                 icon="Edit"
                 title="Edit"
-                onClick={toggleEditMode}
+                onClick={onEdit ?? toggleEditMode}
                 className="edit-mode-button"
             />
         ) : null;

--- a/querybook/webapp/ui/EditableTextField/EditableTextField.tsx
+++ b/querybook/webapp/ui/EditableTextField/EditableTextField.tsx
@@ -17,12 +17,19 @@ export interface IEditableTextFieldProps {
     className?: string;
     readonly?: boolean;
     placeholder?: string;
-    onEdit?: () => void;
+    onEditRedirect?: () => void;
 }
 
 export const EditableTextField: React.FunctionComponent<
     IEditableTextFieldProps
-> = ({ value, onSave, className, placeholder, readonly = false, onEdit }) => {
+> = ({
+    value,
+    onSave,
+    className,
+    placeholder,
+    readonly = false,
+    onEditRedirect,
+}) => {
     const [editMode, setEditMode] = React.useState(false);
     const editorRef = React.useRef<IRichTextEditorHandles>(null);
 
@@ -67,7 +74,7 @@ export const EditableTextField: React.FunctionComponent<
             <TextButton
                 icon="Edit"
                 title="Edit"
-                onClick={onEdit ?? toggleEditMode}
+                onClick={onEditRedirect ?? toggleEditMode}
                 className="edit-mode-button"
             />
         ) : null;


### PR DESCRIPTION
As we may sync more metadata types from metastore, like owners, tags, here we are adding a config for the metastore loader so that we can manage whether the metadata should be read-only or written back to metastore.

By default, it will keep the current behavior, which is only writing into querybook db.