### PR TITLE
fix: dup table description in table search

### DIFF
--- a/querybook/server/logic/data_element.py
+++ b/querybook/server/logic/data_element.py
@@ -25,10 +25,10 @@ def get_data_element_by_name(name: str, session=None):
 
 
 @with_session
-def search_data_elements_by_keyword(keyword: str, limit=10, session=None):
+def search_data_elements_by_keyword(keyword: str, limit=20, session=None):
     return (
         session.query(DataElement)
-        .filter(DataElement.name.like("%" + keyword + "%"))
+        .filter(DataElement.name.like(keyword + "%"))
         .order_by(DataElement.name.asc())
         .limit(limit)
         .all()

--- a/querybook/webapp/components/Search/SearchOverview.tsx
+++ b/querybook/webapp/components/Search/SearchOverview.tsx
@@ -728,10 +728,6 @@ export const SearchOverview: React.FC<ISearchOverviewProps> = ({
                     />
                 </div>
                 <div className="search-filter">
-                    <span className="filter-title">Created At</span>
-                    {dateFilterDOM}
-                </div>
-                <div className="search-filter">
                     <span
                         className="filter-title"
                         aria-label="Table contains ALL selected tags"
@@ -754,6 +750,10 @@ export const SearchOverview: React.FC<ISearchOverviewProps> = ({
                 <div className="search-filter">
                     <span className="filter-title">Search Settings</span>
                     {searchSettingsDOM}
+                </div>
+                <div className="search-filter">
+                    <span className="filter-title">Created At</span>
+                    {dateFilterDOM}
                 </div>
             </>
         ) : (

--- a/querybook/webapp/components/Search/SearchOverview.tsx
+++ b/querybook/webapp/components/Search/SearchOverview.tsx
@@ -693,10 +693,12 @@ export const SearchOverview: React.FC<ISearchOverviewProps> = ({
             </>
         ) : searchType === 'Table' ? (
             <>
-                <div className="search-filter">
-                    <span className="filter-title">Metastore</span>
-                    {metastoreSelectDOM}
-                </div>
+                {queryMetastores.length > 1 && (
+                    <div className="search-filter">
+                        <span className="filter-title">Metastore</span>
+                        {metastoreSelectDOM}
+                    </div>
+                )}
                 <div className="search-filter">
                     <span className="filter-title">Top Tier</span>
                     <div className="result-item-golden horizontal-space-between">

--- a/querybook/webapp/components/Search/SearchResultItem.tsx
+++ b/querybook/webapp/components/Search/SearchResultItem.tsx
@@ -424,11 +424,6 @@ export const DataTableItem: React.FunctionComponent<IDataTableItemProps> = ({
                             {descriptionDOM}
                         </span>
                     </Level>
-                    <Level className="result-items-bottom">
-                        <span className="result-item-description">
-                            {descriptionDOM}
-                        </span>
-                    </Level>
                 </div>
             </div>
             <UrlContextMenu url={url} anchorRef={selfRef} />


### PR DESCRIPTION
remove the duplicate description
also 
- update the search_data_elements_by_keyword to `startswith`,
- change the limit to 20
- hide metastore filter if there is only one
