### PR TITLE
feat: add event logging for query execution progress

### DIFF
--- a/querybook/server/const/event_log.py
+++ b/querybook/server/const/event_log.py
@@ -11,6 +11,8 @@ class EventType(Enum):
     VIEW = "VIEW"
     # a UI element gets clicked
     CLICK = "CLICK"
+    # query/statement execution events
+    EXECUTION = "EXECUTION"
 
 
 class FrontendEvent(TypedDict):


### PR DESCRIPTION
During the query execution, we'll log the execution progress every min with elapsed time and progress percentage.