### PR TITLE
fix: column name overlaps with type

### DIFF
--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -375,6 +375,7 @@ def get_column_by_table(table_id, column_name, with_table=False):
 
 
 @register("/column/<int:column_id>/", methods=["GET"])
+@limiter.limit("120 per minute")
 def get_column(column_id, with_table=False):
     column = logic.get_column_by_id(column_id)
     verify_data_table_permission(column.table_id)

--- a/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.scss
+++ b/querybook/webapp/components/DataTableViewColumn/DataTableColumnCard.scss
@@ -8,13 +8,14 @@
             display: flex;
             flex-direction: row;
             align-items: center;
+            gap: 12px;
+
             .column-name {
-                width: 180px;
-                margin-right: 12px;
+                min-width: 160px;
             }
 
             .column-type {
-                width: 100%;
+                flex: 1;
                 word-break: break-all;
             }
         }

--- a/querybook/webapp/ui/KeyContentDisplay/KeyContentDisplay.scss
+++ b/querybook/webapp/ui/KeyContentDisplay/KeyContentDisplay.scss
@@ -3,16 +3,16 @@
     flex-direction: row;
     margin-bottom: 8px;
     cursor: default;
+    gap: 12px;
 
     .KeyContentDisplay-key {
-        width: 180px;
-        margin-right: 12px;
+        min-width: 160px;
         color: var(--text-light);
         font-size: var(--text-size);
         font-weight: var(--light-bold-font);
     }
     .KeyContentDisplay-content {
-        width: 100%;
+        flex: 1;
         align-self: center;
 
         &.right-align {


### PR DESCRIPTION
 - adjust the layout of the column card
 - increase the rate limit of /column/<column_id> api
before
![image](https://user-images.githubusercontent.com/8308723/227311037-372732d2-5a97-481d-a34a-97a63479c942.png)
after
![image](https://user-images.githubusercontent.com/8308723/227311407-9969427c-963a-451e-a3b4-26d19b95019c.png)

