### PR TITLE
fix: LIMIT ALL can now be used in Querybook

### DIFF
--- a/querybook/webapp/lib/sql-helper/sql-limiter.ts
+++ b/querybook/webapp/lib/sql-helper/sql-limiter.ts
@@ -118,8 +118,8 @@ export function getLimitedQuery(
         .map((statement) => {
             const existingLimit = getSelectStatementLimit(statement, language);
             if (
-                existingLimit == null || 
-                existingLimit >= 0 || 
+                existingLimit == null ||
+                existingLimit >= 0 ||
                 existingLimit === -2
             ) {
                 return statement + ';';

--- a/querybook/webapp/lib/sql-helper/sql-limiter.ts
+++ b/querybook/webapp/lib/sql-helper/sql-limiter.ts
@@ -15,6 +15,7 @@ import { Nullable } from 'lib/typescript';
  * Checks if a select statement has a limit and returns the limit
  * If the statement is not select then null is returned
  * If the statement has no limit then -1 is returned
+ * If the statement has LIMIT ALL then -2 is returned
  *
  * @param statement the query string
  * @param language language of the query
@@ -44,7 +45,7 @@ export function getSelectStatementLimit(
     if (!['select', 'union'].includes(getStatementType(outerStatement))) {
         return null;
     }
-
+    
     const matchLimitPatternNum = tokenPatternMatch(outerStatement, [
         { type: 'KEYWORD', text: 'limit' },
         { type: 'NUMBER' },

--- a/querybook/webapp/lib/sql-helper/sql-limiter.ts
+++ b/querybook/webapp/lib/sql-helper/sql-limiter.ts
@@ -45,7 +45,6 @@ export function getSelectStatementLimit(
     if (!['select', 'union'].includes(getStatementType(outerStatement))) {
         return null;
     }
-    
     const matchLimitPatternNum = tokenPatternMatch(outerStatement, [
         { type: 'KEYWORD', text: 'limit' },
         { type: 'NUMBER' },
@@ -118,7 +117,11 @@ export function getLimitedQuery(
     const updatedQuery = statements
         .map((statement) => {
             const existingLimit = getSelectStatementLimit(statement, language);
-            if (existingLimit == null || existingLimit >= 0 || existingLimit === -2) {
+            if (
+                existingLimit == null || 
+                existingLimit >= 0 || 
+                existingLimit === -2
+            ) {
                 return statement + ';';
             }
 

--- a/querybook/webapp/lib/sql-helper/sql-limiter.ts
+++ b/querybook/webapp/lib/sql-helper/sql-limiter.ts
@@ -45,13 +45,22 @@ export function getSelectStatementLimit(
         return null;
     }
 
-    const matchLimitPattern = tokenPatternMatch(outerStatement, [
+    const matchLimitPatternNum = tokenPatternMatch(outerStatement, [
         { type: 'KEYWORD', text: 'limit' },
         { type: 'NUMBER' },
     ]);
 
-    if (matchLimitPattern) {
-        return Number(matchLimitPattern[1].text);
+    if (matchLimitPatternNum) {
+        return Number(matchLimitPatternNum[1].text);
+    }
+
+    const matchLimitPatternAll = tokenPatternMatch(outerStatement, [
+        { type: 'KEYWORD', text: 'limit' },
+        { type: 'KEYWORD', text: 'all' },
+    ]);
+
+    if (matchLimitPatternAll) {
+        return -2;
     }
 
     const matchFetchFirstPattern = tokenPatternMatch(outerStatement, [
@@ -108,7 +117,7 @@ export function getLimitedQuery(
     const updatedQuery = statements
         .map((statement) => {
             const existingLimit = getSelectStatementLimit(statement, language);
-            if (existingLimit == null || existingLimit >= 0) {
+            if (existingLimit == null || existingLimit >= 0 || existingLimit === -2) {
                 return statement + ';';
             }
 

--- a/querybook/webapp/lib/sql-helper/sql-setting.ts
+++ b/querybook/webapp/lib/sql-helper/sql-setting.ts
@@ -74,7 +74,7 @@ const SettingsByLanguage: Record<string, ILanguageSetting> = {
         keywords: new Set(
             (
                 SQL_KEYWORDS +
-                'alter and as between by case cast constraint create cross cube current_date current_path current_time current_timestamp current_user deallocate delete describe distinct drop else end escape except execute exists extract false fetch first for formatted from full group grouping having if in inner insert intersect into is join left like limit localtime localtimestamp natural next normalize not null offset on only or order outer prepare recursive right rollup row rows select table then ties true uescape union unnest using use values when where with'
+                'all alter and as between by case cast constraint create cross cube current_date current_path current_time current_timestamp current_user deallocate delete describe distinct drop else end escape except execute exists extract false fetch first for formatted from full group grouping having if in inner insert intersect into is join left like limit localtime localtimestamp natural next normalize not null offset on only or order outer prepare recursive right rollup row rows select table then ties true uescape union unnest using use values when where with'
             ).split(' ')
         ),
         type: new Set(


### PR DESCRIPTION
Trino supports [`LIMIT ALL`](https://trino.io/docs/current/sql/select.html#limit-or-fetch-first-clause) but Querybook does not – it automatically adds an additional limit which breaks.

This change disables the automatic limiter when LIMIT ALL is used.