### PR TITLE
feat: load tag from metastore

### DIFF
--- a/querybook/server/const/metastore.py
+++ b/querybook/server/const/metastore.py
@@ -18,6 +18,7 @@ class MetadataMode(Enum):
     READ_ONLY = "read_only"
 
     # On saving, metadata will only be written to querybook db. This is the default mode if not specified.
+    # It also indicates that it will not load this metadata from the metastore.
     WRITE_LOCAL = "write_local"
 
     # On saving, metadata will be written back to metastore, as well as querybook db
@@ -36,6 +37,13 @@ class MetastoreLoaderConfig:
 
     def __init__(self, config: dict[MetadataType, MetadataMode]):
         self._config = {**self._default_config, **config}
+
+    def load_metadata(self, metadataType: MetadataType) -> bool:
+        """Check if the given metadata type will be loaded from metastore"""
+        return (
+            self._config.get(metadataType, MetadataMode.WRITE_LOCAL)
+            != MetadataMode.WRITE_LOCAL
+        )
 
     def to_dict(self):
         return {key.value: value.value for (key, value) in self._config.items()}

--- a/querybook/server/const/metastore.py
+++ b/querybook/server/const/metastore.py
@@ -38,7 +38,7 @@ class MetastoreLoaderConfig:
     def __init__(self, config: dict[MetadataType, MetadataMode]):
         self._config = {**self._default_config, **config}
 
-    def load_metadata(self, metadataType: MetadataType) -> bool:
+    def can_load_external_metadata(self, metadataType: MetadataType) -> bool:
         """Check if the given metadata type will be loaded from metastore"""
         return (
             self._config.get(metadataType, MetadataMode.WRITE_LOCAL)

--- a/querybook/server/const/metastore.py
+++ b/querybook/server/const/metastore.py
@@ -40,9 +40,9 @@ class MetastoreLoaderConfig:
 
     def can_load_external_metadata(self, metadataType: MetadataType) -> bool:
         """Check if the given metadata type will be loaded from metastore"""
-        return (
-            self._config.get(metadataType, MetadataMode.WRITE_LOCAL)
-            != MetadataMode.WRITE_LOCAL
+        return self._config.get(metadataType, MetadataMode.WRITE_LOCAL) in (
+            MetadataMode.READ_ONLY,
+            MetadataMode.WRITE_BACK,
         )
 
     def to_dict(self):

--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod, abstractclassmethod
 import gevent
 import math
-from typing import NamedTuple, List, Dict, Tuple, Optional
+from typing import List, Dict, Tuple, Optional
 import traceback
 
 from app.db import DBSession, with_session
@@ -26,58 +26,12 @@ from logic.metastore import (
     get_schema_by_name,
     get_table_by_schema_id_and_name,
 )
+from logic.tag import create_table_tags
 
+from .metastore_data_types import DataTable, DataColumn
 from .utils import MetastoreTableACLChecker
 
 LOG = get_logger(__name__)
-
-
-class DataSchema(NamedTuple):
-    name: str
-
-
-class DataTable(NamedTuple):
-    name: str
-
-    # The type of table, it can be an arbitrary string
-    type: str = None
-    owner: str = None
-
-    # description from metastore, expect HTML format
-    description: str = None
-
-    # Expected in UTC seconds
-    table_created_at: int = None
-    table_updated_at: int = None
-    table_updated_by: str = None
-
-    # size of table
-    data_size_bytes: int = None
-    # Location of the raw file
-    location: str = None
-
-    # Json arrays of partitions
-    partitions: List = []
-
-    # Store the raw info here
-    raw_description: str = None
-
-    # Arrays of partition keys
-    partition_keys: List[str] = []
-
-    # Custom properties
-    custom_properties: dict[str, str] = None
-
-
-class DataColumn(NamedTuple):
-    name: str
-    type: str
-
-    # column comment from sql query when creating the table
-    comment: str = None
-
-    # user edited description from metastore, expect HTML format
-    description: str = None
 
 
 class BaseMetastoreLoader(metaclass=ABCMeta):
@@ -382,6 +336,14 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
                     description=column.description,
                     table_id=table_id,
                     commit=False,
+                    session=session,
+                )
+
+            # create tags if the metastore is configured to sync tags
+            if self.loader_config.load_metadata(MetadataType.TAG):
+                create_table_tags(
+                    table_id=table_id,
+                    tags=table.tags,
                     session=session,
                 )
             session.commit()

--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -340,7 +340,7 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
                 )
 
             # create tags if the metastore is configured to sync tags
