### PR TITLE
feat: query engine search scroll

### DIFF
--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.scss
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.scss
@@ -35,21 +35,6 @@
         .engine-selector-wrapper {
             max-height: 50vh;
             overflow-y: auto;
-            .engine-selector-search-bar-wrapper {
-                .SearchBar {
-                    display: flex;
-                    flex-direction: row;
-                    .DebouncedInput {
-                        flex: 9;
-                    }
-                    .SearchIcon {
-                        flex: 1;
-                    }
-                    .Button{
-                        flex: 1;
-                    }
-                }
-            }
         }
     }
 

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.scss
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.scss
@@ -32,6 +32,25 @@
                 }
             }
         }
+        .engine-selector-wrapper {
+            max-height: 50vh;
+            overflow-y: auto;
+            .engine-selector-search-bar-wrapper {
+                .SearchBar {
+                    display: flex;
+                    flex-direction: row;
+                    .DebouncedInput {
+                        flex: 9;
+                    }
+                    .SearchIcon {
+                        flex: 1;
+                    }
+                    .Button{
+                        flex: 1;
+                    }
+                }
+            }
+        }
     }
 
     &.readonly {

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
@@ -171,10 +171,6 @@ export const QueryEngineSelector: React.FC<IQueryEngineSelectorProps> = ({
             tooltip: engineInfo.description,
         }));
 
-    const updateKeyword = (keyword: string) => {
-        setKeyword(keyword);
-    };
-
     const engineButtonDOM = (
         <Dropdown
             customButtonRenderer={getEngineSelectorButtonDOM}
@@ -183,13 +179,10 @@ export const QueryEngineSelector: React.FC<IQueryEngineSelectorProps> = ({
         >
             <div className="engine-selector-wrapper">
                 {queryEngines.length > 3 && (
-                    <div
-                        className="engine-selector-search-bar-wrapper"
-                        onClick={stopPropagation}
-                    >
+                    <div onClick={stopPropagation}>
                         <SearchBar
                             value={keyword}
-                            onSearch={updateKeyword}
+                            onSearch={setKeyword}
                             placeholder="Search"
                             transparent
                             delayMethod="throttle"

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import * as React from 'react';
+import { useState, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { IQueryEngine, QueryEngineStatus } from 'const/queryEngine';
@@ -12,6 +13,7 @@ import {
 } from 'lib/sql-helper/sql-limiter';
 import { getShortcutSymbols, KeyMap } from 'lib/utils/keyboard';
 import { formatNumber } from 'lib/utils/number';
+import { stopPropagation } from 'lib/utils/noop';
 import { queryEngineStatusByIdEnvSelector } from 'redux/queryEngine/selector';
 import { AsyncButton, IAsyncButtonHandles } from 'ui/AsyncButton/AsyncButton';
 import { Dropdown } from 'ui/Dropdown/Dropdown';
@@ -19,6 +21,7 @@ import { Icon } from 'ui/Icon/Icon';
 import { ListMenu } from 'ui/Menu/ListMenu';
 import { StatusIcon } from 'ui/StatusIcon/StatusIcon';
 import { Tag } from 'ui/Tag/Tag';
+import { SearchBar } from 'ui/SearchBar/SearchBar';
 
 import './QueryRunButton.scss';
 
@@ -155,19 +158,47 @@ export const QueryEngineSelector: React.FC<IQueryEngineSelectorProps> = ({
         );
     };
 
-    const engineItems = queryEngines.map((engineInfo) => ({
-        name: <span className="query-engine-name">{engineInfo.name}</span>,
-        onClick: onEngineIdSelect.bind(null, engineInfo.id),
-        checked: engineInfo.id === engineId,
-        tooltip: engineInfo.description,
-    }));
+    const [keyword, setKeyword] = useState('');
+
+    const engineItems = queryEngines
+        .filter((engineInfo) =>
+            `${engineInfo.name.toLowerCase()}`.includes(keyword.toLowerCase())
+        )
+        .map((engineInfo) => ({
+            name: <span className="query-engine-name">{engineInfo.name}</span>,
+            onClick: onEngineIdSelect.bind(null, engineInfo.id),
+            checked: engineInfo.id === engineId,
+            tooltip: engineInfo.description,
+        }));
+
+    const updateKeyword = (keyword: string) => {
+        setKeyword(keyword);
+    };
+
     const engineButtonDOM = (
         <Dropdown
             customButtonRenderer={getEngineSelectorButtonDOM}
             layout={['bottom', 'right']}
             className="engine-selector-dropdown"
         >
-            <ListMenu items={engineItems} type="select" />
+            <div className="engine-selector-wrapper">
+                {queryEngines.length > 3 && (
+                    <div
+                        className="engine-selector-search-bar-wrapper"
+                        onClick={stopPropagation}
+                    >
+                        <SearchBar
+                            value={keyword}
+                            onSearch={updateKeyword}
+                            placeholder="Search"
+                            transparent
+                            delayMethod="throttle"
+                            hasClearSearch={true}
+                        />
+                    </div>
+                )}
+                <ListMenu items={engineItems} type="select" />
+            </div>
         </Dropdown>
     );
 

--- a/querybook/webapp/ui/SearchBar/SearchBar.scss
+++ b/querybook/webapp/ui/SearchBar/SearchBar.scss
@@ -24,4 +24,16 @@
         border-left: var(--border);
         height: 20px;
     }
+
+    &.clear-search {
+        .DebouncedInput {
+            flex: 9;
+        }
+        .SearchIcon {
+            flex: 1;
+        }
+        .Button{
+            flex: 1;
+        }
+    }
 }

--- a/querybook/webapp/ui/SearchBar/SearchBar.tsx
+++ b/querybook/webapp/ui/SearchBar/SearchBar.tsx
@@ -74,6 +74,7 @@ export const SearchBar: React.FunctionComponent<ISearchBarProps> = ({
         SearchBar: true,
         [className]: Boolean(className),
         transparent,
+        'clear-search': hasClearSearch,
     });
 
     const clearSearchButton =


### PR DESCRIPTION
Adds a search bar to the list of query engines, scrolling functionality, and a button to clear keywords from the search bar.

<img width="207" alt="Screen Shot 2023-01-26 at 11 57 56 AM" src="https://user-images.githubusercontent.com/72165460/214937678-d5c740a8-09e7-4189-b01b-8070c5466fb3.png">
<img width="174" alt="Screen Shot 2023-01-26 at 11 58 17 AM" src="https://user-images.githubusercontent.com/72165460/214937690-28d37745-4b1d-433e-b395-2b45808c55f8.png">
