### PR TITLE
fix: reset last_run_at on reenabled schedule

### DIFF
--- a/querybook/server/datasources/datadoc.py
+++ b/querybook/server/datasources/datadoc.py
@@ -9,6 +9,7 @@ from app.auth.permission import (
 from app.datasource import register, api_assert, with_impression
 from app.flask_app import socketio, celery
 from app.db import DBSession, with_session
+from datetime import datetime
 from const.impression import ImpressionItemType
 from const.query_execution import QueryExecutionType
 from env import QuerybookSettings
@@ -327,6 +328,8 @@ def update_datadoc_schedule(id, cron=None, enabled=None, kwargs=None):
             updated_fields["cron"] = cron
         if enabled is not None:
             updated_fields["enabled"] = enabled
+            if enabled and not schedule.enabled:
+                updated_fields["last_run_at"] = datetime.now()
         if kwargs is not None:
             updated_fields["kwargs"] = {
                 **kwargs,


### PR DESCRIPTION
When following the below steps, we expect the datadoc to run at the next scheduled time.
    - Create a schedule, let it run.
    - Disable the schedule
    - Wait for at least one iteration of the schedule (e.g. Hourly schedule, wait more than 1 hour).
    - Re-Enable the schedule and save

However, the actual behavior observed is that the datadoc runs immediately upon reenabling the schedule, instead of waiting for the scheduled time. 

This PR sets the `last_run_at` to the default value (current time) when reenabling a schedule so that the scheduler treats it as a new schedule, ensuring that the time it spent being disabled is not factored into calculations for a datadoc's next run time. 