### PR TITLE
fix: clicking a readonly text cell causes querybook crash

### DIFF
--- a/querybook/webapp/ui/RichTextEditor/RichTextEditor.tsx
+++ b/querybook/webapp/ui/RichTextEditor/RichTextEditor.tsx
@@ -146,7 +146,7 @@ export const RichTextEditor = React.forwardRef<
         const selfRef = useRef<HTMLDivElement>();
 
         const focus = useCallback(() => {
-            if (editorRef.current) {
+            if (editorRef.current && toolBarRef.current) {
                 editorRef.current.focus();
                 setToolBarStyle(
                     calculateToolBarStyle(


### PR DESCRIPTION
**Issue**
In readonly mode, when user clicks a text cell, querybook will crash. 

**Cause**
`toolBarRef.current` is null in readonly mode.