### PR TITLE
fix: mismatched scheduled run times

### DIFF
--- a/querybook/webapp/components/DataDocScheduleList/DataDocScheduleItem.tsx
+++ b/querybook/webapp/components/DataDocScheduleList/DataDocScheduleItem.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { TaskStatusIcon } from 'components/Task/TaskStatusIcon';
 import { formatDuration, generateFormattedDate } from 'lib/utils/datetime';
 import { getWithinEnvUrl } from 'lib/utils/query-string';
+import { cronToRecurrence } from 'lib/utils/cron';
 import { IScheduledDoc } from 'redux/scheduledDataDoc/types';
 import { Link } from 'ui/Link/Link';
 import { AccentText, StyledText, UntitledText } from 'ui/StyledText/StyledText';
@@ -13,7 +14,7 @@ import {
     DataDocScheduleActionHistory,
 } from './DataDocScheduleActionButtons';
 import { HumanReadableCronSchedule } from './HumanReadableCronSchedule';
-import { NextRun } from './NextRun';
+import { NextRun } from 'components/NextRun/NextRun';
 
 import './DataDocScheduleItem.scss';
 
@@ -35,7 +36,10 @@ export const DataDocScheduleItem: React.FC<IDataDocScheduleItemProps> = ({
             <div className="DataDocScheduleItem-bottom  horizontal-space-between">
                 <div>
                     <StyledText size="text">
-                        Runs <HumanReadableCronSchedule cron={schedule.cron} />
+                        Runs <HumanReadableCronSchedule cron={schedule.cron} />{' '}
+                        {cronToRecurrence(schedule.cron).recurrence == 'hourly'
+                            ? ''
+                            : ' (UTC time)'}
                     </StyledText>
                     <StyledText color="light" className="mt4">
                         Next Run:{' '}
@@ -43,7 +47,8 @@ export const DataDocScheduleItem: React.FC<IDataDocScheduleItemProps> = ({
                             <NextRun cron={schedule.cron} />
                         ) : (
                             'Disabled'
-                        )}
+                        )}{' '}
+                        (Local time)
                     </StyledText>
                 </div>
                 {lastRecord && (

--- a/querybook/webapp/components/DataDocScheduleList/cronHelper.tsx
+++ b/querybook/webapp/components/DataDocScheduleList/cronHelper.tsx
@@ -1,5 +1,5 @@
 import {
-    getRecurrenceLocalTimeString,
+    getRecurrenceUtcTimeString,
     IRecurrence,
     MONTHS,
     WEEKDAYS,
@@ -25,38 +25,38 @@ const hourly = ({ minute }: IRecurrence) =>
     `at ${minute} minutes past the hour, every hour, daily`;
 
 const daily = (cronRecurrence: IRecurrence) => {
-    const localTime = getRecurrenceLocalTimeString(cronRecurrence, 'hh:mm a');
-    return `at ${localTime}, daily`;
+    const utcTime = getRecurrenceUtcTimeString(cronRecurrence, 'hh:mm a');
+    return `at ${utcTime}, daily`;
 };
 
 const weekly = (cronRecurrence: IRecurrence) => {
-    const localTime = getRecurrenceLocalTimeString(cronRecurrence, 'hh:mm a');
+    const utcTime = getRecurrenceUtcTimeString(cronRecurrence, 'hh:mm a');
     const daysOfWeek = formatItemsSentence(
         cronRecurrence.on.dayWeek.map((day) => WEEKDAYS[day])
     );
 
-    return `at ${localTime}, only on ${daysOfWeek}, weekly`;
+    return `at ${utcTime}, only on ${daysOfWeek}, weekly`;
 };
 
 const monthly = (cronRecurrence: IRecurrence) => {
-    const localTime = getRecurrenceLocalTimeString(cronRecurrence, 'hh:mm a');
+    const utcTime = getRecurrenceUtcTimeString(cronRecurrence, 'hh:mm a');
     const daysOfMonth = formatItemsSentence(
         cronRecurrence.on.dayMonth.map(String)
     );
 
-    return `at ${localTime}, on day ${daysOfMonth} of the month`;
+    return `at ${utcTime}, on day ${daysOfMonth} of the month`;
 };
 
 const yearly = (cronRecurrence: IRecurrence) => {
-    const localTime = getRecurrenceLocalTimeString(cronRecurrence, 'hh:mm a');
+    const utcTime = getRecurrenceUtcTimeString(cronRecurrence, 'hh:mm a');
     const daysOfMonth = formatItemsSentence(
         cronRecurrence.on.dayMonth.map(String)
     );
-
     const months = formatItemsSentence(
         cronRecurrence.on.month.map((m) => MONTHS[m - 1])
     );
-    return `at ${localTime}, on day ${daysOfMonth} of the month, only in ${months}`;
+
+    return `at ${utcTime}, on day ${daysOfMonth} of the month, only in ${months}`;
 };
 
 export const cronFormatter = (recurrence: IRecurrence) => {

--- a/querybook/webapp/components/NextRun/NextRun.tsx
+++ b/querybook/webapp/components/NextRun/NextRun.tsx
@@ -11,7 +11,7 @@ export const NextRun: React.FunctionComponent<{ cron?: string }> = ({
         if (!cron) {
             return null;
         }
-        const nextDate = parseExpression(cron).next().toDate();
+        const nextDate = parseExpression(cron, { utc: true }).next().toDate();
         return generateFormattedDate(moment(nextDate).unix());
     }, [cron]);
 

--- a/querybook/webapp/lib/utils/cron.ts
+++ b/querybook/webapp/lib/utils/cron.ts
@@ -136,6 +136,17 @@ export function getRecurrenceLocalTimeString(
         .format(format);
 }
 
+export function getRecurrenceUtcTimeString(
+    recurrence: IRecurrence,
+    format = 'HH:mm'
+): string {
+    return moment
+        .utc()
+        .hour(recurrence.hour)
+        .minute(recurrence.minute)
+        .format(format);
+}
+
 export function validateCronForRecurrrence(cron: string) {
     if (cron.includes('/')) {
         return false;


### PR DESCRIPTION
- Fixes an issue in [NextRun.tsx](https://github.com/lilyli9/querybook/blob/a97b1564dcc6972d03f07eddf0a5d34959f952d6/querybook/webapp/components/NextRun/NextRun.tsx#L14) to specify that the given cron is based on UTC time and not Local time, and to calculate the next run time accordingly. 

- Also changes "Runs At" to display UTC time instead of Local time to match scheduler, since the selected hour/minute and resultant cron are based on UTC time. Labels to indicate Local/UTC time are also added to the "Runs At" and "Next Run" text for clarification.
<img width="521" alt="Screen Shot 2023-03-08 at 4 11 01 PM" src="https://user-images.githubusercontent.com/72165460/223881665-17ef8b1a-df88-4876-a154-59aa52c80140.png">

- Added an informational message to the recurrence scheduler page and "Next Run" so that users can check the next run time while they are creating/editing a schedule.
<img width="1200" alt="Screen Shot 2023-03-08 at 4 10 21 PM" src="https://user-images.githubusercontent.com/72165460/223881594-fd56544c-fb83-4ba0-be0d-1dde64efda6b.png">
<img width="1205" alt="Screen Shot 2023-03-08 at 4 10 36 PM" src="https://user-images.githubusercontent.com/72165460/223881622-19d01040-bdbb-4e8a-84af-1fe111dbfbe4.png">

