### PR TITLE
fix: remove broadcast from socketio.emit

### DIFF
--- a/querybook/server/datasources/datadoc.py
+++ b/querybook/server/datasources/datadoc.py
@@ -465,7 +465,6 @@ def add_datadoc_editor(
                 (originator, doc_id, uid, None),
                 namespace="/datadoc",
                 room=doc_id,
-                broadcast=True,
             )
 
         socketio.emit(
@@ -473,7 +472,6 @@ def add_datadoc_editor(
             (originator, doc_id, uid, editor_dict),
             namespace="/datadoc",
             room=doc_id,
-            broadcast=True,
         )
         logic.update_es_data_doc_by_id(doc_id)
         send_add_datadoc_editor_email(doc_id, uid, read, write)
@@ -501,7 +499,6 @@ def add_datadoc_access_request(doc_id, originator=None):
             (originator, doc_id, uid, access_request_dict),
             namespace="/datadoc",
             room=doc_id,
-            broadcast=True,
         )
     send_datadoc_access_request_notification(doc_id=doc_id, uid=uid)
     return access_request_dict
@@ -516,7 +513,6 @@ def remove_datadoc_access_request(doc_id, uid, originator=None):
         (originator, doc_id, uid, None),
         namespace="/datadoc",
         room=doc_id,
-        broadcast=True,
     )
 
 
@@ -597,7 +593,6 @@ def update_datadoc_editor(
                 ),
                 namespace="/datadoc",
                 room=editor_dict["data_doc_id"],
-                broadcast=True,
             )
             return editor_dict
 
@@ -620,7 +615,6 @@ def delete_datadoc_editor(
                 (originator, editor_dict["data_doc_id"], editor_dict["uid"], None),
                 namespace="/datadoc",
                 room=editor_dict["data_doc_id"],
-                broadcast=True,
             )
 
 
@@ -663,7 +657,6 @@ def update_datadoc_owner(doc_id, next_owner_id, originator=None):
             (originator, doc_id, current_user.id, current_owner_editor_dict),
             namespace="/datadoc",
             room=doc_id,
-            broadcast=True,
         )
         socketio.emit(
             "data_doc_editor",
@@ -675,7 +668,6 @@ def update_datadoc_owner(doc_id, next_owner_id, originator=None):
             ),
             namespace="/datadoc",
             room=next_owner_editor_dict["data_doc_id"],
-            broadcast=True,
         )
         socketio.emit(
             "data_doc_updated",
@@ -685,7 +677,6 @@ def update_datadoc_owner(doc_id, next_owner_id, originator=None):
             ),
             namespace="/datadoc",
             room=next_owner_editor_dict["data_doc_id"],
-            broadcast=True,
         )
         logic.update_es_data_doc_by_id(doc_id)
         # Update queries in elasticsearch to reflect new permissions

--- a/querybook/server/datasources/query_execution.py
+++ b/querybook/server/datasources/query_execution.py
@@ -96,7 +96,6 @@ def create_query_execution(query, engine_id, data_cell_id=None, originator=None)
                     ),
                     namespace="/datadoc",
                     room=data_doc.id,
-                    broadcast=True,
                 )
 
             return query_execution_dict

--- a/querybook/server/datasources_socketio/datadoc.py
+++ b/querybook/server/datasources_socketio/datadoc.py
@@ -32,7 +32,6 @@ def send_data_doc_session_info(data_doc_id, room, redis_conn=None):
         {"users": user_dict, "cursors": cursor_dict},
         namespace=DATA_DOC_NAMESPACE,
         room=room,
-        broadcast=True,
     )
 
 
@@ -110,7 +109,6 @@ def update_user_list(data_doc_id, add=False, redis_conn=None):
             (add, request.sid, current_user.id),
             namespace=DATA_DOC_NAMESPACE,
             room=data_doc_id,
-            broadcast=True,
         )
 
 
@@ -186,7 +184,6 @@ def fetch_data_doc_editors(doc_id):
                 "data_doc_editors",
                 (request.sid, editor_dicts),
                 namespace=DATA_DOC_NAMESPACE,
-                broadcast=False,
                 room=request.sid,
             )
             send_data_doc_session_info(doc_id, room=request.sid)
@@ -208,7 +205,6 @@ def fetch_data_doc_access_requests(doc_id):
                 "data_doc_access_requests",
                 (request.sid, access_request_dicts),
                 namespace=DATA_DOC_NAMESPACE,
