### PR TITLE
fix: add get_schema_location to metastore loader

### DIFF
--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -538,6 +538,10 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
         """Override this to get data element by name"""
         pass
 
+    def get_schema_location(self, schema_name: str) -> str:
+        """Get schema location, used by table uploader"""
+        pass
+
     @abstractclassmethod
     def get_metastore_params_template(self) -> AllFormField:
         """Override this to get the form field required for the metastore

--- a/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
+++ b/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
@@ -98,6 +98,9 @@ class HMSMetastoreLoader(BaseMetastoreLoader):
             self.hmc, schema_name, table_name, conditions
         )
 
+    def get_schema_location(self, schema_name: str) -> str:
+        return self.hmc.get_database(schema_name).locationUri
+
     def _get_hmc(self, metastore_dict):
         return HiveMetastoreClient(
             hmss_ro_addrs=metastore_dict["metastore_params"]["hms_connection"]


### PR DESCRIPTION
add `get_schema_location` to base metastore loader, to make sure any other metastore loader which can provide schema location can also use the table uploader