### PR TITLE
fix: Enable mssql transpiling

### DIFF
--- a/querybook/server/lib/query_analysis/transpilation/transpilers/sqlglot_transpiler.py
+++ b/querybook/server/lib/query_analysis/transpilation/transpilers/sqlglot_transpiler.py
@@ -17,6 +17,7 @@ QUERYBOOK_TO_SQLGLOT_LANGUAGE_MAPPING = {
     "sqlite": "sqlite",
     "snowflake": "snowflake",
     # different name
+    "mssql": "tsql",
     "postgresql": "postgres",
     "sparksql": "spark",
 }


### PR DESCRIPTION
Supports Microsoft SQL Server transpiling by adding a mapping from Querybook's `mssql` language to [Sqlglot's `TSQL`](https://github.com/tobymao/sqlglot/blob/main/sqlglot/dialects/__init__.py#L78) dialect.