-                broadcast=False,
                 room=request.sid,
             )
             send_data_doc_session_info(doc_id, room=request.sid)
@@ -264,5 +260,4 @@ def move_data_doc_cursor(data_doc_id, data_cell_id=None):
         ),
         namespace=DATA_DOC_NAMESPACE,
         room=data_doc_id,
-        broadcast=True,
     )

--- a/querybook/server/datasources_socketio/helper.py
+++ b/querybook/server/datasources_socketio/helper.py
@@ -33,7 +33,6 @@ def register_socket(url, namespace=None, websocket_logging=True):
                         "error",
                         str(e),
                         namespace=namespace,
-                        broadcast=False,
                         room=flask.request.sid,
                     )
 

--- a/querybook/server/logic/datadoc_collab.py
+++ b/querybook/server/logic/datadoc_collab.py
@@ -38,7 +38,6 @@ def update_datadoc(doc_id, fields, sid="", session=None):
         ),
         namespace=DATA_DOC_NAMESPACE,
         room=doc_id,
-        broadcast=True,
     )
 
     return doc_dict
@@ -67,7 +66,6 @@ def insert_data_cell(
         ),
         namespace=DATA_DOC_NAMESPACE,
         room=doc_id,
-        broadcast=True,
     )
 
     return data_cell_dict
@@ -93,7 +91,6 @@ def move_data_cell(doc_id, from_index, to_index, sid="", session=None):
         ),
         namespace=DATA_DOC_NAMESPACE,
         room=doc_id,
-        broadcast=True,
     )
 
     # Should we return data instead?
@@ -146,7 +143,6 @@ def paste_data_cell(
                 ),
                 namespace=DATA_DOC_NAMESPACE,
                 room=doc_id,
-                broadcast=True,
             )
         else:
             socketio.emit(
@@ -158,7 +154,6 @@ def paste_data_cell(
                 ),
                 namespace=DATA_DOC_NAMESPACE,
                 room=doc_id,
-                broadcast=True,
             )
             socketio.emit(
                 "data_cell_deleted",
@@ -168,7 +163,6 @@ def paste_data_cell(
                 ),
                 namespace=DATA_DOC_NAMESPACE,
                 room=old_data_doc.id,
-                broadcast=True,
             )
     else:  # Copy
         new_cell_dict = insert_data_cell(
@@ -189,7 +183,6 @@ def paste_data_cell(
         (sid),
         namespace=DATA_DOC_NAMESPACE,
         room=doc_id,
-        broadcast=False,
     )
 
 
@@ -209,7 +202,6 @@ def update_data_cell(cell_id, fields, sid="", session=None):
         (sid, data_cell_dict),
         namespace=DATA_DOC_NAMESPACE,
         room=data_doc.id,
-        broadcast=True,
     )
 
     return data_cell_dict
@@ -231,7 +223,6 @@ def delete_data_cell(doc_id, cell_id, sid="", session=None):
         ),
         namespace=DATA_DOC_NAMESPACE,
         room=doc_id,
-        broadcast=True,
     )
 
     return True

--- a/querybook/server/tasks/run_datadoc.py
+++ b/querybook/server/tasks/run_datadoc.py
@@ -148,7 +148,6 @@ def _start_query_execution_task(
             ),
             namespace="/datadoc",
             room=data_doc_id,
-            broadcast=True,
         )
         return query_execution.id
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ greenlet==1.1.2
 alembic==1.8.1
 
 gevent-websocket==0.10.1
-flask-socketio==5.3.1
+flask-socketio==5.3.3
 
 # Query templating
 Jinja2==3.1.2  # From Flask


### PR DESCRIPTION

Recently there is a version upgrade of `python-socketio` to [v3.8.0](https://github.com/miguelgrinberg/python-socketio/blob/main/CHANGES.md) breaks Querybook due to this [change](https://github.com/miguelgrinberg/python-socketio/commit/1cadada02dd7dc1eb96f45e88cbec67e1a393db3#diff-f48cfe03e710293c3fc425967c50df35894a72397328da6bcf4ecbfe5e831836L271) , which remove the `**kwargs` from the  `.emit` function, while we're passing a parameter of `broadcast` today. 

The `broadcast` parameter is actually on the `flask_socketio.emit`, not on the [SocketIO.emit()](https://github.com/miguelgrinberg/Flask-SocketIO/blob/main/src/flask_socketio/__init__.py#L401) ,while we're using the latter. 
