### PR TITLE
fix: sql-formatter

### DIFF
--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -233,11 +233,11 @@ export const QueryEditor: React.FC<
         );
 
         const formatQuery = useCallback(
-            (
-                options: ISQLFormatOptions = {
-                    silent: false,
-                }
-            ) => {
+            (options: ISQLFormatOptions) => {
+                options = {
+                    silent: false, // default false to throw format errors
+                    ...options,
+                };
                 if (editorRef.current) {
                     const indentWithTabs =
                         editorRef.current.getOption('indentWithTabs');

--- a/querybook/webapp/lib/sql-helper/sql-formatter.ts
+++ b/querybook/webapp/lib/sql-helper/sql-formatter.ts
@@ -182,7 +182,7 @@ function formatEachStatement(
             originalStatementText,
         }) => {
             // Use standard formatter to format
-            let formattedStatement = originalStatementText;
+            let formattedStatement = statementText;
             if (
                 firstKeyWord &&
                 allowedStatement.has(firstKeyWord.text.toLocaleLowerCase())

--- a/querybook/webapp/lib/sql-helper/sql-formatter.ts
+++ b/querybook/webapp/lib/sql-helper/sql-formatter.ts
@@ -64,7 +64,6 @@ interface IProcessedStatement {
     statementText: string;
     idToTemplateTag: Record<string, string>;
     firstKeyWord: IToken;
-    originalStatementText: string;
 }
 
 function tokenizeAndFormatQuery(
@@ -139,10 +138,6 @@ function processStatements(
                 statementText,
                 idToTemplateTag,
                 firstKeyWord,
-                originalStatementText: query.slice(
-                    statementRange[0],
-                    statementRange[1] + 1
-                ),
             };
         }
     );
@@ -158,7 +153,7 @@ function formatEachStatement(
     language: string,
     options: ISQLFormatOptions
 ) {
-    const safeSQLFormat = (text: string, unformattedText: string) => {
+    const safeSQLFormat = (text: string) => {
         try {
             return sqlFormat(text, {
                 tabWidth: options.tabWidth,
@@ -167,7 +162,7 @@ function formatEachStatement(
             });
         } catch (e) {
             if (options.silent) {
-                return unformattedText;
+                return text;
             } else {
                 throw e;
             }
@@ -175,22 +170,14 @@ function formatEachStatement(
     };
 
     const formattedStatements: string[] = statements.map(
-        ({
-            firstKeyWord,
-            statementText,
-            idToTemplateTag,
-            originalStatementText,
-        }) => {
+        ({ firstKeyWord, statementText, idToTemplateTag }) => {
             // Use standard formatter to format
             let formattedStatement = statementText;
             if (
                 firstKeyWord &&
                 allowedStatement.has(firstKeyWord.text.toLocaleLowerCase())
             ) {
-                formattedStatement = safeSQLFormat(
-                    statementText,
-                    originalStatementText
-                );
+                formattedStatement = safeSQLFormat(statementText);
             }
 
             for (const [id, templateTag] of Object.entries(idToTemplateTag)) {


### PR DESCRIPTION
sql-formatter is not working properly.
and also the behavior is not consistent between adhoc and datadoc

**cause**: 
https://github.com/pinterest/querybook/pull/1141/files#diff-f96c7f939d2f6190281fe1288630f6ce6e7efec269cd71a04a16a6379686e38fR185

**fix**
 * make the silent option to be default false for both adhoc and datadoc
 * format either fail or succeed on the whole query, not per statement