### PR TITLE
update querybook helm charts

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -15,3 +15,5 @@ maintainers:
     email: yongchana@gmail.com
   - name: Jaehyeok Lee
     email: q32145@gmail.com
+  - name: Changhoon Oh
+    email: ok9897@gmail.com

--- a/helm/templates/scheduler/scheduler-deployment.yaml
+++ b/helm/templates/scheduler/scheduler-deployment.yaml
@@ -55,6 +55,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "querybook.fullname" . }}-secret
                   key: ELASTICSEARCH_HOST
+            {{- range $key, $value := .Values.extraEnv }}
+            - name: {{ $key | quote}}
+              value: {{ $value | quote }}
+            {{- end }}
           resources:
             {{- toYaml .Values.scheduler.resources | nindent 12 }}
       restartPolicy: Always

--- a/helm/templates/web/web-deployment.yaml
+++ b/helm/templates/web/web-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           env:
             - name: PORT
-              value: '10001'
+              value: '8081'
             - name: FLASK_SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -56,8 +56,12 @@ spec:
                 secretKeyRef:
                   name: {{ include "querybook.fullname" . }}-secret
                   key: ELASTICSEARCH_HOST
+            {{- range $key, $value := .Values.extraEnv }}
+            - name: {{ $key | quote}}
+              value: {{ $value | quote }}
+            {{- end }}
           ports:
-            - containerPort: 10001
+            - containerPort: 8081
           resources:
             {{- toYaml .Values.web.resources | nindent 12 }}
       restartPolicy: Always

--- a/helm/templates/web/web-deployment.yaml
+++ b/helm/templates/web/web-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           env:
             - name: PORT
-              value: '8081'
+              value: "{{ .Values.web.service.containerPort }}"
             - name: FLASK_SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -61,7 +61,7 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
           ports:
-            - containerPort: 8081
+            - containerPort: {{ .Values.web.service.containerPort }}
           resources:
             {{- toYaml .Values.web.resources | nindent 12 }}
       restartPolicy: Always

--- a/helm/templates/web/web-ingress.yaml
+++ b/helm/templates/web/web-ingress.yaml
@@ -1,0 +1,44 @@
+{{ if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.web.name }}
+  labels:
+    app: {{ include "querybook.name" . }}
+    chart: {{ include "querybook.chart" . }}
+    component: {{ .Values.web.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $.Values.ingress.path }}
+            pathType: {{ $.Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $.Values.web.name }}
+                port:
+                  name: http
+  {{- end }}
+{{- end }}

--- a/helm/templates/web/web-service.yaml
+++ b/helm/templates/web/web-service.yaml
@@ -12,7 +12,7 @@ spec:
   type: {{ .Values.web.service.serviceType }}
   ports:
     - port: {{ .Values.web.service.servicePort }}
-      targetPort: 8081
+      targetPort: {{ .Values.web.service.containerPort }}
       protocol: TCP
       name: http
   selector:

--- a/helm/templates/web/web-service.yaml
+++ b/helm/templates/web/web-service.yaml
@@ -12,7 +12,7 @@ spec:
   type: {{ .Values.web.service.serviceType }}
   ports:
     - port: {{ .Values.web.service.servicePort }}
-      targetPort: 10001
+      targetPort: 8081
       protocol: TCP
       name: http
   selector:

--- a/helm/templates/worker/worker-deployment.yaml
+++ b/helm/templates/worker/worker-deployment.yaml
@@ -56,6 +56,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "querybook.fullname" . }}-secret
                   key: ELASTICSEARCH_HOST
+            {{- range $key, $value := .Values.extraEnv }}
+            - name: {{ $key | quote}}
+              value: {{ $value | quote }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -38,6 +38,7 @@ web:
   service:
     serviceType: ClusterIP
     servicePort: 80
+    containerPort: 10001
   resources:
     requests:
       memory: 1Gi

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -12,10 +12,6 @@ worker:
     limits:
       memory: 900Mi
       cpu: 1
-  nodeSelector: {}
-  affinity: {}
-  tolerations: []
-  podAnnotations: {}
 
 scheduler:
   replicaCount: 1
@@ -31,10 +27,6 @@ scheduler:
     limits:
       memory: '200Mi'
       cpu: '100m'
-  nodeSelector: {}
-  affinity: {}
-  tolerations: []
-  podAnnotations: {}
 
 web:
   replicaCount: 1
@@ -53,10 +45,6 @@ web:
     limits:
       memory: 3Gi
       cpu: 1
-  nodeSelector: {}
-  affinity: {}
-  tolerations: []
-  podAnnotations: {}
 
 mysql:
   enabled: true
@@ -82,10 +70,6 @@ mysql:
     limits:
       memory: '500Mi'
       cpu: '300m'
-  nodeSelector: {}
-  affinity: {}
-  tolerations: []
-  podAnnotations: {}
 
 redis:
   enabled: true
@@ -105,10 +89,6 @@ redis:
     limits:
       memory: '1Gi'
       cpu: '300m'
-  nodeSelector: {}
-  affinity: {}
-  tolerations: []
-  podAnnotations: {}
 
 elasticsearch:
   enabled: true
@@ -137,10 +117,29 @@ elasticsearch:
     limits:
       memory: '1Gi'
       cpu: '200m'
-  nodeSelector: {}
-  affinity: {}
-  tolerations: []
-  podAnnotations: {}
+
+# assigning pods to node configs. will be applied to all the querybook pods
+nodeSelector: {}
+affinity: {}
+tolerations: []
+podAnnotations: {}
+
+ingress:
+  enabled: true
+  ingressClassName: ~
+  annotations: {}
+  path: /*
+  pathType: ImplementationSpecific
+  hosts:
+  - <your-querybook-app-domain>
+  tls: []
+  # - secretName: <your-querybook-tls-secret>
+  #   hosts:
+  #     - <your-querybook-app-domain>
+
+extraEnv:
+  PUBLIC_URL: https://<your-querybook-app-domain>
+  # any other Querybook configuration env. variables can be injected from here
 
 secret:
   flask_secret_key: SOME_RANDOM_SECRET_KEY


### PR DESCRIPTION
- add ingress template to make http/https endpoint on webserver component
- add extraEnv props. to inject common environment variables to all the pods of components
- fix pod assigning configs on `values.yaml` to valid position (all the pod templates actually has same global configs)