### PR TITLE
specify module versions to avoid errors during make

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,3 +5,7 @@ pytest==5.2.2
 black==19.10b0
 pre-commit==2.2.0
 coverage==5.4
+importlib-metadata==4.13.0
+markupsafe==2.0.1
+itsdangerous==2.0.1
+protobuf==3.20.*


### PR DESCRIPTION
not sure if it's just myself, when  launching query book on devapp, I got different errors that requires to downgrade modules

For example:
Exception Value:    'EntryPoints' object has no attribute 'get'

which requires importlib-metadata to be below 5.0