### PR TITLE
feat: make struct form fields ordered

### DIFF
--- a/querybook/server/lib/dag_exporter/exporters/demo_dag_exporter.py
+++ b/querybook/server/lib/dag_exporter/exporters/demo_dag_exporter.py
@@ -72,8 +72,8 @@ class DemoDAGExporter(BaseDAGExporter):
     @property
     def dag_exporter_meta(self):
         return StructFormField(
-            name=FormField(description="dag name"),
-            description=FormField(description="dag description"),
+            ("name", FormField(description="dag name")),
+            ("description", FormField(description="dag description")),
         )
 
     @with_session

--- a/querybook/server/lib/export/exporters/gspread_exporter.py
+++ b/querybook/server/lib/export/exporters/gspread_exporter.py
@@ -94,16 +94,25 @@ class GoogleSheetsExporter(BaseExporter):
     @property
     def export_form(self):
         return StructFormField(
-            sheet_url=FormField(
-                description="Optional, if not provided a new sheet will be created."
+            (
+                "sheet_url",
+                FormField(
+                    description="Optional, if not provided a new sheet will be created."
+                ),
             ),
-            worksheet_title=FormField(
-                description='Defaults to "Sheet1"',
-                helper="Title of the worksheet, if not found then a sheet will be created",
+            (
+                "worksheet_title",
+                FormField(
+                    description='Defaults to "Sheet1"',
+                    helper="Title of the worksheet, if not found then a sheet will be created",
+                ),
             ),
-            start_cell=FormField(
-                description="The top left cell position where data will be filled. Defaults to A1",
-                regex="^[A-Z]{1,3}[1-9][0-9]*$",
+            (
+                "start_cell",
+                FormField(
+                    description="The top left cell position where data will be filled. Defaults to A1",
+                    regex="^[A-Z]{1,3}[1-9][0-9]*$",
+                ),
             ),
         )
 

--- a/querybook/server/lib/metastore/loaders/glue_data_catalog_loader.py
+++ b/querybook/server/lib/metastore/loaders/glue_data_catalog_loader.py
@@ -26,13 +26,16 @@ class GlueDataCatalogLoader(BaseMetastoreLoader):
     @classmethod
     def get_metastore_params_template(cls):
         return StructFormField(
-            catalog_id=FormField(
-                required=True,
-                description="Enter the Glue Data Catalog ID",
-                regex=r"^\d{12}$",
+            (
+                "catalog_id",
+                FormField(
+                    required=True,
+                    description="Enter the Glue Data Catalog ID",
+                    regex=r"^\d{12}$",
+                ),
             ),
-            region=FormField(required=True, description="Enter the AWS Region"),
-            load_partitions=load_partitions_field,
+            ("region", FormField(required=True, description="Enter the AWS Region")),
+            ("load_partitions", load_partitions_field),
         )
 
     def get_all_schema_names(self) -> List[str]:

--- a/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
+++ b/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
@@ -27,15 +27,18 @@ class HMSMetastoreLoader(BaseMetastoreLoader):
     @classmethod
     def get_metastore_params_template(cls):
         return StructFormField(
-            hms_connection=ExpandableFormField(
-                of=FormField(
-                    required=True,
-                    description="Put url to hive metastore server here",
-                    field_type=FormFieldType.String,
+            (
+                "hms_connection",
+                ExpandableFormField(
+                    of=FormField(
+                        required=True,
+                        description="Put url to hive metastore server here",
+                        field_type=FormFieldType.String,
+                    ),
+                    min=1,
                 ),
-                min=1,
             ),
-            load_partitions=load_partitions_field,
+            ("load_partitions", load_partitions_field),
         )
 
     def get_all_schema_names(self) -> List[str]:

--- a/querybook/server/lib/metastore/loaders/thrifthive_metastore_loader.py
+++ b/querybook/server/lib/metastore/loaders/thrifthive_metastore_loader.py
@@ -17,31 +17,41 @@ class HMSThriftMetastoreLoader(HMSMetastoreLoader):
     @classmethod
     def get_metastore_params_template(cls):
         return StructFormField(
-            connection_string=FormField(
-                required=True,
-                description="Put your JDBC connection string here",
-                regex="^(?:jdbc:)?hive2:\\/\\/([\\w.-]+(?:\\:\\d+)?(?:,[\\w.-]+(?:\\:\\d+)?)*)\\/(\\w*)((?:;[\\w.-]+=[\\w.-]+)*)(\\?[\\w.-]+=[\\w.-]+(?:;[\\w.-]+=[\\w.-]+)*)?(\\#[\\w.-]+=[\\w.-]+(?:;[\\w.-]+=[\\w.-]+)*)?$",  # noqa: E501
-                helper="""
-        <p>
-        Format
-        jdbc:hive2://&lt;host1&gt;:&lt;port1&gt;,&lt;host2&gt;:&lt;port2&gt;/dbName;sess_var_list?hive_conf_list#hive_var_list
-        </p>
-        <p>Currently support zookeeper in session var, and will pass any conf variables to HS2</p>
-        <p>See
-            <a href="https://cwiki.apache.org/confluence/display/Hive/HiveServer2+Clients#HiveServer2Clients-JDBC">
-                here
-            </a> for more details.
-        </p>""",
-            ),
-            username=FormField(regex="\\w+"),
-            password=FormField(hidden=True),
-            hms_connection=ExpandableFormField(
-                of=FormField(
-                    required=True, description="Put url to hive metastore server here"
+            (
+                "hive_resource_manager",
+                FormField(
+                    description="Provide resource manager link here to provide insights"
                 ),
-                min=1,
             ),
-            load_partitions=load_partitions_field,
+            (
+                "connection_string",
+                FormField(
+                    required=True,
+                    description="Put your JDBC connection string here",
+                    regex="^(?:jdbc:)?hive2:\\/\\/([\\w.-]+(?:\\:\\d+)?(?:,[\\w.-]+(?:\\:\\d+)?)*)\\/(\\w*)((?:;[\\w.-]+=[\\w.-]+)*)(\\?[\\w.-]+=[\\w.-]+(?:;[\\w.-]+=[\\w.-]+)*)?(\\#[\\w.-]+=[\\w.-]+(?:;[\\w.-]+=[\\w.-]+)*)?$",  # noqa: E501
+                    helper="""
+<p>
+Format
+jdbc:hive2://&lt;host1&gt;:&lt;port1&gt;,&lt;host2&gt;:&lt;port2&gt;/dbName;sess_var_list?hive_conf_list#hive_var_list
+</p>
+<p>Currently support zookeeper in session var, and will pass any conf variables to HS2</p>
+<p>See [here](https://cwiki.apache.org/confluence/display/Hive/HiveServer2+Clients#HiveServer2Clients-JDBC) for more details.
+</p>""",
+                ),
+            ),
+            ("username", FormField(regex="\\w+")),
+            ("password", FormField(hidden=True)),
+            (
+                "hms_connection",
+                ExpandableFormField(
+                    of=FormField(
+                        required=True,
+                        description="Put url to hive metastore server here",
+                    ),
+                    min=1,
+                ),
+            ),
+            ("load_partitions", load_partitions_field),
         )
 
     def get_table_and_columns(

--- a/querybook/server/lib/query_executor/executor_template/templates.py
+++ b/querybook/server/lib/query_executor/executor_template/templates.py
@@ -1,14 +1,17 @@
 from lib.form import FormField, StructFormField, FormFieldType, ExpandableFormField
 
 hive_executor_template = StructFormField(
-    hive_resource_manager=FormField(
-        description="Provide resource manager link here to provide insights"
+    (
+        "hive_resource_manager",
+        FormField(description="Provide resource manager link here to provide insights"),
     ),
-    connection_string=FormField(
-        required=True,
-        description="Put your JDBC connection string here",
-        regex="^(?:jdbc:)?hive2:\\/\\/([\\w.-]+(?:\\:\\d+)?(?:,[\\w.-]+(?:\\:\\d+)?)*)\\/(\\w*)((?:;[\\w.-]+=[\\w.-]+)*)(\\?[\\w.-]+=[\\w.-]+(?:;[\\w.-]+=[\\w.-]+)*)?(\\#[\\w.-]+=[\\w.-]+(?:;[\\w.-]+=[\\w.-]+)*)?$",  # noqa: E501
-        helper="""
+    (
+        "connection_string",
+        FormField(
+            required=True,
+            description="Put your JDBC connection string here",
+            regex="^(?:jdbc:)?hive2:\\/\\/([\\w.-]+(?:\\:\\d+)?(?:,[\\w.-]+(?:\\:\\d+)?)*)\\/(\\w*)((?:;[\\w.-]+=[\\w.-]+)*)(\\?[\\w.-]+=[\\w.-]+(?:;[\\w.-]+=[\\w.-]+)*)?(\\#[\\w.-]+=[\\w.-]+(?:;[\\w.-]+=[\\w.-]+)*)?$",  # noqa: E501
+            helper="""
 <p>
 Format
 jdbc:hive2://&lt;host1&gt;:&lt;port1&gt;,&lt;host2&gt;:&lt;port2&gt;/dbName;sess_var_list?hive_conf_list#hive_var_list
@@ -16,75 +19,100 @@ jdbc:hive2://&lt;host1&gt;:&lt;port1&gt;,&lt;host2&gt;:&lt;port2&gt;/dbName;sess
 <p>Currently support zookeeper in session var, and will pass any conf variables to HS2</p>
 <p>See [here](https://cwiki.apache.org/confluence/display/Hive/HiveServer2+Clients#HiveServer2Clients-JDBC) for more details.
 </p>""",
+        ),
     ),
-    username=FormField(regex="\\w+"),
-    password=FormField(hidden=True),
-    impersonate=FormField(field_type=FormFieldType.Boolean),
+    ("username", FormField(regex="\\w+")),
+    ("password", FormField(hidden=True)),
+    ("impersonate", FormField(field_type=FormFieldType.Boolean)),
 )
 
 presto_executor_template = StructFormField(
-    connection_string=FormField(
-        required=True,
-        regex="^(?:jdbc:)?presto:\\/\\/([\\w.-]+(?:\\:\\d+)?(?:,[\\w.-]+(?:\\:\\d+)?)*)(\\/\\w+)?(\\/\\w+)?(\\?[\\w]+=[^&]+(?:&[\\w]+=[^&]+)*)?$",  # noqa: E501
-        helper="""
+    (
+        "connection_string",
+        FormField(
+            required=True,
+            regex="^(?:jdbc:)?presto:\\/\\/([\\w.-]+(?:\\:\\d+)?(?:,[\\w.-]+(?:\\:\\d+)?)*)(\\/\\w+)?(\\/\\w+)?(\\?[\\w]+=[^&]+(?:&[\\w]+=[^&]+)*)?$",  # noqa: E501
+            helper="""
 <p>Format jdbc:presto://&lt;host:port&gt;/&lt;catalog&gt;/&lt;schema&gt;?presto_conf_list</p>
 <p>Catalog and schema are optional. We only support SSL as the conf option.</p>
 <p>See [here](https://prestodb.github.io/docs/current/installation/jdbc.html) for more details.</p>""",
+        ),
     ),
-    username=FormField(regex="\\w+"),
-    password=FormField(hidden=True),
-    impersonate=FormField(field_type=FormFieldType.Boolean),
-    proxy_user_id=FormField(
-        field_type=FormFieldType.String,
-        helper="""
+    ("username", FormField(regex="\\w+")),
+    ("password", FormField(hidden=True)),
+    ("impersonate", FormField(field_type=FormFieldType.Boolean)),
+    (
+        "proxy_user_id",
+        FormField(
+            field_type=FormFieldType.String,
+            helper="""
 <p>User field used as proxy_user. proxy_user will be forwaded to Presto as the session user.</p>
 <p>Defaults to username. Possible values are username, email, fullname </p>
 <p>See [here](https://prestodb.github.io/docs/current/installation/jdbc.html) for more details.</p>""",
+        ),
     ),
 )
 
 trino_executor_template = StructFormField(
-    connection_string=FormField(
-        required=True,
-        regex="^(?:jdbc:)?trino:\\/\\/([\\w.-]+(?:\\:\\d+)?(?:,[\\w.-]+(?:\\:\\d+)?)*)(\\/\\w+)?(\\/\\w+)?(\\?[\\w]+=[^&]+(?:&[\\w]+=[^&]+)*)?$",  # noqa: E501
-        helper="""
+    (
+        "connection_string",
+        FormField(
+            required=True,
+            regex="^(?:jdbc:)?trino:\\/\\/([\\w.-]+(?:\\:\\d+)?(?:,[\\w.-]+(?:\\:\\d+)?)*)(\\/\\w+)?(\\/\\w+)?(\\?[\\w]+=[^&]+(?:&[\\w]+=[^&]+)*)?$",  # noqa: E501
+            helper="""
 <p>Format jdbc:trino://&lt;host:port&gt;/&lt;catalog&gt;/&lt;schema&gt;?trino_conf_list</p>
 <p>Catalog and schema are optional. We only support SSL as the conf option.</p>
 <p>See [here](https://trino.io/docs/current/installation/jdbc.html) for more details.</p>""",
+        ),
     ),
-    username=FormField(required=True, regex="\\w+"),
-    impersonate=FormField(field_type=FormFieldType.Boolean),
-    proxy_user_id=FormField(
-        field_type=FormFieldType.String,
-        helper="""
+    ("username", FormField(regex="\\w+")),
+    ("impersonate", FormField(field_type=FormFieldType.Boolean)),
+    (
+        "proxy_user_id",
+        FormField(
+            field_type=FormFieldType.String,
+            helper="""
 <p>User field used as proxy_user. proxy_user will be forwaded to Trino as the session user.</p>
 <p>Defaults to username. Possible values are username, email, fullname </p>
 <p>See [here](https://trino.io/docs/current/installation/jdbc.html) for more details.</p>""",
+        ),
     ),
 )
 
 sqlalchemy_template = StructFormField(
-    connection_string=FormField(
-        required=True,
-        helper="""
+    (
+        "connection_string",
+        FormField(
+            required=True,
+            helper="""
 <p>
     See [here](https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls) for more details.
 </p>""",
+        ),
     ),
-    connect_args=ExpandableFormField(
-        of=StructFormField(
-            key=FormField(required=True),
-            value=FormField(required=True),
-            isJson=FormField(
-                field_type=FormFieldType.Boolean,
-                helper="If true, then the value will be parsed as JSON",
-            ),
-        )
+    (
+        "connect_args",
+        ExpandableFormField(
+            of=StructFormField(
+                ("key", FormField(required=True)),
+                ("value", FormField(required=True)),
+                (
+                    "isJson",
+                    FormField(
+                        field_type=FormFieldType.Boolean,
+                        helper="If true, then the value will be parsed as JSON",
+                    ),
+                ),
+            )
+        ),
     ),
 )
 
 bigquery_template = StructFormField(
-    google_credentials_json=FormField(
-        helper="The JSON string used to log in as service account. If not provided then **GOOGLE_CREDS** from settings will be used.",
+    (
+        "google_credentials_json",
+        FormField(
+            helper="The JSON string used to log in as service account. If not provided then **GOOGLE_CREDS** from settings will be used.",
+        ),
     )
 )

--- a/querybook/tests/test_lib/test_form/test__init__.py
+++ b/querybook/tests/test_lib/test_form/test__init__.py
@@ -85,8 +85,8 @@ class ValidateFormTestCase(TestCase):
 
     def test_dict_field(self):
         form = StructFormField(
-            name=FormField(),
-            phone_numbers=ExpandableFormField(of=FormField(), min=1, max=2),
+            ("name", FormField()),
+            ("phone_numbers", ExpandableFormField(of=FormField(), min=1, max=2)),
         )
         self.assertEqual(
             validate_form(form, "123"),

--- a/querybook/webapp/ui/SmartForm/SmartForm.tsx
+++ b/querybook/webapp/ui/SmartForm/SmartForm.tsx
@@ -125,7 +125,7 @@ function ExpandableFormField<T extends []>({
         if (value == null) {
             onChange('', [] as any);
         }
-    }, [value]);
+    }, [value, onChange]);
 
     if (!Array.isArray(value)) {
         return <div className="ExpandableFormField">Invalid Field</div>;
@@ -174,17 +174,15 @@ function StructFormField<T extends Record<string, unknown>>({
     value: T;
     onChange: onChangeFunc<T>;
 }) {
-    const fieldsDOM = Object.entries(formField.fields).map(
-        ([key, subField]) => (
-            <FormField key={key} stacked label={titleize(key)}>
-                <SmartForm
-                    formField={subField}
-                    value={value[key]}
-                    onChange={prependOnChangePath(key, onChange)}
-                />
-            </FormField>
-        )
-    );
+    const fieldsDOM = formField.fields.map(([key, subField]) => (
+        <FormField key={key} stacked label={titleize(key)}>
+            <SmartForm
+                formField={subField}
+                value={value[key]}
+                onChange={prependOnChangePath(key, onChange)}
+            />
+        </FormField>
+    ));
 
     return <>{fieldsDOM}</>;
 }

--- a/querybook/webapp/ui/SmartForm/formFunctions.ts
+++ b/querybook/webapp/ui/SmartForm/formFunctions.ts
@@ -70,9 +70,7 @@ export function validateForm(value: any, form: AllFormField): ValidationResp {
             return [false, 'Invalid value for struct', ''];
         }
 
-        for (const [key, subfield] of Object.entries(
-            (form as IStructFormField).fields
-        )) {
+        for (const [key, subfield] of (form as IStructFormField).fields) {
             const resp = validateForm(value[key], subfield);
             if (!resp[0]) {
                 return [
@@ -113,7 +111,7 @@ export function getDefaultFormValue(
     if (fieldType === 'list') {
         return [];
     } else if (fieldType === 'struct') {
-        return Object.entries((form as IStructFormField).fields).reduce(
+        return (form as IStructFormField).fields.reduce(
             (hash, [key, field]) => {
                 hash[key] = getDefaultFormValue(field);
                 return hash;

--- a/querybook/webapp/ui/SmartForm/types.ts
+++ b/querybook/webapp/ui/SmartForm/types.ts
@@ -26,7 +26,7 @@ interface IExpandableFormField extends IBaseFormField {
 
 interface IStructFormField extends IBaseFormField {
     field_type: 'struct';
-    fields: Record<string, AllFormField>;
+    fields: Array<[name: string, field: AllFormField]>;
 }
 
 type AllFormField = IFormField | IExpandableFormField | IStructFormField;


### PR DESCRIPTION
Previously StructFormField was created by a dictionary of values (kwargs), but when we send the form fields to the frontend they would be come unordered. This change would now use `args` which is ordered. The change is backward compatible since StructFormField would still accept kwargs and then convert them into array