### PR TITLE
fix: add tooltip length

### DIFF
--- a/querybook/webapp/components/DataTableView/DataTableHeader.tsx
+++ b/querybook/webapp/components/DataTableView/DataTableHeader.tsx
@@ -151,6 +151,7 @@ export const DataTableHeader: React.FunctionComponent<IDataTableHeader> = ({
                         weight="bold"
                         color="lightest"
                         tooltip={ownerType.description}
+                        tooltipPos="right"
                     >
                         {ownerType.display_name}
                     </AccentText>

--- a/querybook/webapp/const/tooltip.ts
+++ b/querybook/webapp/const/tooltip.ts
@@ -1,1 +1,9 @@
 export type TooltipDirection = 'up' | 'down' | 'left' | 'right';
+// By default, tooltips will be single-line no matter their length.
+export type TooltipLength =
+    | 'small'
+    | 'medium'
+    | 'medium'
+    | 'xlarge'
+    | 'fit'
+    | undefined;

--- a/querybook/webapp/ui/Tag/Tag.tsx
+++ b/querybook/webapp/ui/Tag/Tag.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { ColorPalette } from 'const/chartColors';
-import { TooltipDirection } from 'const/tooltip';
+import { TooltipDirection, TooltipLength } from 'const/tooltip';
 
 import './Tag.scss';
 
@@ -33,10 +33,12 @@ export interface ITagProps {
 export const TagGroup = styled.div.attrs<{
     tooltip?: string;
     tooltipPos?: TooltipDirection;
+    tooltipLength?: TooltipLength;
     className?: string;
-}>(({ tooltip, tooltipPos, className }) => ({
+}>(({ tooltip, tooltipPos, tooltipLength = 'large', className }) => ({
     'aria-label': tooltip,
     'data-balloon-pos': tooltipPos,
+    'data-balloon-length': tooltipLength,
     className: `${className} TagGroup`,
 }))``;
 


### PR DESCRIPTION
**Issue**
For long tag tooltips, it is always in single line and will be cut by the table view modal. 

**Fix**
Querybook is using [Balloon.css](https://kazzkiq.github.io/balloon.css/) for tooltips, it acutally supports the length property `data-balloon-length` which can help with this issue.

before:
![Snip20230308_8](https://user-images.githubusercontent.com/8308723/223885036-69b10d96-5a7d-47b8-87ef-c273b3142902.png)
after:
![image](https://user-images.githubusercontent.com/8308723/223884967-312a0b0d-6a4e-4da0-b9db-ac5363d0e8f4.png)
