### PR TITLE
feat: update delete cell confirmation popup

### DIFF
--- a/querybook/webapp/components/DataDoc/DataDoc.tsx
+++ b/querybook/webapp/components/DataDoc/DataDoc.tsx
@@ -60,6 +60,7 @@ import { Message } from 'ui/Message/Message';
 
 import { DataDocCellControl } from './DataDocCellControl';
 import { DataDocContentContainer } from './DataDocContentContainer';
+import { DataDocDeletePreview } from './DataDocDeletePreview';
 import { DataDocError } from './DataDocError';
 import { DataDocHeader } from './DataDocHeader';
 import { DataDocLoading } from './DataDocLoading';
@@ -427,9 +428,18 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
                     }
                 };
                 if (shouldConfirm) {
+                    let cellName = '';
+                    if ('title' in cell.meta) {
+                        cellName = cell.meta.title
+                            ? ` "${cell.meta.title}"`
+                            : cellName;
+                    }
                     sendConfirm({
-                        header: 'Delete Cell?',
-                        message: 'Deleted cells cannot be recovered',
+                        header: `Delete ${
+                            cell.cell_type[0].toUpperCase() +
+                            cell.cell_type.slice(1).toLowerCase()
+                        } Cell${cellName}?`,
+                        message: <DataDocDeletePreview cell={cell} />,
                         onConfirm: deleteCell,
                         onHide: resolve,
                         confirmColor: 'cancel',

--- a/querybook/webapp/components/DataDoc/DataDocDeletePreview.tsx
+++ b/querybook/webapp/components/DataDoc/DataDocDeletePreview.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+
+import { IDataCell } from 'const/datadoc';
+import { ThemedCodeHighlightWithMark } from 'ui/CodeHighlight/ThemedCodeHighlightWithMark';
+
+interface IProps {
+    cell: IDataCell;
+}
+
+export const DataDocDeletePreview: React.FunctionComponent<IProps> = ({
+    cell,
+}) => {
+    const [query, setQuery] = useState<string>();
+
+    useEffect(() => {
+        setQuery(cell.context as string);
+    }, [cell.context]);
+
+    return (
+        <div>
+            <span>Deleted cells cannot be recovered</span>
+            {cell.cell_type === 'query' && query !== '' && (
+                <ThemedCodeHighlightWithMark
+                    query={query}
+                    maxEditorHeight="20vh"
+                    autoHeight={false}
+                />
+            )}
+        </div>
+    );
+};


### PR DESCRIPTION
This adds more detail to the delete datadoc cell confirmation page to help users check which cell will be deleted. The confirmation page new details include the type of cell (text/query/chart), the name of the cell if it exists, and a query cell preview for query datadoc cells. This cell preview is uneditable, and shows a scroll bar for longer queries. 

![Screen Shot 2023-02-24 at 11 46 36 AM](https://user-images.githubusercontent.com/72165460/221276787-09d54520-54f0-41de-ae0b-5280cf918409.png)
![Screen Shot 2023-02-24 at 11 46 24 AM](https://user-images.githubusercontent.com/72165460/221276790-de445abe-5a29-4391-91c7-2a8b0a8454ff.png)
![Screen Shot 2023-02-24 at 11 46 47 AM](https://user-images.githubusercontent.com/72165460/221276784-933fdb24-29bb-4840-a405-75a76abb42e5.png)

***Currently the cell preview has a known issue where queries less than 10 lines will overlap with the query line count, depicted in the below screenshot. We were unable to fix this overlap, but otherwise the cell preview works as expected.***

![Screen Shot 2023-02-24 at 11 47 23 AM](https://user-images.githubusercontent.com/72165460/221276777-9dd283e7-3a81-4cb8-8b63-f4676e47b5d4.png)



