### PR TITLE
fix: event logger when current user is None

### DIFF
--- a/querybook/server/lib/event_logger/__init__.py
+++ b/querybook/server/lib/event_logger/__init__.py
@@ -15,8 +15,10 @@ class EventLogger:
 
     def log(self, event_type: EventType, event_data: dict, timestamp: int = None):
         try:
+            # default uid 0 if we cant get the current user
+            uid = current_user.id if current_user else 0
             self.logger.log(
-                uid=current_user.id,
+                uid=uid,
                 event_type=event_type,
                 event_data=event_data,
                 timestamp=timestamp,


### PR DESCRIPTION
worker can't get current user. here we're changing the uid to be optional, which will be default to 0.