### PR TITLE
fix: filter null store values

### DIFF
--- a/querybook/webapp/components/TableUploader/useQueryEnginesForUpload.ts
+++ b/querybook/webapp/components/TableUploader/useQueryEnginesForUpload.ts
@@ -25,6 +25,7 @@ export function useMetastoresForUpload() {
                 queryEngines
                     .filter((engine) => engine.feature_params.upload_exporter)
                     .map((engine) => engine.metastore_id)
+                    .filter((metastoreId) => metastoreId != null)
             ),
         [queryEngines]
     );


### PR DESCRIPTION
This fixes an issue where having a query engine with a missing or deleted metastore causes the Table Upload UI to crash on the "Table Spec" section.