### PR TITLE
fix: add safe suppress to sqlformat error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.17.0",
+    "version": "3.17.1",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -9,6 +9,7 @@ import React, {
     useState,
 } from 'react';
 import { Controlled as ReactCodeMirror } from 'react-codemirror2';
+import toast from 'react-hot-toast';
 
 import { showTooltipFor } from 'components/CodeMirrorTooltip';
 import { ICodeMirrorTooltipProps } from 'components/CodeMirrorTooltip/CodeMirrorTooltip';
@@ -232,7 +233,11 @@ export const QueryEditor: React.FC<
         );
 
         const formatQuery = useCallback(
-            (options: ISQLFormatOptions = {}) => {
+            (
+                options: ISQLFormatOptions = {
+                    silent: false,
+                }
+            ) => {
                 if (editorRef.current) {
                     const indentWithTabs =
                         editorRef.current.getOption('indentWithTabs');
@@ -246,12 +251,16 @@ export const QueryEditor: React.FC<
                     }
                 }
 
-                const formattedQuery = format(
-                    editorRef.current.getValue(),
-                    language,
-                    options
-                );
-                editorRef.current?.setValue(formattedQuery);
+                try {
+                    const formattedQuery = format(
+                        editorRef.current.getValue(),
+                        language,
+                        options
+                    );
+                    editorRef.current?.setValue(formattedQuery);
+                } catch (e) {
+                    toast.error('Failed to format query.');
+                }
             },
             [language]
         );


### PR DESCRIPTION
user reported sql-formatter is throwing errors when formatting statements with `BETWEEN`. See https://github.com/sql-formatter-org/sql-formatter/issues/534 for details

In this PR, I added try/catch when calling format to make it safer. Also refactored the code to break it down into smaller functions