### PR TITLE
fix: number type variable with value 0

### DIFF
--- a/querybook/server/lib/query_analysis/templating.py
+++ b/querybook/server/lib/query_analysis/templating.py
@@ -273,7 +273,7 @@ def flatten_recursive_variables(
     variables_dag = {}
 
     for key, value in raw_variables.items():
-        if not value:
+        if value is None:
             value = ""
 
         # check if a string has any custom global functions or raw variables


### PR DESCRIPTION
Queries contain a number template variable with value 0 can't be rendered properly. The value will become empty. 