### PR TITLE
feat: toggle run all notifications

### DIFF
--- a/querybook/server/datasources/datadoc.py
+++ b/querybook/server/datasources/datadoc.py
@@ -381,7 +381,7 @@ def run_data_doc(id):
 
 
 @register("/datadoc/<int:id>/run/", methods=["POST"])
-def adhoc_run_data_doc(id, sendNotification=True):
+def adhoc_run_data_doc(id, send_notification=False):
     assert_can_write(id)
     verify_data_doc_permission(id)
 
@@ -395,7 +395,7 @@ def adhoc_run_data_doc(id, sendNotification=True):
                 "with": notifier_name,
             }
         ]
-        if sendNotification
+        if send_notification
         else []
     )
 

--- a/querybook/server/datasources/datadoc.py
+++ b/querybook/server/datasources/datadoc.py
@@ -381,11 +381,23 @@ def run_data_doc(id):
 
 
 @register("/datadoc/<int:id>/run/", methods=["POST"])
-def adhoc_run_data_doc(id):
+def adhoc_run_data_doc(id, sendNotification=True):
     assert_can_write(id)
     verify_data_doc_permission(id)
 
     notifier_name = get_user_preferred_notifier(current_user.id)
+
+    notifications = (
+        [
+            {
+                "config": {"to_user": [current_user.id]},
+                "on": 0,
+                "with": notifier_name,
+            }
+        ]
+        if sendNotification
+        else []
+    )
 
     celery.send_task(
         "tasks.run_datadoc.run_datadoc",
@@ -394,13 +406,7 @@ def adhoc_run_data_doc(id):
             "doc_id": id,
             "user_id": current_user.id,
             "execution_type": QueryExecutionType.ADHOC.value,
-            "notifications": [
-                {
-                    "config": {"to_user": [current_user.id]},
-                    "on": 0,
-                    "with": notifier_name,
-                }
-            ],
+            "notifications": notifications,
         },
     )
 