-            if self.loader_config.load_metadata(MetadataType.TAG):
+            if self.loader_config.can_load_external_metadata(MetadataType.TAG):
                 create_table_tags(
                     table_id=table_id,
                     tags=table.tags,

--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -344,6 +344,7 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
                 create_table_tags(
                     table_id=table_id,
                     tags=table.tags,
+                    commit=False,
                     session=session,
                 )
             session.commit()

--- a/querybook/server/lib/metastore/loaders/glue_data_catalog_loader.py
+++ b/querybook/server/lib/metastore/loaders/glue_data_catalog_loader.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Tuple
 
 from clients.glue_client import GlueDataCatalogClient
 from lib.form import StructFormField, FormField
-from lib.metastore.base_metastore_loader import (
-    BaseMetastoreLoader,
+from lib.metastore.base_metastore_loader import BaseMetastoreLoader
+from lib.metastore.metastore_data_types import (
     DataTable,
     DataColumn,
 )

--- a/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
+++ b/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
@@ -3,8 +3,8 @@ from lib.form import ExpandableFormField, FormField, FormFieldType, StructFormFi
 from hmsclient.genthrift.hive_metastore.ttypes import NoSuchObjectException
 
 from clients.hms_client import HiveMetastoreClient
-from lib.metastore.base_metastore_loader import (
-    BaseMetastoreLoader,
+from lib.metastore.base_metastore_loader import BaseMetastoreLoader
+from lib.metastore.metastore_data_types import (
     DataTable,
     DataColumn,
 )

--- a/querybook/server/lib/metastore/loaders/mysql_metastore_loader.py
+++ b/querybook/server/lib/metastore/loaders/mysql_metastore_loader.py
@@ -2,7 +2,10 @@ from typing import List, Tuple
 
 from lib.utils.utils import DATETIME_TO_UTC
 from lib.utils import json as ujson
-from lib.metastore.base_metastore_loader import DataTable, DataColumn
+from lib.metastore.metastore_data_types import (
+    DataTable,
+    DataColumn,
+)
 from .sqlalchemy_metastore_loader import SqlAlchemyMetastoreLoader
 
 

--- a/querybook/server/lib/metastore/loaders/sqlalchemy_metastore_loader.py
+++ b/querybook/server/lib/metastore/loaders/sqlalchemy_metastore_loader.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Tuple
 
-from lib.metastore.base_metastore_loader import (
-    BaseMetastoreLoader,
+from lib.metastore.base_metastore_loader import BaseMetastoreLoader
+from lib.metastore.metastore_data_types import (
     DataTable,
     DataColumn,
 )

--- a/querybook/server/lib/metastore/loaders/thrifthive_metastore_loader.py
+++ b/querybook/server/lib/metastore/loaders/thrifthive_metastore_loader.py
@@ -6,7 +6,10 @@ from lib.query_executor.clients.hive import HiveClient
 from clients.hms_client import HiveMetastoreClient
 from lib.metastore.loaders.hive_metastore_loader import HMSMetastoreLoader
 from lib.metastore.loaders.form_fileds import load_partitions_field
-from lib.metastore.base_metastore_loader import DataTable, DataColumn
+from lib.metastore.metastore_data_types import (
+    DataTable,
+    DataColumn,
+)
 
 
 class HMSThriftMetastoreLoader(HMSMetastoreLoader):

--- a/querybook/server/lib/metastore/metastore_data_types.py
+++ b/querybook/server/lib/metastore/metastore_data_types.py
@@ -1,0 +1,60 @@
+from typing import NamedTuple, List
+
+
+class DataSchema(NamedTuple):
+    name: str
+
+
+class DataTag(NamedTuple):
+    name: str
+    # below properties will be stored in tag.meta
+    type: str = None
+    description: str = None
+    color: str = None
+
+
+class DataTable(NamedTuple):
+    name: str
+
+    # The type of table, it can be an arbitrary string
+    type: str = None
+    owner: str = None
+
+    # description from metastore, expect HTML format
+    description: str = None
+
+    # list of tags
+    tags: List[DataTag] = []
+
+    # Expected in UTC seconds
+    table_created_at: int = None
+    table_updated_at: int = None
+    table_updated_by: str = None
+
+    # size of table
+    data_size_bytes: int = None
+    # Location of the raw file
+    location: str = None
+
+    # Json arrays of partitions
+    partitions: List = []
+
+    # Store the raw info here
+    raw_description: str = None
+
+    # Arrays of partition keys
+    partition_keys: List[str] = []
+
+    # Custom properties
+    custom_properties: dict[str, str] = None
+
+
+class DataColumn(NamedTuple):
+    name: str
+    type: str
+
+    # column comment from sql query when creating the table
+    comment: str = None
+
+    # user edited description from metastore, expect HTML format
+    description: str = None

--- a/querybook/server/logic/tag.py
+++ b/querybook/server/logic/tag.py
@@ -2,6 +2,7 @@ import datetime
 from app.db import with_session
 from models.tag import Tag, TagItem
 from logic.metastore import update_es_tables_by_id
+from lib.metastore.metastore_data_types import DataTag
 
 
 @with_session
@@ -93,8 +94,8 @@ def delete_tag_from_table(
 
 @with_session
 def create_table_tags(
-    table_id=None,
-    tags=[],
+    table_id: int = None,
+    tags: list[DataTag] = [],
     commit=True,
     session=None,
 ):
@@ -118,12 +119,10 @@ def create_table_tags(
         )
 
         # add a new tag_item to associate with the table
-        tag_item = TagItem.get(table_id=table_id, tag_name=tag.name, session=session)
-        if not tag_item:
-            TagItem.create(
-                {"tag_name": tag.name, "table_id": table_id, "uid": None},
-                session=session,
-            )
+        TagItem.create(
+            {"tag_name": tag.name, "table_id": table_id, "uid": None},
+            session=session,
+        )
 
     if commit:
         session.commit()

--- a/querybook/tests/test_lib/test_metastore/test_loaders/test_glue_data_catalog_loader.py
+++ b/querybook/tests/test_lib/test_metastore/test_loaders/test_glue_data_catalog_loader.py
@@ -5,7 +5,10 @@ import boto3
 from datetime import datetime
 
 from lib.metastore.loaders.glue_data_catalog_loader import GlueDataCatalogLoader
-from lib.metastore.base_metastore_loader import DataColumn, DataTable
+from lib.metastore.metastore_data_types import (
+    DataTable,
+    DataColumn,
+)
 
 moto_import_failed = False
 try:

--- a/querybook/webapp/components/DataTableTags/DataTableTags.scss
+++ b/querybook/webapp/components/DataTableTags/DataTableTags.scss
@@ -1,7 +1,7 @@
 .DataTableTags {
     flex-wrap: wrap;
 
-    .Tag {
+    .TableTag {
         margin: 4px 12px 4px 0px;
         cursor: pointer;
     }

--- a/querybook/webapp/components/DataTableTags/DataTableTags.tsx
+++ b/querybook/webapp/components/DataTableTags/DataTableTags.tsx
@@ -124,7 +124,7 @@ export const TableTag: React.FC<{
     );
 
     return (
-        <>
+        <div className="TableTag">
             {canUserUpdate && (
                 <ContextMenu
                     anchorRef={tagRef}
@@ -138,9 +138,11 @@ export const TableTag: React.FC<{
                     onHide={() => setShowConfigModal(false)}
                 />
             )}
-
             <HoverIconTag
                 key={tag.id}
+                tagName={tag.name}
+                tagType={tagMeta.type}
+                tagIcon={tagMeta.icon}
                 iconOnHover={canUserDelete ? 'X' : null}
                 onIconHoverClick={canUserDelete ? handleDeleteTag : null}
                 tooltip={tagMeta.tooltip}
@@ -148,18 +150,8 @@ export const TableTag: React.FC<{
                 color={tagMeta.color}
                 onClick={handleTagClick}
                 ref={tagRef}
-                withBorder={tagMeta.admin}
                 mini={mini}
-            >
-                {tagMeta.icon && (
-                    <Icon
-                        name={tagMeta.icon as any}
-                        size={16}
-                        className="mr4"
-                    />
-                )}
-                <span>{tag.name}</span>
-            </HoverIconTag>
-        </>
+            />
+        </div>
     );
 };

--- a/querybook/webapp/components/DataTableTags/DataTableTags.tsx
+++ b/querybook/webapp/components/DataTableTags/DataTableTags.tsx
@@ -140,9 +140,9 @@ export const TableTag: React.FC<{
             )}
             <HoverIconTag
                 key={tag.id}
-                tagName={tag.name}
-                tagType={tagMeta.type}
-                tagIcon={tagMeta.icon}
+                name={tag.name}
+                type={tagMeta.type}
+                icon={tagMeta.icon}
                 iconOnHover={canUserDelete ? 'X' : null}
                 onIconHoverClick={canUserDelete ? handleDeleteTag : null}
                 tooltip={tagMeta.tooltip}

--- a/querybook/webapp/components/DataTableTags/TableTagConfigModal.tsx
+++ b/querybook/webapp/components/DataTableTags/TableTagConfigModal.tsx
@@ -91,7 +91,7 @@ export const TableTagConfigModal: React.FC<{
                         <SimpleField
                             name="type"
                             type="input"
-                            help="The type of the tag. E.g. table tier, domain"
+                            help="The type of the tag. E.g. table domain"
                         />
                         <SimpleField name="tooltip" type="input" />
                         <SimpleField

--- a/querybook/webapp/components/DataTableTags/TableTagConfigModal.tsx
+++ b/querybook/webapp/components/DataTableTags/TableTagConfigModal.tsx
@@ -88,6 +88,11 @@ export const TableTagConfigModal: React.FC<{
             {({ submitForm }) => (
                 <div className="ph12">
                     <FormWrapper minLabelWidth="120px">
+                        <SimpleField
+                            name="type"
+                            type="input"
+                            help="The type of the tag. E.g. table tier, domain"
+                        />
                         <SimpleField name="tooltip" type="input" />
                         <SimpleField
                             name="color"

--- a/querybook/webapp/components/DataTableTags/TableTagGroupSelect.tsx
+++ b/querybook/webapp/components/DataTableTags/TableTagGroupSelect.tsx
@@ -29,7 +29,7 @@ export const TableTagGroupSelect: React.FC<{
             {tags.map((tag) => (
                 <HoverIconTag
                     key={tag}
-                    tagName={tag}
+                    name={tag}
                     iconOnHover={'X'}
                     onIconHoverClick={() => handleTagRemove(tag)}
                 />

--- a/querybook/webapp/components/DataTableTags/TableTagGroupSelect.tsx
+++ b/querybook/webapp/components/DataTableTags/TableTagGroupSelect.tsx
@@ -29,11 +29,10 @@ export const TableTagGroupSelect: React.FC<{
             {tags.map((tag) => (
                 <HoverIconTag
                     key={tag}
+                    tagName={tag}
                     iconOnHover={'X'}
                     onIconHoverClick={() => handleTagRemove(tag)}
-                >
-                    <span>{tag}</span>
-                </HoverIconTag>
+                />
             ))}
         </div>
     ) : null;

--- a/querybook/webapp/components/DataTableView/DataTableHeader.scss
+++ b/querybook/webapp/components/DataTableView/DataTableHeader.scss
@@ -6,9 +6,6 @@
     .table-title {
         font-family: var(--font-accent);
     }
-    .header-subtitle {
-        align-self: flex-start;
-    }
     .DataTableHeader-owner-list {
         .owner-badges {
             flex-wrap: wrap;
@@ -19,9 +16,6 @@
         }
     }
     .DataTableHeader-tags {
-        .header-subtitle {
-            margin-top: 6px;
-        }
         .DataTableTags {
             min-height: 34px;
         }

--- a/querybook/webapp/components/DataTableView/DataTableHeader.tsx
+++ b/querybook/webapp/components/DataTableView/DataTableHeader.tsx
@@ -6,7 +6,12 @@ import { BoardItemAddButton } from 'components/BoardItemAddButton/BoardItemAddBu
 import { DataTableTags } from 'components/DataTableTags/DataTableTags';
 import { ImpressionWidget } from 'components/ImpressionWidget/ImpressionWidget';
 import { UserBadge } from 'components/UserBadge/UserBadge';
-import { IDataTable } from 'const/metastore';
+import {
+    IDataTable,
+    IQueryMetastore,
+    MetadataMode,
+    MetadataType,
+} from 'const/metastore';
 import { IMyUserInfo } from 'const/user';
 import * as Utils from 'lib/utils';
 import {
@@ -26,6 +31,7 @@ export interface IDataTableHeader {
     table: IDataTable;
     userInfo: IMyUserInfo;
     tableName: string;
+    metastore: IQueryMetastore;
     updateDataTableGolden: (golden: boolean) => any;
 }
 
@@ -33,6 +39,7 @@ export const DataTableHeader: React.FunctionComponent<IDataTableHeader> = ({
     table,
     tableName,
     userInfo,
+    metastore,
 
     updateDataTableGolden,
 }) => {
@@ -177,7 +184,13 @@ export const DataTableHeader: React.FunctionComponent<IDataTableHeader> = ({
             >
                 Tags
             </AccentText>
-            <DataTableTags tableId={table.id} />
+            <DataTableTags
+                tableId={table.id}
+                readonly={
+                    metastore.config[MetadataType.TAG] !==
+                    MetadataMode.WRITE_LOCAL
+                }
+            />
         </div>
     );
 

--- a/querybook/webapp/components/DataTableView/DataTableView.tsx
+++ b/querybook/webapp/components/DataTableView/DataTableView.tsx
@@ -363,6 +363,7 @@ export const DataTableView: React.FC<IDataTableViewProps> = ({ tableId }) => {
                     table={table}
                     tableName={tableName}
                     userInfo={userInfo}
+                    metastore={metastore}
                     updateDataTableGolden={updateDataTableGolden}
                 />
                 <Tabs

--- a/querybook/webapp/components/Search/TableSelect.tsx
+++ b/querybook/webapp/components/Search/TableSelect.tsx
@@ -126,7 +126,7 @@ export const TableSelect: React.FunctionComponent<ITableSelectProps> = ({
                     {tableNames.map((tableName) => (
                         <HoverIconTag
                             key={tableName}
-                            tagName={tableName}
+                            name={tableName}
                             iconOnHover="X"
                             onIconHoverClick={() => {
                                 const newTableNames = tableNames.filter(

--- a/querybook/webapp/components/Search/TableSelect.tsx
+++ b/querybook/webapp/components/Search/TableSelect.tsx
@@ -126,6 +126,7 @@ export const TableSelect: React.FunctionComponent<ITableSelectProps> = ({
                     {tableNames.map((tableName) => (
                         <HoverIconTag
                             key={tableName}
+                            tagName={tableName}
                             iconOnHover="X"
                             onIconHoverClick={() => {
                                 const newTableNames = tableNames.filter(
@@ -133,9 +134,7 @@ export const TableSelect: React.FunctionComponent<ITableSelectProps> = ({
                                 );
                                 onTableNamesChange(newTableNames);
                             }}
-                        >
-                            <span>{tableName}</span>
-                        </HoverIconTag>
+                        />
                     ))}
                 </div>
             ) : null}

--- a/querybook/webapp/const/tag.ts
+++ b/querybook/webapp/const/tag.ts
@@ -1,4 +1,5 @@
 export interface ITagMeta {
+    type?: string;
     admin?: boolean;
     color?: string;
     icon?: string;

--- a/querybook/webapp/stylesheets/_utilities.scss
+++ b/querybook/webapp/stylesheets/_utilities.scss
@@ -109,6 +109,10 @@
     text-overflow: ellipsis;
 }
 
+.cursor-pointer {
+    cursor: pointer;
+}
+
 @mixin padding-classes {
     $padding-size-options: 0, 2, 4, 8, 12, 16, 20, 24;
     @each $size in $padding-size-options {

--- a/querybook/webapp/ui/Tag/HoverIconTag.tsx
+++ b/querybook/webapp/ui/Tag/HoverIconTag.tsx
@@ -7,70 +7,56 @@ import type { AllLucideIconNames } from 'ui/Icon/LucideIcons';
 import { ITagProps, Tag, TagGroup } from './Tag';
 
 export interface IHoverIconTagProps extends Omit<ITagProps, 'children'> {
-    tagName: string;
-    tagType?: string;
-    tagIcon?: string;
+    name: string;
+    type?: string;
+    icon?: string;
     iconOnHover?: AllLucideIconNames;
     onIconHoverClick?: (e?: React.MouseEvent) => any;
 }
 export const HoverIconTag = React.forwardRef<
     HTMLSpanElement,
     IHoverIconTagProps
->(
-    (
-        {
-            tagName,
-            tagType,
-            tagIcon,
-            iconOnHover,
-            onIconHoverClick,
-            ...tagProps
-        },
-        ref
-    ) => {
-        const hoverDOM = iconOnHover ? (
-            <div className="HoverIconTag-hover" onClick={onIconHoverClick}>
-                <Icon name={iconOnHover} />
-            </div>
-        ) : null;
+>(({ name, type, icon, iconOnHover, onIconHoverClick, ...tagProps }, ref) => {
+    const hoverDOM = iconOnHover ? (
+        <div className="HoverIconTag-hover" onClick={onIconHoverClick}>
+            <Icon name={iconOnHover} />
+        </div>
+    ) : null;
 
-        const className = clsx(tagProps['className'], 'HoverIconTag');
+    const className = clsx(tagProps['className'], 'HoverIconTag');
 
-        const { tooltip, tooltipPos, color, mini, onClick } = tagProps;
+    const iconDOM = icon && (
+        <Icon name={icon as any} size={16} className="mr4" />
+    );
 
-        const iconDOM = tagIcon && (
-            <Icon name={tagIcon as any} size={16} className="mr4" />
-        );
-
-        if (tagType) {
-            return (
-                <span
-                    aria-label={tooltip}
-                    data-balloon-pos={tooltipPos}
-                    onClick={onClick}
-                    ref={ref}
-                    className={className}
-                >
-                    <TagGroup>
-                        <Tag mini={mini}>
-                            {iconDOM}
-                            <span>{tagType}</span>
-                        </Tag>
-                        <Tag mini={mini} highlighted color={color}>
-                            {tagName}
-                            {hoverDOM}
-                        </Tag>
-                    </TagGroup>
-                </span>
-            );
-        }
-
+    if (type) {
+        const { tooltip, tooltipPos, color, mini, onClick, ...extraProps } =
+            tagProps;
         return (
-            <Tag {...tagProps} ref={ref} className={className}>
-                {iconDOM}
-                <span>{tagName}</span>
-                {hoverDOM}
-            </Tag>
+            <TagGroup
+                tooltip={tooltip}
+                tooltipPos={tooltipPos}
+                className={className}
+                onClick={onClick}
+                ref={ref}
+            >
+                <Tag mini={mini}>
+                    {iconDOM}
+                    <span>{type}</span>
+                </Tag>
+                <Tag mini={mini} highlighted color={color} {...extraProps}>
+                    {name}
+                    {hoverDOM}
+                </Tag>
+            </TagGroup>
         );
     }
-);
+
+    return (
+        <Tag {...tagProps} ref={ref} className={className}>
+            {iconDOM}
+            <span>{name}</span>
+            {hoverDOM}
+        </Tag>
+    );
+});

--- a/querybook/webapp/ui/Tag/HoverIconTag.tsx
+++ b/querybook/webapp/ui/Tag/HoverIconTag.tsx
@@ -4,28 +4,73 @@ import React from 'react';
 import { Icon } from 'ui/Icon/Icon';
 import type { AllLucideIconNames } from 'ui/Icon/LucideIcons';
 
-import { ITagProps, Tag } from './Tag';
+import { ITagProps, Tag, TagGroup } from './Tag';
 
-export interface IHoverIconTagProps extends ITagProps {
+export interface IHoverIconTagProps extends Omit<ITagProps, 'children'> {
+    tagName: string;
+    tagType?: string;
+    tagIcon?: string;
     iconOnHover?: AllLucideIconNames;
     onIconHoverClick?: (e?: React.MouseEvent) => any;
 }
 export const HoverIconTag = React.forwardRef<
     HTMLSpanElement,
     IHoverIconTagProps
->(({ iconOnHover, onIconHoverClick, children, ...tagProps }, ref) => {
-    const hoverDOM = iconOnHover ? (
-        <div className="HoverIconTag-hover" onClick={onIconHoverClick}>
-            <Icon name={iconOnHover} />
-        </div>
-    ) : null;
+>(
+    (
+        {
+            tagName,
+            tagType,
+            tagIcon,
+            iconOnHover,
+            onIconHoverClick,
+            ...tagProps
+        },
+        ref
+    ) => {
+        const hoverDOM = iconOnHover ? (
+            <div className="HoverIconTag-hover" onClick={onIconHoverClick}>
+                <Icon name={iconOnHover} />
+            </div>
+        ) : null;
 
-    const className = clsx(tagProps['className'], 'HoverIconTag');
+        const className = clsx(tagProps['className'], 'HoverIconTag');
 
-    return (
-        <Tag {...tagProps} ref={ref} className={className}>
-            {children}
-            {hoverDOM}
-        </Tag>
-    );
-});
+        const { tooltip, tooltipPos, color, mini, onClick } = tagProps;
+
+        const iconDOM = tagIcon && (
+            <Icon name={tagIcon as any} size={16} className="mr4" />
+        );
+
+        if (tagType) {
+            return (
+                <span
+                    aria-label={tooltip}
+                    data-balloon-pos={tooltipPos}
+                    onClick={onClick}
+                    ref={ref}
+                    className={className}
+                >
+                    <TagGroup>
+                        <Tag mini={mini}>
+                            {iconDOM}
+                            <span>{tagType}</span>
+                        </Tag>
+                        <Tag mini={mini} highlighted color={color}>
+                            {tagName}
+                            {hoverDOM}
+                        </Tag>
+                    </TagGroup>
+                </span>
+            );
+        }
+
+        return (
+            <Tag {...tagProps} ref={ref} className={className}>
+                {iconDOM}
+                <span>{tagName}</span>
+                {hoverDOM}
+            </Tag>
+        );
+    }
+);

--- a/querybook/webapp/ui/Tag/Tag.scss
+++ b/querybook/webapp/ui/Tag/Tag.scss
@@ -10,7 +10,7 @@
     display: inline-flex;
     margin: 2px 0px;
     border-radius: var(--border-radius-sm);
-    cursor: default;
+    cursor: inherit;
 }
 .Tag + .Tag {
     margin-left: 6px;

--- a/querybook/webapp/ui/Tag/Tag.scss
+++ b/querybook/webapp/ui/Tag/Tag.scss
@@ -61,8 +61,6 @@
 }
 
 .TagGroup {
-    overflow: hidden;
-
     .Tag {
         margin: 0;
         border-radius: 0;
@@ -71,6 +69,14 @@
             background-color: var(--color-accent-dark);
             color: var(--color-accent-lightest-0);
         }
+    }
+    .Tag:first-child {
+        border-top-left-radius: var(--border-radius-sm);
+        border-bottom-left-radius: var(--border-radius-sm);
+    }
+    .Tag:last-child {
+        border-top-right-radius: var(--border-radius-sm);
+        border-bottom-right-radius: var(--border-radius-sm);
     }
 
     &.small .Tag {

--- a/querybook/webapp/ui/Tag/Tag.tsx
+++ b/querybook/webapp/ui/Tag/Tag.tsx
@@ -8,8 +8,9 @@ import { TooltipDirection } from 'const/tooltip';
 import './Tag.scss';
 
 export interface ITagGroupProps {
+    tooltip?: string;
+    tooltipPos?: TooltipDirection;
     className?: string;
-    children: React.ReactNode;
 }
 
 export interface ITagProps {
@@ -29,10 +30,15 @@ export interface ITagProps {
     className?: string;
 }
 
-export const TagGroup: React.FunctionComponent<ITagGroupProps> = ({
-    className,
-    children,
-}) => <div className={`${className} TagGroup`}>{children}</div>;
+export const TagGroup = styled.div.attrs<{
+    tooltip?: string;
+    tooltipPos?: TooltipDirection;
+    className?: string;
+}>(({ tooltip, tooltipPos, className }) => ({
+    'aria-label': tooltip,
+    'data-balloon-pos': tooltipPos,
+    className: `${className} TagGroup`,
+}))``;
 
 const StyledColorTag = styled.span.attrs<{
     highlighted?: boolean;

--- a/querybook/webapp/ui/Tag/Tag.tsx
+++ b/querybook/webapp/ui/Tag/Tag.tsx
@@ -21,7 +21,7 @@ export interface ITagProps {
     withBorder?: boolean;
     color?: string;
 
-    tooltip?: React.ReactNode;
+    tooltip?: string;
     tooltipPos?: TooltipDirection;
 
     onClick?: () => any;


### PR DESCRIPTION
Allow loading tags from metastore
 - By default, it will not load tags from metastore. 
 - To enable it
     - Update metastore loader's `loader_config` to have `MetadataType.TAG` not equal to ` MetadataMode.WRITE_LOCAL`. 
     - Update metastore loader's `get_table_and_columns` function to return tags as `table.tags`
 - If enabled loading tags from metastore, tags can't be added or updated through Querybook UI.
 - All the tags synced from metastore will have `tag.admin = True`
 - Added a new meta field `meta.type` to indicate a tag type. If a tag has a type, it will be rendered along with the tag name as a tag group. see below screenshot as an example
 
![image](https://user-images.githubusercontent.com/8308723/218826349-1c44296d-82b5-4204-940f-5ccc14add420.png)
