### PR TITLE
specify module versions to avoid errors during launch in devapp 

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,11 @@
 ipython
 watchdog_gevent
 watchdog[watchmedo]
-
 black==22.3.0
 pre-commit==2.9.2
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
+importlib-metadata==4.13.0
+markupsafe==2.0.1
+itsdangerous==2.0.1
+protobuf==3.20.*
+


### PR DESCRIPTION
not sure if others have this issue as well, when calling make for the first time, getting errors due to module version incompatibility. for example:

EntryPoints' object has no attribute 'get', which requires setting importlib-metadata below version 5.0