### PR TITLE
feat: add ability to choose other hourly options

### DIFF
--- a/querybook/webapp/__tests__/lib/utils/cron.test.ts
+++ b/querybook/webapp/__tests__/lib/utils/cron.test.ts
@@ -8,6 +8,7 @@ test('basic recurrence to cron', () => {
 
             recurrence: 'daily',
             on: {},
+            step: {},
         })
     ).toBe('1 1 * * *');
 });
@@ -20,6 +21,7 @@ test('yearly to cron', () => {
 
             recurrence: 'yearly',
             on: { dayMonth: [1, 15], month: [3, 6, 9, 12] },
+            step: {},
         })
     ).toBe('0 0 1,15 3,6,9,12 *');
 });
@@ -32,6 +34,7 @@ test('monthly to cron', () => {
 
             recurrence: 'monthly',
             on: { dayMonth: [1, 5, 6] },
+            step: {},
         })
     ).toBe('5 4 1,5,6 * *');
 });
@@ -44,6 +47,7 @@ test('weekly to cron', () => {
 
             recurrence: 'weekly',
             on: { dayWeek: [1, 5, 6] },
+            step: {},
         })
     ).toBe('5 4 * * 1,5,6');
 });
@@ -56,8 +60,9 @@ test('hourly to cron', () => {
 
             recurrence: 'hourly',
             on: {},
+            step: { hour: 2 },
         })
-    ).toBe('30 * * * *');
+    ).toBe('30 */2 * * *');
 });
 
 test('basic cron to recurrence', () => {
@@ -67,6 +72,7 @@ test('basic cron to recurrence', () => {
 
         recurrence: 'daily',
         on: {},
+        step: {},
     });
 });
 
@@ -77,6 +83,7 @@ test('yearly cron to recurrence', () => {
 
         recurrence: 'yearly',
         on: { dayMonth: [1, 2, 3], month: [3, 6, 9, 12] },
+        step: {},
     });
 });
 
@@ -87,6 +94,7 @@ test('monthly cron to recurrence', () => {
 
         recurrence: 'monthly',
         on: { dayMonth: [1, 2, 3] },
+        step: {},
     });
 });
 
