### PR TITLE
fix: Fix Scheduled DataDocs Only toggle

### DIFF
--- a/querybook/webapp/components/DataDocScheduleList/DataDocScheduleItem.tsx
+++ b/querybook/webapp/components/DataDocScheduleList/DataDocScheduleItem.tsx
@@ -97,6 +97,7 @@ export const DataDocScheduleItem: React.FC<IDataDocScheduleItemProps> = ({
     };
 
     const { doc, schedule, last_record: lastRecord } = docWithSchedule;
+    const isScheduleDisabled = schedule?.enabled === false;
 
     return (
         <div className="DataDocScheduleItem mb12">
@@ -107,7 +108,7 @@ export const DataDocScheduleItem: React.FC<IDataDocScheduleItemProps> = ({
                             <AccentText
                                 weight="bold"
                                 size="med"
-                                color={schedule.enabled ? 'text' : 'lightest'}
+                                color={isScheduleDisabled ? 'lightest' : 'text'}
                             >
                                 {doc.title}
                             </AccentText>


### PR DESCRIPTION
PR #1122 introduced a bug with the Scheduled DataDoc Only toggle.  Unchecking this option would cause a crash if DataDocs without a schedule are returned.