### PR TITLE
feat: add button to sort columns in view table UI

### DIFF
--- a/querybook/webapp/components/DataTableViewColumn/DataTableViewColumn.scss
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableViewColumn.scss
@@ -1,0 +1,15 @@
+.DataTableViewColumn {
+    .DataTableViewSearchBar {
+        display: flex;
+        background-color: var(--bg-light);
+        border-radius: var(--border-radius-sm);
+
+        > .SearchBar {
+            flex: 1
+        }
+
+        > .OrderByButton {
+            margin-right: 8px;
+        }
+    }
+}

--- a/querybook/webapp/components/DataTableViewColumn/DataTableViewColumn.tsx
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableViewColumn.tsx
@@ -5,8 +5,10 @@ import { IDataColumn, IDataTable } from 'const/metastore';
 import { Nullable } from 'lib/typescript';
 import { Loading } from 'ui/Loading/Loading';
 import { SearchBar } from 'ui/SearchBar/SearchBar';
+import { OrderByButton } from 'ui/OrderByButton/OrderByButton';
 
 import { DataTableColumnCard } from './DataTableColumnCard';
+import './DataTableViewColumn.scss';
 
 export interface IDataTableViewColumnProps {
     table: IDataTable;
@@ -29,6 +31,8 @@ export const DataTableViewColumn: React.FunctionComponent<
     onEditColumnDescriptionRedirect,
 }) => {
     const [filterString, setFilterString] = React.useState('');
+    const [orderBoardByAsc, setOrderBoardByAsc] = React.useState(true);
+    const [orderBoardBy, setOrderBoardBy] = React.useState(false);
 
     const filteredColumns = React.useMemo(() => {
         const filteredCols = tableColumns.filter((column) =>
@@ -39,23 +43,54 @@ export const DataTableViewColumn: React.FunctionComponent<
         if (numberOfRows != null) {
             filteredCols.splice(numberOfRows);
         }
+        if (orderBoardBy) {
+            if (orderBoardByAsc) {
+                filteredCols.sort((a, b) =>
+                    a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1
+                );
+            } else {
+                filteredCols.sort((a, b) =>
+                    a.name.toLowerCase() < b.name.toLowerCase() ? 1 : -1
+                );
+            }
+        }
         return filteredCols;
-    }, [tableColumns, filterString, numberOfRows]);
+    }, [
+        tableColumns,
+        filterString,
+        numberOfRows,
+        orderBoardByAsc,
+        orderBoardBy,
+    ]);
 
     if (!table || !tableColumns) {
         return <Loading />;
     }
 
-    const filterDOM = (
-        <SearchBar
-            value={filterString}
-            onSearch={(s) => setFilterString(s)}
-            isSearching={false}
-            placeholder={`Find Columns`}
-            hasIcon
-            autoFocus
-            className="mb8"
+    const sortButton = (
+        <OrderByButton
+            asc={orderBoardByAsc}
+            hideAscToggle={!orderBoardBy}
+            onAscToggle={() => setOrderBoardByAsc((v) => !v)}
+            orderByField="name"
+            orderByFieldSymbol={orderBoardBy ? 'Aa' : 'Default'}
+            onOrderByFieldToggle={() => setOrderBoardBy((v) => !v)}
         />
+    );
+
+    const filterDOM = (
+        <div className="DataTableViewSearchBar">
+            <SearchBar
+                value={filterString}
+                onSearch={(s) => setFilterString(s)}
+                isSearching={false}
+                placeholder={`Find Columns`}
+                hasIcon
+                autoFocus
+                transparent
+            />
+            {sortButton}
+        </div>
     );
 
     const columnDOM = filteredColumns.map((col) => (

--- a/querybook/webapp/ui/OrderByButton/OrderByButton.tsx
+++ b/querybook/webapp/ui/OrderByButton/OrderByButton.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from 'react';
 
 import NOOP from 'lib/utils/noop';
 import { TextToggleButton } from 'ui/Button/TextToggleButton';
+import { TooltipDirection } from 'const/tooltip';
 
 import './OrderByButton.scss';
 
@@ -23,6 +24,7 @@ export interface ISortButtonProps {
     orderByFieldSymbol?: string;
     className?: string;
     hideAscToggle?: boolean;
+    toolTipPos?: TooltipDirection;
 
     onOrderByFieldToggle?: () => void;
     onAscToggle?: () => void;
@@ -34,6 +36,7 @@ export const OrderByButton: React.FC<ISortButtonProps> = ({
     orderByFieldSymbol,
     className,
     hideAscToggle,
+    toolTipPos = 'left',
 
     onOrderByFieldToggle = NOOP,
     onAscToggle = NOOP,
@@ -50,7 +53,7 @@ export const OrderByButton: React.FC<ISortButtonProps> = ({
                     value={false}
                     onChange={onAscToggle}
                     tooltip={asc ? 'Ascending' : 'Descending'}
-                    tooltipPos="left"
+                    tooltipPos={toolTipPos}
                     text={asc ? '↑' : '↓'}
                 />
             )}
@@ -58,7 +61,7 @@ export const OrderByButton: React.FC<ISortButtonProps> = ({
                 value={false}
                 onChange={onOrderByFieldToggle}
                 tooltip={`Order by ${orderByField}`}
-                tooltipPos="left"
+                tooltipPos={toolTipPos}
                 text={buttonSymbol}
             />
         </span>


### PR DESCRIPTION
This adds a button to the View Table UI to allow users to switch between sorting column field names in ascending/descending alphabetical order, and to revert to the Default(as ordered in the database) order. 

![Screen Shot 2023-02-24 at 11 56 28 AM](https://user-images.githubusercontent.com/72165460/222288878-5d66077d-9c3f-4db4-b17f-d1c851dcadb8.png)
![Screen Shot 2023-02-24 at 11 56 37 AM](https://user-images.githubusercontent.com/72165460/222288884-fb8a92ff-ec65-4991-99a1-a8a8f3a0d6ae.png)
![Screen Shot 2023-02-24 at 11 56 45 AM](https://user-images.githubusercontent.com/72165460/222288886-f105f68d-1742-4774-9fc5-804a90e7dabd.png)