--- a/querybook/webapp/components/DataDocRightSidebar/DataDocRunAllButton.tsx
+++ b/querybook/webapp/components/DataDocRightSidebar/DataDocRunAllButton.tsx
@@ -36,7 +36,7 @@ export const DataDocRunAllButton: React.FunctionComponent<IProps> = ({
             message: (
                 <DataDocRunAllButtonConfirm
                     defaultNotification={notification.current}
-                    handleNotificationChange={(value) => {
+                    onNotificationChange={(value) => {
                         notification.current = value;
                     }}
                     hasQueryRunning={hasQueryRunning}

--- a/querybook/webapp/components/DataDocRightSidebar/DataDocRunAllButton.tsx
+++ b/querybook/webapp/components/DataDocRightSidebar/DataDocRunAllButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import toast from 'react-hot-toast';
 
 import { ComponentType, ElementType } from 'const/analytics';
@@ -9,7 +9,8 @@ import { sendConfirm } from 'lib/querybookUI';
 import { makeLatestQueryExecutionsSelector } from 'redux/queryExecutions/selector';
 import { DataDocResource } from 'resource/dataDoc';
 import { IconButton } from 'ui/Button/IconButton';
-import { Message } from 'ui/Message/Message';
+
+import { DataDocRunAllButtonConfirm } from './DataDocRunAllButtonConfirm';
 
 interface IProps {
     docId: number;
@@ -27,43 +28,38 @@ export const DataDocRunAllButton: React.FunctionComponent<IProps> = ({
         () => latestQueryExecutions.some((q) => q.status < 3),
         [latestQueryExecutions]
     );
-
-    const ConfirmMessageDOM = useCallback(
-        () => (
-            <div>
-                {hasQueryRunning && (
-                    <Message type="warning" className="mb8">
-                        There are some query cells still running. Do you want to
-                        run anyway?
-                    </Message>
-                )}
-                <div>
-                    {`You will be executing ${queryCells.length} query cells sequentially. If any of them
-                fails, the sequence of execution will be stopped.`}
-                </div>
-            </div>
-        ),
-        [queryCells.length, hasQueryRunning]
-    );
+    const notification = useRef(true);
 
     const onRunAll = useCallback(() => {
         sendConfirm({
             header: 'Run All Cells',
-            message: ConfirmMessageDOM(),
+            message: (
+                <DataDocRunAllButtonConfirm
+                    defaultNotification={notification.current}
+                    handleNotificationChange={(value) => {
+                        notification.current = value;
+                    }}
+                    hasQueryRunning={hasQueryRunning}
+                    queryCells={queryCells}
+                />
+            ),
             onConfirm: () => {
                 trackClick({
                     component: ComponentType.DATADOC_PAGE,
                     element: ElementType.RUN_ALL_CELLS_BUTTON,
                 });
-                toast.promise(DataDocResource.run(docId), {
-                    loading: null,
-                    success: 'DataDoc execution started!',
-                    error: 'Failed to start the execution',
-                });
+                toast.promise(
+                    DataDocResource.run(docId, notification.current),
+                    {
+                        loading: null,
+                        success: 'DataDoc execution started!',
+                        error: 'Failed to start the execution',
+                    }
+                );
             },
             confirmText: 'Run',
         });
-    }, [ConfirmMessageDOM, docId]);
+    }, [docId, hasQueryRunning, notification, queryCells]);
 
     return (
         <IconButton

--- a/querybook/webapp/components/DataDocRightSidebar/DataDocRunAllButtonConfirm.tsx
+++ b/querybook/webapp/components/DataDocRightSidebar/DataDocRunAllButtonConfirm.tsx
@@ -6,25 +6,25 @@ import { ToggleSwitch } from 'ui/ToggleSwitch/ToggleSwitch';
 
 interface IProps {
     defaultNotification: boolean;
-    handleNotificationChange: (notification: boolean) => void;
+    onNotificationChange: (notification: boolean) => void;
     hasQueryRunning: boolean;
     queryCells: ReturnType<typeof useQueryCells>;
 }
 
 export const DataDocRunAllButtonConfirm: React.FunctionComponent<IProps> = ({
     defaultNotification,
-    handleNotificationChange,
+    onNotificationChange,
     hasQueryRunning,
     queryCells,
 }) => {
     const [notification, setNotification] = useState(defaultNotification);
 
     const internalNotificationChange = useCallback(
-        (value) => {
-            handleNotificationChange(value);
+        (value: boolean) => {
+            onNotificationChange(value);
             setNotification(value);
         },
-        [handleNotificationChange, setNotification]
+        [onNotificationChange, setNotification]
     );
 
     return (
@@ -46,9 +46,7 @@ export const DataDocRunAllButtonConfirm: React.FunctionComponent<IProps> = ({
                     onChange={internalNotificationChange}
                 />
 
-                <span data-balloon-pos={'up'} className="ml4">
-                    Send Notification when Finished
-                </span>
+                <span className="ml4">Send Notification when Finished</span>
             </div>
         </div>
     );

--- a/querybook/webapp/components/DataDocRightSidebar/DataDocRunAllButtonConfirm.tsx
+++ b/querybook/webapp/components/DataDocRightSidebar/DataDocRunAllButtonConfirm.tsx
@@ -1,0 +1,55 @@
+import React, { useCallback, useState } from 'react';
+
+import { useQueryCells } from 'hooks/dataDoc/useQueryCells';
+import { Message } from 'ui/Message/Message';
+import { ToggleSwitch } from 'ui/ToggleSwitch/ToggleSwitch';
+
+interface IProps {
+    defaultNotification: boolean;
+    handleNotificationChange: (notification: boolean) => void;
+    hasQueryRunning: boolean;
+    queryCells: ReturnType<typeof useQueryCells>;
+}
+
+export const DataDocRunAllButtonConfirm: React.FunctionComponent<IProps> = ({
+    defaultNotification,
+    handleNotificationChange,
+    hasQueryRunning,
+    queryCells,
+}) => {
+    const [notification, setNotification] = useState(defaultNotification);
+
+    const internalNotificationChange = useCallback(
+        (value) => {
+            handleNotificationChange(value);
+            setNotification(value);
+        },
+        [handleNotificationChange, setNotification]
+    );
+
+    return (
+        <div>
+            {hasQueryRunning && (
+                <Message type="warning" className="mb8">
+                    There are some query cells still running. Do you want to run
+                    anyway?
+                </Message>
+            )}
+            <div>
+                {`You will be executing ${queryCells.length} query cells sequentially. If any of them
+            fails, the sequence of execution will be stopped.`}
+            </div>
+            <br />
+            <div className="flex-row">
+                <ToggleSwitch
+                    checked={notification}
+                    onChange={internalNotificationChange}
+                />
+
+                <span data-balloon-pos={'up'} className="ml4">
+                    Send Notification when Finished
+                </span>
+            </div>
+        </div>
+    );
+};

--- a/querybook/webapp/resource/dataDoc.ts
+++ b/querybook/webapp/resource/dataDoc.ts
@@ -101,9 +101,9 @@ export const DataDocResource = {
         }>(`/favorite_data_doc/${docId}/`),
     unfavorite: (docId: number) => ds.delete(`/favorite_data_doc/${docId}/`),
 
-    run: (docId: number, sendNotification: boolean = true) =>
+    run: (docId: number, sendNotification: boolean = false) =>
         ds.save<null>(`/datadoc/${docId}/run/`, {
-            sendNotification: sendNotification,
+            send_notification: sendNotification,
         }),
 
     getDAGExport: (docId: number) =>

--- a/querybook/webapp/resource/dataDoc.ts
+++ b/querybook/webapp/resource/dataDoc.ts
@@ -101,7 +101,10 @@ export const DataDocResource = {
         }>(`/favorite_data_doc/${docId}/`),
     unfavorite: (docId: number) => ds.delete(`/favorite_data_doc/${docId}/`),
 
-    run: (docId: number) => ds.save<null>(`/datadoc/${docId}/run/`),
+    run: (docId: number, sendNotification: boolean = true) =>
+        ds.save<null>(`/datadoc/${docId}/run/`, {
+            sendNotification: sendNotification,
+        }),
 
     getDAGExport: (docId: number) =>
         ds.fetch<IDataDocSavedDAGExport>(`/datadoc/${docId}/dag_export/`),


### PR DESCRIPTION
Added a toggle to the run all confirmation page so that users can choose whether they want a notification to be sent upon run completion. By default, the notification and toggle will be enabled to match previous behavior of Querybook where a notification will always be sent to the user upon run completion. The type of notification sent is still based on "notification preference" in user settings.

<img width="593" alt="Screen Shot 2023-02-13 at 4 00 06 PM" src="https://user-images.githubusercontent.com/72165460/218601772-9b6ae38f-5ba6-4a54-b133-0d7c8a35ff2c.png">