### PR TITLE
feat: create data element along with syncing table

### DIFF
--- a/querybook/server/const/data_element.py
+++ b/querybook/server/const/data_element.py
@@ -51,11 +51,11 @@ class DataElementTuple(NamedTuple):
 class DataElementAssociationTuple(NamedTuple):
     # association type
     type: DataElementAssociationType
-    # data element name. required for all association types
-    value: str
+    # data element tuple or name. required for all association types
+    value_data_element: Union[DataElementTuple, str]
     # for map association, value can either be a data element or a primitive type, e.g. i32
     value_primitive_type: str = None
-    # data element name. required if associtaion type is map
-    key: str = None
+    # data element tuple or name. required if associtaion type is map
+    key_data_element: Union[DataElementTuple, str] = None
     # for map association, key can either be a data element or a primitive type, e.g. i32
     key_primitive_type: str = None

--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional, Tuple
 
 import gevent
 from app.db import DBSession, with_session
+from const.data_element import DataElementTuple, DataElementAssociationTuple
 from const.metastore import (
     DataColumn,
     DataOwnerType,
@@ -16,6 +17,7 @@ from lib.form import AllFormField
 from lib.logger import get_logger
 from lib.utils import json
 from lib.utils.utils import with_exception
+from logic.data_element import create_column_data_element_association
 from logic.elasticsearch import delete_es_table_by_id, update_table_by_id
 from logic.metastore import (
     create_column,
@@ -33,7 +35,6 @@ from logic.metastore import (
     iterate_data_schema,
 )
 from logic.tag import create_column_tags, create_table_tags
-from logic.data_element import create_column_data_element_association
 
 from .utils import MetastoreTableACLChecker
 
@@ -405,9 +406,15 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
                 if self.loader_config.can_load_external_metadata(
                     MetadataType.DATA_ELEMENT
                 ):
+                    data_element_association = (
+                        self._populate_column_data_element_association(
+                            column.data_element
+                        )
+                    )
                     create_column_data_element_association(
+                        metastore_id=self.metastore_id,
                         column_id=column_id,
-                        data_element_association=column.data_element,
+                        data_element_association=data_element_association,
                         commit=False,
                         session=session,
                     )
@@ -435,6 +442,26 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
         except Exception:
             session.rollback()
             LOG.error(traceback.format_exc())
+
+    def _populate_column_data_element_association(
+        self, data_element_association: DataElementAssociationTuple
+    ) -> DataElementAssociationTuple:
+        """If the value_data_element or key_data_element is a name instead of DataElementTuple,
+        this function will help to replace the name with the actual DataElementTuple"""
+        if data_element_association is None:
+            return None
+
+        value_data_element = data_element_association.value_data_element
+        if type(value_data_element) is str:
+            value_data_element = self.get_data_element(value_data_element)
+
+        key_data_element = data_element_association.key_data_element
+        if type(key_data_element) is str:
+            key_data_element = self.get_data_element(key_data_element)
+
+        return data_element_association._replace(
+            value_data_element=value_data_element, key_data_element=key_data_element
+        )
 
     @with_exception
     def _get_all_filtered_schema_names(self) -> List[str]:
@@ -506,6 +533,10 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
             Tuple[DataTable, List[DataColumn]] -- Return [null, null] if not found
         """
         pass
+
+    def get_data_element(self, data_element_name: str) -> DataElementTuple:
+        """Override this to get data element by name"""
+        return None
 
     @abstractclassmethod
     def get_metastore_params_template(self) -> AllFormField:


### PR DESCRIPTION
When syncing a table, we'll create or update the data element if we find any data elements associated with any columns.