@@ -97,15 +105,17 @@ test('weekly cron to recurrence', () => {
 
         recurrence: 'weekly',
         on: { dayWeek: [1, 2, 3] },
+        step: {},
     });
 });
 
 test('hourly cron to recurrence', () => {
-    expect(cronToRecurrence('1 * * * *')).toStrictEqual({
+    expect(cronToRecurrence('1 */2 * * *')).toStrictEqual({
         hour: 0,
         minute: 1,
 
         recurrence: 'hourly',
         on: {},
+        step: { hour: 2 },
     });
 });

--- a/querybook/webapp/__tests__/ui/RecurrenceEditor.test.js
+++ b/querybook/webapp/__tests__/ui/RecurrenceEditor.test.js
@@ -9,6 +9,7 @@ const recurrence = {
 
     recurrence: 'daily',
     on: [0],
+    step: 1,
 };
 
 it('renders without crashing', () => {

--- a/querybook/webapp/components/DataDocSchedule/DataDocScheduleForm.tsx
+++ b/querybook/webapp/components/DataDocSchedule/DataDocScheduleForm.tsx
@@ -17,6 +17,7 @@ import {
     cronToRecurrence,
     IRecurrence,
     recurrenceOnYup,
+    recurrenceStepYup,
     recurrenceToCron,
     recurrenceTypes,
 } from 'lib/utils/cron';
@@ -63,6 +64,7 @@ const scheduleFormSchema = Yup.object().shape({
         minute: Yup.number().min(0).max(59),
         recurrence: Yup.string().oneOf(recurrenceTypes),
         on: recurrenceOnYup,
+        step: recurrenceStepYup,
     }),
     enabled: Yup.boolean().notRequired(),
     kwargs: Yup.object().shape({

--- a/querybook/webapp/components/Task/TaskEditor.tsx
+++ b/querybook/webapp/components/Task/TaskEditor.tsx
@@ -11,6 +11,7 @@ import { sendConfirm } from 'lib/querybookUI';
 import {
     cronToRecurrence,
     recurrenceOnYup,
+    recurrenceStepYup,
     recurrenceToCron,
     recurrenceTypes,
     validateCronForRecurrrence,
@@ -50,6 +51,7 @@ const taskFormSchema = Yup.object().shape({
                   minute: Yup.number().min(0).max(59),
                   recurrence: Yup.string().oneOf(recurrenceTypes),
                   on: recurrenceOnYup,
+                  step: recurrenceStepYup,
               })
             : schema
     ),

--- a/querybook/webapp/ui/ReccurenceEditor/RecurrenceEditor.tsx
+++ b/querybook/webapp/ui/ReccurenceEditor/RecurrenceEditor.tsx
@@ -42,32 +42,67 @@ export const RecurrenceEditor: React.FunctionComponent<IProps> = ({
     const isHourly = recurrence.recurrence === 'hourly';
 
     const hourSecondField = (
-        <FormField
-            label={isHourly ? 'Minute' : 'Hour/Minute (UTC)'}
-            error={recurrenceError?.hour}
-        >
+        <FormField label={'Hour/Minute (UTC)'} error={recurrenceError?.hour}>
             <div className="flex-row">
+                {recurrence.recurrence === 'hourly'
+                    ? [
+                          <div className="editor-text mr12">{'Every'}</div>,
+                          <TimePicker
+                              allowEmpty={false}
+                              value={moment().hour(recurrence.step.hour)}
+                              showHour={true}
+                              showMinute={false}
+                              showSecond={false}
+                              disabledHours={() => [0]}
+                              hideDisabledOptions
+                              format={'H'}
+                              onChange={(value) => {
+                                  const newRecurrence = {
+                                      ...recurrence,
+                                      step: { hour: value.hour() },
+                                  };
+                                  setRecurrence(newRecurrence);
+                              }}
+                          />,
+                          <div className="editor-text ml12 mr12">
+                              {'hours at minute'}
+                          </div>,
+                      ]
+                    : ''}
+
                 <TimePicker
                     allowEmpty={false}
-                    value={moment()
-                        .hour(recurrence.hour)
-                        .minute(recurrence.minute)}
+                    value={
+                        recurrence.recurrence === 'hourly'
+                            ? moment().minute(recurrence.minute)
+                            : moment()
+                                  .hour(recurrence.hour)
+                                  .minute(recurrence.minute)
+                    }
                     minuteStep={15}
                     showHour={!(recurrence.recurrence === 'hourly')}
                     showSecond={false}
                     format={isHourly ? 'mm' : 'H:mm'}
                     onChange={(value) => {
-                        const newRecurrence = {
-                            ...recurrence,
-                            hour: value.hour(),
-                            minute: value.minute(),
-                        };
-                        setRecurrence(newRecurrence);
+                        if (recurrence.recurrence === 'hourly') {
+                            const newRecurrence = {
+                                ...recurrence,
+                                minute: value.minute(),
+                            };
+                            setRecurrence(newRecurrence);
+                        } else {
+                            const newRecurrence = {
+                                ...recurrence,
+                                hour: value.hour(),
+                                minute: value.minute(),
+                            };
+                            setRecurrence(newRecurrence);
+                        }
                     }}
                 />
                 <div className="editor-text ml12">
                     {recurrence.recurrence === 'hourly'
-                        ? `Every hour at minute ${recurrence.minute} `
+                        ? ``
                         : `Local Time: ${localTime}`}
                 </div>
             </div>
@@ -88,6 +123,9 @@ export const RecurrenceEditor: React.FunctionComponent<IProps> = ({
                             };
                             if (field.value !== key) {
                                 newRecurrence.on = {};
+                            }
+                            if (key === 'hourly' && !newRecurrence.step.hour) {
+                                newRecurrence.step.hour = Number(1);
                             }
                             setRecurrence(newRecurrence);
                         }}


### PR DESCRIPTION
Adds an option to schedule datadocs for more hourly intervals. For example, selecting 2 in the hour dropdown and 45 in the minute dropdown will schedule the datadoc to run every 2 hours on the 45th minute. Also updated tests and validation methods to account for the new recurrence property "step".

<img width="753" alt="Screen Shot 2023-02-20 at 8 21 28 AM" src="https://user-images.githubusercontent.com/72165460/220157842-312086a1-94ad-4d70-a0d9-9f5ef64d5819.png">
<img width="759" alt="Screen Shot 2023-02-20 at 8 21 52 AM" src="https://user-images.githubusercontent.com/72165460/220157867-7955ca6a-2cdb-451f-bb64-c9d8aa7450c1.png">
