### PR TITLE
feat: Fix Editor endpoint.

### DIFF
--- a/querybook/server/datasources/datadoc.py
+++ b/querybook/server/datasources/datadoc.py
@@ -442,9 +442,16 @@ def add_datadoc_editor(
 ):
     with DBSession() as session:
         assert_can_write(doc_id, session=session)
-        editor = logic.create_data_doc_editor(
-            data_doc_id=doc_id, uid=uid, read=read, write=write, commit=False
-        )
+
+        # CREATE & UPDATE FUNCTION ADDED
+        editor = logic.create_or_update_data_doc_editor(data_doc_id=doc_id, uid=uid, read=read, write=write, commit=False)
+        
+        # ONLY CREATE FUNCTION COMMENT
+        #
+        # editor = logic.create_data_doc_editor(
+        #     data_doc_id=doc_id, uid=uid, read=read, write=write, commit=False
+        # )
+        
         editor_dict = editor.to_dict()
 
         access_request = logic.get_data_doc_access_request_by_doc_id(


### PR DESCRIPTION
Fix Editor Function at Editor Endpoint : /datadoc/<int:doc_id>/editor/<int:uid>/
and Web EndPoint -> http://localhost:10001/demo_environment/datadoc/2/doc-3/

BUG:
If we share private datadoc ( in read-only) to user's and after that.. if they ask for  'edit' the datadoc.. owner can't give them permission, because it's already created in DataDocEditor.. So, we need to call "update_datadoc_editor".. instead of this.. i created "create_or_update_datadoc_edtor" function and it's fix.

