### PR TITLE
fix: update data_element table charset to utf8

### DIFF
--- a/docs_website/docs/changelog/breaking_change.md
+++ b/docs_website/docs/changelog/breaking_change.md
@@ -7,6 +7,13 @@ slug: /changelog
 
 Here are the list of breaking changes that you should be aware of when updating Querybook:
 
+## v3.22.0
+
+Updated the charset of table `data_element` to `utf8mb4`. For those mysql db's default charset is not utf8, please run below sql to update it if needed.
+```sql
+ALTER TABLE data_element CONVERT TO CHARACTER SET utf8mb4
+```
+
 ## v3.13.0
 
 Added two new abstract methods `notify_recipients` and `notifier_help` for `BaseNotifier`, which will allow a notifier to send messages to a list of recipients and provide help text for the recipients. Follow the example of `SlackNotifier` and `EmailNotifier` to implement it for your own notifier.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.21.0",
+    "version": "3.22.0",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/migrations/versions/7f6cdb3621f7_add_data_element_support.py
+++ b/querybook/migrations/versions/7f6cdb3621f7_add_data_element_support.py
@@ -63,6 +63,8 @@ def upgrade():
             ["data_element_id"], ["data_element.id"], ondelete="CASCADE"
         ),
         sa.PrimaryKeyConstraint("id"),
+        mysql_charset="utf8mb4",
+        mysql_engine="InnoDB",
     )
     # ### end Alembic commands ###
 

--- a/querybook/server/models/data_element.py
+++ b/querybook/server/models/data_element.py
@@ -13,6 +13,7 @@ Base = db.Base
 
 class DataElement(CRUDMixin, Base):
     __tablename__ = "data_element"
+    __table_args__ = {"mysql_engine": "InnoDB", "mysql_charset": "utf8mb4"}
 
     id = sql.Column(sql.Integer, primary_key=True)
     created_at = sql.Column(sql.DateTime, default=now)


### PR DESCRIPTION
the default charset may not be utf8, which doesn't support utf8 chars in the description column

if the table has already been created, please run below to update
`ALTER TABLE data_element CONVERT TO CHARACTER SET utf8mb4;`