### PR TITLE
add more configurations for ldap integration

### DIFF
--- a/docs_website/docs/configurations/infra_config.md
+++ b/docs_website/docs/configurations/infra_config.md
@@ -126,6 +126,11 @@ for LDAP authentication:
       - `LDAP_SEARCH` (**required**) LDAP search base (ex. `ou=people,dc=example,dc=com`)
       - `LDAP_FILTER` (optional) LDAP filter condition (ex. `(departmentNumber=01000)`)
       - `LDAP_UID_FIELD` (optional) Field that matches the username when searching for the account to bind to (defaults to `uid`)
+      - `LDAP_EMAIL_FIELD`: (optional) Field that matches the user email (default to `mail`)
+      - `LDAP_LASTNAME_FIELD`: (optional) Field that matches the user surname (default to `sn`)
+      - `LDAP_FIRSTNAME_FIELD`: (optional) Field that matches the user given name (default to `givenName`)
+      - `LDAP_FULLNAME_FIELD`: (optional) Field that matches the user full/common name (default to `cn`)
+
     - Login flow:
       1) Initialized connection for the _bind user_.
       2) Searching the _login user_ using the _bind user_ in LDAP dictionary based on `LDAP_SEARCH` and `LDAP_FILTER`.

--- a/querybook/config/querybook_default_config.yaml
+++ b/querybook/config/querybook_default_config.yaml
@@ -48,6 +48,10 @@ OAUTH_USER_PROFILE: ~
 LDAP_CONN: ~
 LDAP_USER_DN: uid={},dc=example,dc=com
 LDAP_UID_FIELD: uid
+LDAP_EMAIL_FIELD: mail
+LDAP_LASTNAME_FIELD: sn
+LDAP_FIRSTNAME_FIELD: givenName
+LDAP_FULLNAME_FIELD: cn
 
 # --------------- Result Store ---------------
 RESULT_STORE_TYPE: db

--- a/querybook/server/app/auth/ldap_auth.py
+++ b/querybook/server/app/auth/ldap_auth.py
@@ -30,7 +30,12 @@ class LDAPAuthErrors:
 
 @dataclass
 class LDAPUserInfo:
-    LDAP_ATTRS = ["cn", "givenName", "mail", "sn"]
+    LDAP_ATTRS = [
+        QuerybookSettings.LDAP_FULLNAME_FIELD,  # default: cn
+        QuerybookSettings.LDAP_FIRSTNAME_FIELD,  # default: givenName
+        QuerybookSettings.LDAP_EMAIL_FIELD,  # default: mail
+        QuerybookSettings.LDAP_LASTNAME_FIELD,  # default: sn
+    ]
 
     cn: Optional[str] = None
     dn: Optional[str] = None
@@ -91,11 +96,11 @@ def _parse_user_info(ldap_user_info: Tuple[str, Dict]) -> LDAPUserInfo:
     try:
         user_info = ldap_user_info[1]
         return LDAPUserInfo(
-            cn=_parse_value(user_info["cn"]),
+            cn=_parse_value(user_info[QuerybookSettings.LDAP_FULLNAME_FIELD]),
             dn=ldap_user_info[0],
-            email=_parse_value(user_info["mail"]),
-            first_name=_parse_value(user_info["givenName"]),
-            last_name=_parse_value(user_info["sn"]),
+            email=_parse_value(user_info[QuerybookSettings.LDAP_EMAIL_FIELD]),
+            first_name=_parse_value(user_info[QuerybookSettings.LDAP_FIRSTNAME_FIELD]),
+            last_name=_parse_value(user_info[QuerybookSettings.LDAP_LASTNAME_FIELD]),
         )
 
     except (IndexError, NameError):

--- a/querybook/server/env.py
+++ b/querybook/server/env.py
@@ -83,6 +83,10 @@ class QuerybookSettings(object):
     LDAP_SEARCH = get_env_config("LDAP_SEARCH")
     LDAP_FILTER = get_env_config("LDAP_FILTER")
     LDAP_UID_FIELD = get_env_config("LDAP_UID_FIELD")
+    LDAP_EMAIL_FIELD = get_env_config("LDAP_EMAIL_FIELD")
+    LDAP_LASTNAME_FIELD = get_env_config("LDAP_LASTNAME_FIELD")
+    LDAP_FIRSTNAME_FIELD = get_env_config("LDAP_FIRSTNAME_FIELD")
+    LDAP_FULLNAME_FIELD = get_env_config("LDAP_FULLNAME_FIELD")
     # Configuration validation
     if LDAP_CONN is not None:
         if LDAP_USE_BIND_USER:


### PR DESCRIPTION
In our company, LDAP has attribute names different from standards.

There are additional LDAP configs for those case in flask app builder
- https://flask-appbuilder.readthedocs.io/en/latest/security.html#authentication-ldap

querybook was implemented on top of flask without fab. so I added some more configs for ldap integrations.

config attribute naming is based on the page below
- https://docs.bmc.com/docs/fpsc121/ldap-attributes-and-associated-fields-495323340.html