### PR TITLE
fix: some bug fix related to tag and data element

### DIFF
--- a/querybook/server/datasources/data_element.py
+++ b/querybook/server/datasources/data_element.py
@@ -1,39 +1,6 @@
-from app.auth.permission import verify_data_column_permission
 from app.datasource import register
-from lib.logger import get_logger
 from lib.metastore import get_metastore_loader
 from logic import data_element as logic
-from const.data_element import DataElementAssociationDict
-
-LOG = get_logger(__file__)
-
-
-@register(
-    "/column/<int:column_id>/data_element/",
-    methods=["GET"],
-)
-def get_data_element_by_column_id(column_id: int) -> DataElementAssociationDict:
-    verify_data_column_permission(column_id)
-    associations = logic.get_data_element_associations_by_column_id(column_id=column_id)
-
-    if not associations:
-        return None
-
-    # check if there are more than 1 association type
-    association_types = set([r.type for r in associations])
-    if len(association_types) > 1:
-        LOG.error(
-            f"Column {column_id} has more than one data element associated with it"
-        )
-        return None
-
-    data_element = {}
-    for row in associations:
-        data_element["type"] = row.type.value
-        data_element[row.property_name] = (
-            row.data_element.to_dict() if row.data_element else row.primitive_type
-        )
-    return data_element
 
 
 @register("/data_element/<int:data_element_id>/metastore_link/", methods=["GET"])

