### PR TITLE
External/disable run doc if already running

### DIFF
--- a/querybook/server/lib/scheduled_datadoc/validator.py
+++ b/querybook/server/lib/scheduled_datadoc/validator.py
@@ -13,7 +13,6 @@ class InvalidScheduleException(Exception):
 valid_schedule_config_keys = [
     "exports",
     "notifications",
-    "retry",
     "disable_if_running_doc",
 ]
 valid_export_config_keys = ["exporter_cell_id", "exporter_name", "exporter_params"]

--- a/querybook/server/lib/scheduled_datadoc/validator.py
+++ b/querybook/server/lib/scheduled_datadoc/validator.py
@@ -10,7 +10,12 @@ class InvalidScheduleException(Exception):
     pass
 
 
-valid_schedule_config_keys = ["exports", "notifications"]
+valid_schedule_config_keys = [
+    "exports",
+    "notifications",
+    "retry",
+    "disable_if_running_doc",
+]
 valid_export_config_keys = ["exporter_cell_id", "exporter_name", "exporter_params"]
 valid_notification_keys = ["with", "on", "config"]
 valid_notification_config_keys = ["to", "to_user"]

--- a/querybook/webapp/components/DataDocSchedule/DataDocScheduleForm.tsx
+++ b/querybook/webapp/components/DataDocSchedule/DataDocScheduleForm.tsx
@@ -85,6 +85,7 @@ const scheduleFormSchema = Yup.object().shape({
                 exporter_params: Yup.object(),
             })
         ),
+        disable_if_running_doc: Yup.boolean().required(),
     }),
 });
 
@@ -109,6 +110,7 @@ interface IScheduleFormValues {
     kwargs: {
         notifications: IDataDocScheduleNotification[];
         exports: IDataDocScheduleKwargs['exports'];
+        disable_if_running_doc?: boolean;
     };
 }
 
@@ -143,6 +145,7 @@ export const DataDocScheduleForm: React.FunctionComponent<
               kwargs: {
                   exports: [],
                   notifications: [],
+                  disable_if_running_doc: true,
               },
           }
         : {
@@ -166,6 +169,7 @@ export const DataDocScheduleForm: React.FunctionComponent<
                           ],
                       },
                   })),
+                  disable_if_running_doc: kwargs.disable_if_running_doc,
               },
           };
 
@@ -215,6 +219,14 @@ export const DataDocScheduleForm: React.FunctionComponent<
                 isValid,
                 dirty,
             }) => {
+                const disableIfRunningDocField = (
+                    <SimpleField
+                        label="Prevent Overlapping Runs"
+                        name="kwargs.disable_if_running_doc"
+                        type="toggle"
+                    />
+                );
+
                 const enabledField = !isCreateForm && (
                     <SimpleField label="Enabled" name="enabled" type="toggle" />
                 );
@@ -280,6 +292,7 @@ export const DataDocScheduleForm: React.FunctionComponent<
                                             setFieldValue('recurrence', val)
                                         }
                                     />
+                                    {disableIfRunningDocField}
                                     {enabledField}
                                     {notificationField}
                                     {exportField}

--- a/querybook/webapp/const/schedule.ts
+++ b/querybook/webapp/const/schedule.ts
@@ -83,6 +83,7 @@ export interface IDataDocScheduleKwargs {
         exporter_name?: string;
         exporter_params?: Record<string, any>;
     }>;
+    disable_if_running_doc?: boolean;
 }
 
 export interface IDataDocTaskSchedule extends ITaskSchedule {


### PR DESCRIPTION
Adds a toggle to the scheduler to allow users to choose whether a scheduled datadoc should run again if the datadoc is already running. This could prevent overlapping runs that would potentially lead to failures or errant population of data. This change references only the most recent run status for the datadoc to determine if the datadoc is still running. 

<img width="642" alt="Screen Shot 2023-03-02 at 11 17 39 AM" src="https://user-images.githubusercontent.com/72165460/222853023-4ee73323-9a0e-4784-bf40-6b4a709f0e54.png">
