### PR TITLE
fix: stay on current env after deleting doc

### DIFF
--- a/querybook/webapp/components/DataDocRightSidebar/DeleteDataDocButton.tsx
+++ b/querybook/webapp/components/DataDocRightSidebar/DeleteDataDocButton.tsx
@@ -35,7 +35,7 @@ export const DeleteDataDocButton: React.FunctionComponent<
                     });
                     toast.promise(
                         dispatch(dataDocActions.deleteDataDoc(docId)).then(() =>
-                            navigateWithinEnv('/datadoc/')
+                            navigateWithinEnv('/')
                         ),
                         {
                             loading: 'Deleting DataDoc...',


### PR DESCRIPTION
This fixes an issue where deleting a DataDoc in a non-default environment causes the UI to jump to the default environment instead of remaining in the current environment. The issue seems to be related to QB reloading after attempting to navigate to '{currentEnv.name}/datadoc' after deleting a datadoc. The change included in this PR avoids the reload while also refreshing the page to be able to see that the datadoc was deleted.