--- a/querybook/server/logic/data_element.py
+++ b/querybook/server/logic/data_element.py
@@ -48,7 +48,7 @@ def get_data_element_association_by_column_id(
     for row in associations:
         data_element["type"] = row.type.value
         data_element[row.property_name] = (
-            row.data_element.to_dict() if row.data_element else row.primitive_type
+            row.data_element if row.data_element else row.primitive_type
         )
     return data_element
 

--- a/querybook/server/logic/data_element.py
+++ b/querybook/server/logic/data_element.py
@@ -1,6 +1,7 @@
 from typing import Union
 from app.db import with_session
 from const.data_element import (
+    DataElementAssociationDict,
     DataElementAssociationProperty,
     DataElementAssociationTuple,
     DataElementAssociationType,
@@ -24,12 +25,32 @@ def get_data_element_by_name(name: str, session=None):
 
 
 @with_session
-def get_data_element_associations_by_column_id(column_id: int, session=None) -> dict:
-    return (
+def get_data_element_association_by_column_id(
+    column_id: int, session=None
+) -> DataElementAssociationDict:
+    associations = (
         session.query(DataElementAssociation)
         .filter(DataElementAssociation.column_id == column_id)
         .all()
     )
+    if not associations:
+        return None
+
+    # check if there are more than 1 association type
+    association_types = set([r.type for r in associations])
+    if len(association_types) > 1:
+        LOG.error(
+            f"Column {column_id} has more than one data element associated with it"
+        )
+        return None
+
+    data_element = {}
+    for row in associations:
+        data_element["type"] = row.type.value
+        data_element[row.property_name] = (
+            row.data_element.to_dict() if row.data_element else row.primitive_type
+        )
+    return data_element
 
 
 @with_session
@@ -75,7 +96,11 @@ def create_data_element_association(
     primitive_type: str = None,
     session=None,
 ):
-    if data_element_tuple is None:
+    if (
+        data_element_tuple is None
+        or not data_element_tuple.name
+        or not data_element_tuple.type
+    ):
         return None
 
     if type(data_element_tuple) is str:

--- a/querybook/server/logic/data_element.py
+++ b/querybook/server/logic/data_element.py
@@ -97,7 +97,7 @@ def create_data_element_association(
     session=None,
 ):
     if (
-        data_element_tuple is None
+        not data_element_tuple
         or not data_element_tuple.name
         or not data_element_tuple.type
     ):

--- a/querybook/server/logic/tag.py
+++ b/querybook/server/logic/tag.py
@@ -54,7 +54,7 @@ def create_or_update_tag(tag_name, meta={}, commit=True, session=None):
     else:
         tag = Tag.update(
             id=tag.id,
-            fields={"count": tag.count + 1, "meta": meta},
+            fields={"count": tag.count + 1, "meta": {**tag.meta, **meta}},
             skip_if_value_none=True,
             commit=commit,
             session=session,

--- a/querybook/webapp/components/DataTableStats/DataTableColumnStats.tsx
+++ b/querybook/webapp/components/DataTableStats/DataTableColumnStats.tsx
@@ -1,27 +1,19 @@
 import * as React from 'react';
 
-import { useResource } from 'hooks/useResource';
+import { ITableColumnStats } from 'const/metastore';
 import { isNumeric } from 'lib/utils/number';
-import { TableColumnResource } from 'resource/table';
 import { KeyContentDisplay } from 'ui/KeyContentDisplay/KeyContentDisplay';
 
 import { TableStats } from './DataTableStatsCommon';
 
 interface IProps {
-    columnId: number;
+    stats: ITableColumnStats[];
 }
 
 export const DataTableColumnStats: React.FunctionComponent<IProps> = ({
-    columnId,
+    stats,
 }) => {
-    const { data: tableColumnStats } = useResource(
-        React.useCallback(
-            () => TableColumnResource.getStats(columnId),
-            [columnId]
-        )
-    );
-
-    const statsDOM = (tableColumnStats || []).map((tableColumnStat) => (
+    const statsDOM = (stats || []).map((tableColumnStat) => (
         <KeyContentDisplay
             key={tableColumnStat.id}
             keyString={tableColumnStat.key}

--- a/querybook/webapp/components/DataTableTags/DataTableTags.tsx
+++ b/querybook/webapp/components/DataTableTags/DataTableTags.tsx
@@ -26,12 +26,14 @@ interface IProps {
     tableId: number;
     readonly?: boolean;
     mini?: boolean;
+    showType?: boolean;
 }
 
 export const DataTableTags: React.FunctionComponent<IProps> = ({
     tableId,
     readonly = false,
     mini = false,
+    showType = true,
 }) => {
     const isUserAdmin = useSelector(
         (state: IStoreState) => state.user.myUserInfo.isAdmin
@@ -62,6 +64,7 @@ export const DataTableTags: React.FunctionComponent<IProps> = ({
             key={tag.id}
             isUserAdmin={isUserAdmin}
             mini={mini}
+            showType={showType}
         />
     ));
 
@@ -82,7 +85,8 @@ export const TableTag: React.FC<{
     readonly?: boolean;
     deleteTag?: (tagName: string) => void;
     mini?: boolean;
-}> = ({ tag, readonly, deleteTag, isUserAdmin, mini }) => {
+    showType?: boolean;
+}> = ({ tag, readonly, deleteTag, isUserAdmin, mini, showType = true }) => {
     const tagMeta = tag.meta ?? {};
     const tagRef = React.useRef<HTMLSpanElement>();
     const [showConfigModal, setShowConfigModal] = React.useState(false);
@@ -151,6 +155,7 @@ export const TableTag: React.FC<{
                 onClick={handleTagClick}
                 ref={tagRef}
                 mini={mini}
+                showType={showType}
             />
         </div>
     );

--- a/querybook/webapp/components/DataTableTags/TableTagSelect.tsx
+++ b/querybook/webapp/components/DataTableTags/TableTagSelect.tsx
@@ -20,7 +20,7 @@ interface IProps {
 const tagReactSelectStyle = makeReactSelectStyle(true, miniReactSelectStyles);
 
 function isTagValid(val: string, existingTags: string[]) {
-    const regex = /^[a-z0-9]{1,255}$/i;
+    const regex = /^[a-z0-9_ ]{1,255}$/i;
     const match = val.match(regex);
     return Boolean(match && !existingTags.includes(val));
 }

--- a/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.scss
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.scss
@@ -4,24 +4,19 @@
     .Card {
         margin: 16px 0px;
 
-        .DataTableColumnCard-top {
-            cursor: pointer;
-            .DataTableColumnCard-left {
-                display: flex;
-                flex-direction: row;
-                align-items: center;
-                max-width: 95%;
-
-                .column-type {
-                    min-width: 80px;
-                    word-break: break-all;
-                }
+        .DataTableColumnCard-header {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            .column-name {
+                width: 180px;
+                margin-right: 12px;
             }
-        }
 
-        .DataTableColumnCard-preview {
-            @include one-line-ellipsis();
-            width: 95%;
+            .column-type {
+                width: 100%;
+                word-break: break-all;
+            }
         }
 
         .EditableTextField .editor-wrapper {
@@ -31,7 +26,6 @@
 }
 
 .DataTableColumnCardNestedType {
-
     .column-type {
         min-width: 80px;
         word-break: break-all;

--- a/querybook/webapp/components/DataTableViewMini/TablePanelView.tsx
+++ b/querybook/webapp/components/DataTableViewMini/TablePanelView.tsx
@@ -44,7 +44,7 @@ export const TablePanelView: React.FunctionComponent<ITablePanelViewProps> = ({
                         ? (table.description as ContentState).getPlainText()
                         : ''}
                 </SubPanelSection>
-                <DataTableTags tableId={table.id} readonly />
+                <DataTableTags tableId={table.id} readonly showType={false} />
             </PanelSection>
         );
 

--- a/querybook/webapp/const/metastore.ts
+++ b/querybook/webapp/const/metastore.ts
@@ -1,5 +1,8 @@
 import type { ContentState } from 'draft-js';
 
+import { IDataElementAssociation } from './dataElement';
+import { ITag } from './tag';
+
 // Keep it in sync with MetadataType in server/const/metastore.py
 export enum MetadataType {
     TABLE_DESCRIPTION = 'table_description',
@@ -116,6 +119,9 @@ export interface IDataColumn {
     name: string;
     table_id: number;
     type: string;
+    stats?: ITableColumnStats[];
+    tags?: ITag[];
+    data_element_association?: IDataElementAssociation;
 }
 
 export interface ILineage {

--- a/querybook/webapp/const/metastore.ts
+++ b/querybook/webapp/const/metastore.ts
@@ -119,6 +119,8 @@ export interface IDataColumn {
     name: string;
     table_id: number;
     type: string;
+}
+export interface IDetailedDataColumn extends IDataColumn {
     stats?: ITableColumnStats[];
     tags?: ITag[];
     data_element_association?: IDataElementAssociation;

--- a/querybook/webapp/resource/table.ts
+++ b/querybook/webapp/resource/table.ts
@@ -10,6 +10,7 @@ import type {
     IDataTableSamples,
     IDataTableWarning,
     IDataTableWarningUpdateFields,
+    IDetailedDataColumn,
     ILineage,
     IPaginatedQuerySampleFilters,
     IQueryMetastore,
@@ -168,10 +169,9 @@ export const TableResource = {
 };
 
 export const TableColumnResource = {
-    get: (columnId: number) => ds.fetch<IDataColumn>(`/column/${columnId}/`),
+    get: (columnId: number) =>
+        ds.fetch<IDetailedDataColumn>(`/column/${columnId}/`),
 
-    getStats: (columnId: number) =>
-        ds.fetch<ITableColumnStats[]>(`/column/stats/${columnId}/`),
     update: (columnId: number, description: ContentState) => {
         const params = {
             description: convertContentStateToHTML(description),

--- a/querybook/webapp/resource/table.ts
+++ b/querybook/webapp/resource/table.ts
@@ -1,7 +1,6 @@
 import type { ContentState } from 'draft-js';
 import JSONBig from 'json-bigint';
 
-import { IDataElementAssociation } from 'const/dataElement';
 import type {
     DataTableWarningSeverity,
     IDataColumn,
@@ -169,6 +168,8 @@ export const TableResource = {
 };
 
 export const TableColumnResource = {
+    get: (columnId: number) => ds.fetch<IDataColumn>(`/column/${columnId}/`),
+
     getStats: (columnId: number) =>
         ds.fetch<ITableColumnStats[]>(`/column/stats/${columnId}/`),
     update: (columnId: number, description: ContentState) => {
@@ -240,9 +241,6 @@ export const TableTagResource = {
 };
 
 export const DataElementResource = {
-    getDataElementByColumnId: (columnId: number) =>
-        ds.fetch<IDataElementAssociation>(`/column/${columnId}/data_element/`),
-
     getMetastoreLink: (dataElementId: number) =>
         ds.fetch<string>(`/data_element/${dataElementId}/metastore_link/`),
 };

--- a/querybook/webapp/ui/Tag/HoverIconTag.tsx
+++ b/querybook/webapp/ui/Tag/HoverIconTag.tsx
@@ -11,52 +11,66 @@ export interface IHoverIconTagProps extends Omit<ITagProps, 'children'> {
     type?: string;
     icon?: string;
     iconOnHover?: AllLucideIconNames;
+    showType?: boolean;
     onIconHoverClick?: (e?: React.MouseEvent) => any;
 }
 export const HoverIconTag = React.forwardRef<
     HTMLSpanElement,
     IHoverIconTagProps
->(({ name, type, icon, iconOnHover, onIconHoverClick, ...tagProps }, ref) => {
-    const hoverDOM = iconOnHover ? (
-        <div className="HoverIconTag-hover" onClick={onIconHoverClick}>
-            <Icon name={iconOnHover} />
-        </div>
-    ) : null;
+>(
+    (
+        {
+            name,
+            type,
+            icon,
+            iconOnHover,
+            showType = true,
+            onIconHoverClick,
+            ...tagProps
+        },
+        ref
+    ) => {
+        const hoverDOM = iconOnHover ? (
+            <div className="HoverIconTag-hover" onClick={onIconHoverClick}>
+                <Icon name={iconOnHover} />
+            </div>
+        ) : null;
 
-    const className = clsx(tagProps['className'], 'HoverIconTag');
+        const className = clsx(tagProps['className'], 'HoverIconTag');
 
-    const iconDOM = icon && (
-        <Icon name={icon as any} size={16} className="mr4" />
-    );
+        const iconDOM = icon && (
+            <Icon name={icon as any} size={16} className="mr4" />
+        );
 
-    if (type) {
-        const { tooltip, tooltipPos, color, mini, onClick, ...extraProps } =
-            tagProps;
+        if (type && showType) {
+            const { tooltip, tooltipPos, color, mini, onClick, ...extraProps } =
+                tagProps;
+            return (
+                <TagGroup
+                    tooltip={tooltip}
+                    tooltipPos={tooltipPos}
+                    className={className}
+                    onClick={onClick}
+                    ref={ref}
+                >
+                    <Tag mini={mini}>
+                        {iconDOM}
+                        <span>{type}</span>
+                    </Tag>
+                    <Tag mini={mini} highlighted color={color} {...extraProps}>
+                        {name}
+                        {hoverDOM}
+                    </Tag>
+                </TagGroup>
+            );
+        }
+
         return (
-            <TagGroup
-                tooltip={tooltip}
-                tooltipPos={tooltipPos}
-                className={className}
-                onClick={onClick}
-                ref={ref}
-            >
-                <Tag mini={mini}>
-                    {iconDOM}
-                    <span>{type}</span>
-                </Tag>
-                <Tag mini={mini} highlighted color={color} {...extraProps}>
-                    {name}
-                    {hoverDOM}
-                </Tag>
-            </TagGroup>
+            <Tag {...tagProps} ref={ref} className={className}>
+                {iconDOM}
+                <span>{name}</span>
+                {hoverDOM}
+            </Tag>
         );
     }
-
-    return (
-        <Tag {...tagProps} ref={ref} className={className}>
-            {iconDOM}
-            <span>{name}</span>
-            {hoverDOM}
-        </Tag>
-    );
-});
+);

--- a/querybook/webapp/ui/Tag/Tag.scss
+++ b/querybook/webapp/ui/Tag/Tag.scss
@@ -26,6 +26,7 @@
     font-size: var(--small-text-size);
     font-family: var(--font-accent);
     max-width: 100%;
+    white-space: nowrap;
 
     span {
         @include one-line-ellipsis();


### PR DESCRIPTION
some bug fixes
 - can't add tags whose name contains space and underscore
 - too many api calls on the column tab in table view. Combined the tag, data element and column stats into one api call
 - unnecessary wrap of the tag name on the left sidebar mini table view. Change it to nowrap and also hide tag type in the mini view.
 
Also removed the expand/collapse toggle button and move the column name before the column type
![image](https://user-images.githubusercontent.com/8308723/225788674-80838c56-4289-464a-8f71-e3585a41dbda.png)
 
