### PR TITLE
fix: Ensure meta_info is updated when an exception occurs

### DIFF
--- a/querybook/server/lib/query_executor/base_executor.py
+++ b/querybook/server/lib/query_executor/base_executor.py
@@ -597,7 +597,9 @@ class QueryExecutorBaseClass(metaclass=ABCMeta):
         try:
             # Try our best to fetch logs again
             if self._cursor:
-                self._logger.on_statement_update(log=self._get_logs())
+                self._logger.on_statement_update(
+                    log=self._get_logs(), meta_info=self.meta_info
+                )
         except Exception:
             # In case of failure just ignore
             pass


### PR DESCRIPTION
Basically, if a Trino query fails fast enough that the `poll()` function never runs successfully, the `meta_info` for the execution won't be captured, containing the Trino tracking URL. Something like "asdfg" as a query would trigger this because Trino doesn't need to do any metastore lookups before failing the query. Whereas queries that are slower to fail will go through 2 or more poll() iterations, and the successful ones will update the meta_info prior to the exception.

This PR fixes the issue by catching exceptions and updating the tracking URLs, as well as ensuring that on_statement_update() get a copy of meta_info when an exception occurs during the first poll()
