### PR TITLE
feat: make datadoc table of contents sidebar resizable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.23.0",
+    "version": "3.23.1",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.scss
+++ b/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.scss
@@ -23,7 +23,7 @@
 
     .sidebar-content-table,
     .sidebar-content-contents {
-        width: 280px;
+        width: 100%;
         height: calc(100vh - 158px);
         max-height: 1200px;
     }

--- a/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
+++ b/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
@@ -25,6 +25,7 @@ interface IProps {
 
 type LeftSidebarContentState = 'contents' | 'table' | 'default';
 const TOGGLE_TOC_SHORTCUT = getShortcutSymbols(KeyMap.dataDoc.toggleToC.key);
+const DEFAULT_SIDEBAR_WIDTH = 280;
 
 export const DataDocLeftSidebar: React.FunctionComponent<IProps> = ({
     docId,
@@ -71,14 +72,36 @@ export const DataDocLeftSidebar: React.FunctionComponent<IProps> = ({
         }
     }, [sidebarTableId]);
 
+    const resizeToCollapseSidebar = React.useCallback(
+        (event, direction, elementRef) => {
+            if (
+                direction === 'right' &&
+                elementRef.clientWidth === DEFAULT_SIDEBAR_WIDTH
+            ) {
+                const sidebarRect = elementRef.getBoundingClientRect();
+                // this checks if mouse cursor is 1/3 * SIDEBAR_WIDTH left of sidebar
+                if (
+                    event instanceof MouseEvent &&
+                    sidebarRect.left + sidebarRect.width - event.clientX >
+                        DEFAULT_SIDEBAR_WIDTH / 3
+                ) {
+                    setContentState('default');
+                }
+            }
+        },
+        []
+    );
+
     let contentDOM: React.ReactChild;
     if (contentState === 'contents') {
         contentDOM = (
             <Resizable
                 defaultSize={{
-                    width: '280px',
+                    width: `${DEFAULT_SIDEBAR_WIDTH}px`,
                 }}
+                minWidth={DEFAULT_SIDEBAR_WIDTH}
                 enable={enableResizable({ right: true })}
+                onResize={resizeToCollapseSidebar}
             >
                 <div className="sidebar-content sidebar-content-contents">
                     <Level className="contents-panel-header">

--- a/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
+++ b/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { DataTableViewMini } from 'components/DataTableViewMini/DataTableViewMini';
 import { IDataCell } from 'const/datadoc';
 import { useEvent } from 'hooks/useEvent';
+import { useResizeToCollapseSidebar } from 'hooks/useResizeToCollapse';
 import { enableResizable } from 'lib/utils';
 import { getShortcutSymbols, KeyMap, matchKeyMap } from 'lib/utils/keyboard';
 import { setSidebarTableId } from 'redux/querybookUI/action';
@@ -72,24 +73,10 @@ export const DataDocLeftSidebar: React.FunctionComponent<IProps> = ({
         }
     }, [sidebarTableId]);
 
-    const resizeToCollapseSidebar = React.useCallback(
-        (event, direction, elementRef) => {
-            if (
-                direction === 'right' &&
-                elementRef.clientWidth === DEFAULT_SIDEBAR_WIDTH
-            ) {
-                const sidebarRect = elementRef.getBoundingClientRect();
-                // this checks if mouse cursor is 1/3 * SIDEBAR_WIDTH left of sidebar
-                if (
-                    event instanceof MouseEvent &&
-                    sidebarRect.left + sidebarRect.width - event.clientX >
-                        DEFAULT_SIDEBAR_WIDTH / 3
-                ) {
-                    setContentState('default');
-                }
-            }
-        },
-        []
+    const resizeToCollapseSidebar = useResizeToCollapseSidebar(
+        DEFAULT_SIDEBAR_WIDTH,
+        1 / 3,
+        React.useCallback(() => setContentState('default'), [])
     );
 
     let contentDOM: React.ReactChild;

--- a/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
+++ b/querybook/webapp/components/DataDocLeftSidebar/DataDocLeftSidebar.tsx
@@ -1,10 +1,12 @@
 import clsx from 'clsx';
+import Resizable from 're-resizable';
 import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { DataTableViewMini } from 'components/DataTableViewMini/DataTableViewMini';
 import { IDataCell } from 'const/datadoc';
 import { useEvent } from 'hooks/useEvent';
+import { enableResizable } from 'lib/utils';
 import { getShortcutSymbols, KeyMap, matchKeyMap } from 'lib/utils/keyboard';
 import { setSidebarTableId } from 'redux/querybookUI/action';
 import { IStoreState } from 'redux/store/types';
@@ -72,24 +74,31 @@ export const DataDocLeftSidebar: React.FunctionComponent<IProps> = ({
     let contentDOM: React.ReactChild;
     if (contentState === 'contents') {
         contentDOM = (
-            <div className="sidebar-content sidebar-content-contents">
-                <Level className="contents-panel-header">
-                    <IconButton
-                        icon="ArrowLeft"
-                        onClick={() => setContentState('default')}
-                    />
-                    <div className="flex-row">
-                        <span className="mr4">
-                            contents ({TOGGLE_TOC_SHORTCUT})
-                        </span>
-                        <InfoButton layout={['right', 'top']}>
-                            Click to jump to the corresponding cell. Drag cells
-                            to reorder them.
-                        </InfoButton>
-                    </div>
-                </Level>
-                <DataDocContents cells={cells} docId={docId} />
-            </div>
+            <Resizable
+                defaultSize={{
+                    width: '280px',
+                }}
+                enable={enableResizable({ right: true })}
+            >
+                <div className="sidebar-content sidebar-content-contents">
+                    <Level className="contents-panel-header">
+                        <IconButton
+                            icon="ArrowLeft"
+                            onClick={() => setContentState('default')}
+                        />
+                        <div className="flex-row">
+                            <span className="mr4">
+                                contents ({TOGGLE_TOC_SHORTCUT})
+                            </span>
+                            <InfoButton layout={['right', 'top']}>
+                                Click to jump to the corresponding cell. Drag
+                                cells to reorder them.
+                            </InfoButton>
+                        </div>
+                    </Level>
+                    <DataDocContents cells={cells} docId={docId} />
+                </div>
+            </Resizable>
         );
     } else if (contentState === 'table') {
         contentDOM = (

--- a/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentAppSidebar.tsx
+++ b/querybook/webapp/components/EnvironmentAppSidebar/EnvironmentAppSidebar.tsx
@@ -8,6 +8,7 @@ import { QuerySnippetNavigator } from 'components/QuerySnippetNavigator/QuerySni
 import { QueryViewNavigator } from 'components/QueryViewNavigator/QueryViewNavigator';
 import { useEvent } from 'hooks/useEvent';
 import { useLocalStoreState } from 'hooks/useLocalStoreState';
+import { useResizeToCollapseSidebar } from 'hooks/useResizeToCollapse';
 import { SIDEBAR_ENTITY } from 'lib/local-store/const';
 import { KeyMap, matchKeyMap } from 'lib/utils/keyboard';
 import { navigateWithinEnv } from 'lib/utils/query-string';
@@ -55,24 +56,10 @@ export const EnvironmentAppSidebar: React.FunctionComponent = () => {
         [dispatch, collapsed, setEntity]
     );
 
-    const scrollToCollapseSidebar = React.useCallback(
-        (event, direction, elementRef) => {
-            if (
-                direction === 'right' &&
-                elementRef.clientWidth === SIDEBAR_WIDTH
-            ) {
-                const sidebarRect = elementRef.getBoundingClientRect();
-                // this checks if mouse cursor is SIDEBAR_WIDTH / 2 left of sidebar
-                if (
-                    event instanceof MouseEvent &&
-                    sidebarRect.left + sidebarRect.width - event.clientX >
-                        SIDEBAR_WIDTH / 2
-                ) {
-                    dispatch(setCollapsed(true));
-                }
-            }
-        },
-        []
+    const resizeToCollapseSidebar = useResizeToCollapseSidebar(
+        SIDEBAR_WIDTH,
+        1 / 3,
+        React.useCallback(() => dispatch(setCollapsed(true)), [dispatch])
     );
 
     const handleCollapseKeyDown = React.useCallback(
@@ -175,7 +162,7 @@ export const EnvironmentAppSidebar: React.FunctionComponent = () => {
             className={className}
             initialWidth={SIDEBAR_WIDTH}
             minWidth={SIDEBAR_WIDTH}
-            onResize={scrollToCollapseSidebar}
+            onResize={resizeToCollapseSidebar}
         >
             {contentDOM}
         </Sidebar>

--- a/querybook/webapp/hooks/useResizeToCollapse.ts
+++ b/querybook/webapp/hooks/useResizeToCollapse.ts
@@ -1,0 +1,27 @@
+import { useCallback } from 'react';
+
+export function useResizeToCollapseSidebar(
+    defaultWidth: number,
+    gapPercentage: number,
+    onCollapse: () => void
+) {
+    return useCallback(
+        (event: Event, direction: string, elementRef) => {
+            if (
+                direction === 'right' &&
+                elementRef.clientWidth === defaultWidth
+            ) {
+                const sidebarRect = elementRef.getBoundingClientRect();
+                // this checks if mouse cursor is defaultWidth * gapPercentage left of sidebar
+                if (
+                    event instanceof MouseEvent &&
+                    sidebarRect.left + sidebarRect.width - event.clientX >
+                        defaultWidth * gapPercentage
+                ) {
+                    onCollapse();
+                }
+            }
+        },
+        [defaultWidth, gapPercentage, onCollapse]
+    );
+}


### PR DESCRIPTION
make datadoc table of contents sidebar resizable, only on the right side
![sidebar-resizing](https://user-images.githubusercontent.com/8308723/230657498-3032aa45-0fbf-463b-95b8-b72cbaf86ad5.gif)
