### PR TITLE
fix: Revert "feat: add estimated time for query execution (#1158)"

### DIFF
--- a/querybook/webapp/components/DataDocStatementExecution/DataDocStatementExecution.scss
+++ b/querybook/webapp/components/DataDocStatementExecution/DataDocStatementExecution.scss
@@ -28,11 +28,9 @@
         .statement-execution-progress-wrapper {
             margin-bottom: 10px;
 
-            .ProgressBar {
-                flex: 1;
-            }
-            .progress-text {
-                flex: 1;
+            progress {
+                width: 40%;
+                display: inline-block;
             }
         }
     }

--- a/querybook/webapp/components/DataDocStatementExecution/DataDocStatementExecution.tsx
+++ b/querybook/webapp/components/DataDocStatementExecution/DataDocStatementExecution.tsx
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -9,7 +8,6 @@ import {
 import { StatementExecutionDefaultResultSize } from 'const/queryResultLimit';
 import { useToggleState } from 'hooks/useToggleState';
 import { sanitizeAndExtraMarkdown } from 'lib/markdown';
-import { formatDuration } from 'lib/utils/datetime';
 import { fetchResult } from 'redux/queryExecutions/action';
 import { IStoreState } from 'redux/store/types';
 import { Icon } from 'ui/Icon/Icon';
@@ -135,51 +133,21 @@ export const DataDocStatementExecution: React.FC<IProps> = ({
                 <span className="statement-status-label">Initializing</span>
             );
         } else if (status === StatementExecutionStatus.RUNNING) {
-            const { created_at: createdAt } = statementExecution;
-            const percentComplete = statementExecution.percent_complete ?? 0;
-
-            const statusLabel = (
-                <span className="statement-status-label">Running</span>
-            );
-
-            const estimatedTimeText = (() => {
-                let progressMessage = `${Math.floor(percentComplete || 0)}%`;
-
-                if (
-                    percentComplete == null ||
-                    percentComplete === 0 ||
-                    percentComplete === 100
-                ) {
-                    return progressMessage;
-                }
-
-                const secondsPassedSinceStart =
-                    new Date().getTime() / 1000 - createdAt;
-                const secondsRemainToComplete =
-                    secondsPassedSinceStart / (percentComplete / 100) -
-                    secondsPassedSinceStart;
-                const durationToComplete = formatDuration(
-                    moment.duration(secondsRemainToComplete, 'seconds')
-                );
-
-                progressMessage += ` (${durationToComplete} Remaining)`;
-
-                return progressMessage;
-            })();
-
-            const progressBar = (
-                <div className="statement-execution-progress-wrapper flex-row">
+            const percentComplete = statementExecution.percent_complete;
+            const statusLabel =
+                status === StatementExecutionStatus.RUNNING ? (
+                    <span className="statement-status-label">Running</span>
+                ) : null;
+            const progressBar = status === StatementExecutionStatus.RUNNING && (
+                <div className="statement-execution-progress-wrapper">
                     <ProgressBar
                         value={percentComplete}
+                        showValue
                         isSmall
                         type="success"
                     />
-                    <AccentText className="progress-text">
-                        {estimatedTimeText}
-                    </AccentText>
                 </div>
             );
-
             contentDOM = (
                 <div className="statement-execution-text-container">
                     <div className="statement-execution-text-title">


### PR DESCRIPTION
This reverts commit 7a256797ffdbe6c2ba60376fd0f864c96fa236c5.

User has reported that the estimate has been inaccurate (for presto) and could be misleading