### PR TITLE
Implement a validating optimizer to toggle test mode

### DIFF
--- a/querybook/server/datasources/query_execution.py
+++ b/querybook/server/datasources/query_execution.py
@@ -632,21 +632,23 @@ def send_query_execution_invitation_notification(execution_id, uid, session=None
 
 @register("/query/validate/", methods=["POST"])
 def perform_query_syntax_check(
-    query: str, engine_id: int, var_config: list[DataDocMetaVarConfig]
+    query: str,
+    engine_id: int,
+    var_config: list[DataDocMetaVarConfig],
+    validators: list[str],
 ):
     verify_query_engine_permission(engine_id)
 
     engine = admin_logic.get_query_engine_by_id(engine_id)
-    validator_name = engine.feature_params.get("validator", None)
+    # validator_name = engine.feature_params.get("validator", None) # DEBUG
     # api_assert(validator_name is not None, "This engine has no validator configured") # DEBUG
-
     # validator = get_validator_by_name(validator_name) # DEBUG
 
     from lib.query_analysis.validation.validators.optimizing_validator import (
         OptimizingValidator,
     )  # DEBUG
 
-    validator = OptimizingValidator("whatever")  # DEBUG
+    validator = OptimizingValidator(optimizer_names=tuple(validators))
 
     api_assert(
         engine.language in validator.languages(),

--- a/querybook/server/datasources/query_execution.py
+++ b/querybook/server/datasources/query_execution.py
@@ -180,7 +180,6 @@ def cancel_query_execution(query_execution_id):
         "RECEIVED",  # Rare case where task is received but not yet start
         "RETRY",  # Very unlikely case, because query normally do not retry
     ):
-
         task.revoke(terminate=True)  # last attempt to cancel it
         cancel_query_and_notify()
     elif task.state == "ABORTED":
@@ -639,9 +638,15 @@ def perform_query_syntax_check(
 
     engine = admin_logic.get_query_engine_by_id(engine_id)
     validator_name = engine.feature_params.get("validator", None)
-    api_assert(validator_name is not None, "This engine has no validator configured")
+    # api_assert(validator_name is not None, "This engine has no validator configured") # DEBUG
 
-    validator = get_validator_by_name(validator_name)
+    # validator = get_validator_by_name(validator_name) # DEBUG
+
+    from lib.query_analysis.validation.validators.optimizing_validator import (
+        OptimizingValidator,
+    )  # DEBUG
+
+    validator = OptimizingValidator("whatever")  # DEBUG
 
     api_assert(
         engine.language in validator.languages(),

--- a/querybook/server/lib/query_analysis/validation/base_query_validator.py
+++ b/querybook/server/lib/query_analysis/validation/base_query_validator.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from lib.query_analysis.templating import (
     QueryTemplatingError,
     render_templated_query,
@@ -18,6 +18,7 @@ class QueryValidationSeverity(Enum):
     INFO = "info"
 
 
+# TODO: This would be cleaner as a dataclass, but we'd have to make the argument and attribute names consistent
 class QueryValidationResult(object):
     def __init__(
         self,
@@ -26,20 +27,23 @@ class QueryValidationResult(object):
         severity: QueryValidationSeverity,
         message: str,
         obj_type: QueryValidationResultObjectType = QueryValidationResultObjectType.LINT,
+        diff: Optional[str] = None,
     ):
         self.type = obj_type
         self.line = line
         self.ch = ch
         self.severity = severity
         self.message = message
+        self.diff = diff
 
-    def to_dict(self):
+    def to_dict(self):  # TODO: would be neater to use dataclasses.asdict
         return {
             "type": self.type.value,
             "line": self.line,
             "ch": self.ch,
             "severity": self.severity.value,
             "message": self.message,
+            "diff": self.diff,
         }
 
 

--- a/querybook/server/lib/query_analysis/validation/validators/optimizing_validator.py
+++ b/querybook/server/lib/query_analysis/validation/validators/optimizing_validator.py
@@ -34,6 +34,7 @@ class BaseOptimization:
 
 
 class ApplyTableSampleOptimization(BaseOptimization):
+    # TODO: do not rapply if already applied
     sample_percent: int = 10
 
     def optimize(self, query: str) -> str:

--- a/querybook/server/lib/query_analysis/validation/validators/optimizing_validator.py
+++ b/querybook/server/lib/query_analysis/validation/validators/optimizing_validator.py
@@ -4,9 +4,72 @@ from lib.query_analysis.validation.base_query_validator import (
     QueryValidationResult,
     QueryValidationSeverity,
 )
+import difflib
+from dataclasses import dataclass, asdict
+from sqlglot import exp, parse_one, expressions
+
+
+@dataclass
+class DiffOpcode:
+    tag: str  # one of replace, delete, insert, equal
+    #  Would use an enum, but it's hard to make into a string with asdict()
+    #  Python 3.11's StrEnum will fix this
+    a_start: int
+    a_end: int
+    b_start: int
+    b_end: int
+
+
+@dataclass
+class Diff:
+    a: str  # The original string
+    b: str  #  The new string
+    opcodes: List[
+        DiffOpcode
+    ]  # The list of operations to turn a into b, in the opcode format of difflib.SequenceMatcher
+
+
+class BaseOptimization:
+    pass
+
+
+class ApplyTableSampleOptimization(BaseOptimization):
+    sample_percent: int = 10
+
+    def optimize(self, query: str) -> str:
+        def transformer(node):
+            if isinstance(node, exp.Table):
+                t = expressions.TableSample()
+                t.args["method"] = "SYSTEM"
+                t.args["size"] = str(self.sample_percent)
+                t.args["kind"] = "TABLESAMPLE"
+                t.args["this"] = node
+                node = t
+                return node
+            else:
+                return node
+
+        expression_tree = parse_one(query)
+        transformed_tree = expression_tree.transform(transformer)
+        return transformed_tree.sql()
+
+
+class RemoveTableSampleOptimization(BaseOptimization):
+    def optimize(self, query: str) -> str:
+        def transformer(node):
+            if isinstance(node, exp.TableSample):
+                return node.args["this"]
+            else:
+                return node
+
+        expression_tree = parse_one(query)
+        transformed_tree = expression_tree.transform(transformer)
+        return transformed_tree.sql()
 
 
 class OptimizingValidator(BaseQueryValidator):
+    optimizers: List[BaseOptimization] = [ApplyTableSampleOptimization()]
+
     def languages(self):
         return ["presto", "trino", "sqlite"]
 
@@ -16,15 +79,29 @@ class OptimizingValidator(BaseQueryValidator):
         uid: int,  # who is doing the syntax check
         engine_id: int,  # which engine they are checking against
     ) -> List[QueryValidationResult]:
+        # TODO: different validators depending on engine
         validation_errors = []
 
+        new_query = query
+        for o in self.optimizers:
+            new_query = o.optimize(query)
+
+        cruncher = difflib.SequenceMatcher(isjunk=None, a=query, b=new_query)
+
+        #  The output format of SequenceMatcher is an unnamed tuple, so make it legible
+        #  https://github.com/python/cpython/blob/3.11/Lib/difflib.py#L495
+        diff = Diff(
+            a=query,
+            b=new_query,
+            opcodes=[DiffOpcode(*i) for i in cruncher.get_opcodes()],
+        )
         validation_errors = [
             QueryValidationResult(
                 0,
                 0,
                 QueryValidationSeverity.ERROR,  # TODO: Should there be a new type in QueryValidationResultObjectType for optmization suggestions/diffs?
                 "A WILD ERROR APPEARS!",
-                diff="new query",
+                diff=asdict(diff),
             )
         ]
         return validation_errors

--- a/querybook/server/lib/query_analysis/validation/validators/optimizing_validator.py
+++ b/querybook/server/lib/query_analysis/validation/validators/optimizing_validator.py
@@ -1,0 +1,30 @@
+from typing import List, Tuple
+from lib.query_analysis.validation.base_query_validator import (
+    BaseQueryValidator,
+    QueryValidationResult,
+    QueryValidationSeverity,
+)
+
+
+class OptimizingValidator(BaseQueryValidator):
+    def languages(self):
+        return ["presto", "trino", "sqlite"]
+
+    def validate(
+        self,
+        query: str,
+        uid: int,  # who is doing the syntax check
+        engine_id: int,  # which engine they are checking against
+    ) -> List[QueryValidationResult]:
+        validation_errors = []
+
+        validation_errors = [
+            QueryValidationResult(
+                0,
+                0,
+                QueryValidationSeverity.ERROR,  # TODO: Should there be a new type in QueryValidationResultObjectType for optmization suggestions/diffs?
+                "A WILD ERROR APPEARS!",
+                diff="new query",
+            )
+        ]
+        return validation_errors

--- a/querybook/webapp/components/QueryComposer/QueryComposer.tsx
+++ b/querybook/webapp/components/QueryComposer/QueryComposer.tsx
@@ -384,7 +384,8 @@ function useTestMode(
     // TODO: Should the implementation be different per query engine?
 ) {
     return useCallback( //TODO: useResource to memoize?
-        () => {
+        (selected) => {
+            console.log('CCCC', selected);
             const engineId = queryEngine.id;
 
             function HandleValidateFulfilled(
@@ -393,7 +394,6 @@ function useTestMode(
                 error,
             ) {
                 // TODO: Handle Errors
-                console.log(optimizedQuery);
                 // Assumes that only one optimization is returned
                 setQuery(optimizedQuery.data[0].diff.b);
             };
@@ -401,7 +401,9 @@ function useTestMode(
             TemplatedQueryResource.validateQuery(
                 query,
                 engineId,
-                templatedVariables
+                templatedVariables,
+                selected ? ['RemoveTableSampleOptimization'] : ['ApplyTableSampleOptimization']
+
             ).then(HandleValidateFulfilled); // TODO: this works, but it's not the React way
         }
     )

--- a/querybook/webapp/components/QueryComposer/QueryComposer.tsx
+++ b/querybook/webapp/components/QueryComposer/QueryComposer.tsx
@@ -394,8 +394,8 @@ function useTestMode(
             ) {
                 // TODO: Handle Errors
                 console.log(optimizedQuery);
-                // TODO handle multiple diffs
-                setQuery(query + optimizedQuery.data[0].diff);
+                // Assumes that only one optimization is returned
+                setQuery(optimizedQuery.data[0].diff.b);
             };
 
             TemplatedQueryResource.validateQuery(

--- a/querybook/webapp/components/QueryComposer/QueryComposer.tsx
+++ b/querybook/webapp/components/QueryComposer/QueryComposer.tsx
@@ -63,6 +63,9 @@ import { Modal } from 'ui/Modal/Modal';
 import { QueryComposerExecution } from './QueryComposerExecution';
 import { runQuery, transformQuery } from './RunQuery';
 
+import { TemplatedQueryResource } from 'resource/queryExecution';
+import { useResource } from 'hooks/useResource';
+
 import './QueryComposer.scss';
 
 const QUERY_EXECUTION_HEIGHT = 300;
@@ -373,6 +376,37 @@ function useTranspileQuery(
     };
 }
 
+function useTestMode(
+    query: string,
+    queryEngine: IQueryEngine,
+    templatedVariables: IDataDocMetaVariable[],
+    setQuery: (query: string) => any,
+    // TODO: Should the implementation be different per query engine?
+) {
+    return useCallback( //TODO: useResource to memoize?
+        () => {
+            const engineId = queryEngine.id;
+
+            function HandleValidateFulfilled(
+                optimizedQuery,
+                isLoading,
+                error,
+            ) {
+                // TODO: Handle Errors
+                console.log(optimizedQuery);
+                // TODO handle multiple diffs
+                setQuery(query + optimizedQuery.data[0].diff);
+            };
+
+            TemplatedQueryResource.validateQuery(
+                query,
+                engineId,
+                templatedVariables
+            ).then(HandleValidateFulfilled); // TODO: this works, but it's not the React way
+        }
+    )
+}
+
 const QueryComposer: React.FC = () => {
     useTrackView(ComponentType.ADHOC_QUERY);
     useBrowserTitle('Adhoc Query');
@@ -391,6 +425,7 @@ const QueryComposer: React.FC = () => {
         environmentId
     );
     const { rowLimit, setRowLimit } = useRowLimit(dispatch, environmentId);
+
 
     const [resultsCollapsed, setResultsCollapsed] = useState(false);
 
@@ -432,6 +467,8 @@ const QueryComposer: React.FC = () => {
         handleTranspileQuery,
         transpilerOptions,
     } = useTranspileQuery(engine, queryEngines, setEngineId, setQuery);
+
+    const setTestMode = useTestMode(query, engine, templatedVariables, setQuery);
 
     const handleCreateDataDoc = useCallback(async () => {
         trackClick({
@@ -637,6 +674,7 @@ const QueryComposer: React.FC = () => {
                 runButtonTooltipPos={'down'}
                 rowLimit={rowLimit}
                 onRowLimitChange={setRowLimit}
+                onTestModeChange={setTestMode}
             />
         </div>
     );

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
@@ -23,6 +23,7 @@ import { ListMenu } from 'ui/Menu/ListMenu';
 import { SearchBar } from 'ui/SearchBar/SearchBar';
 import { StatusIcon } from 'ui/StatusIcon/StatusIcon';
 import { Tag } from 'ui/Tag/Tag';
+import { ToggleButton } from 'ui/ToggleButton/ToggleButton';
 
 import './QueryRunButton.scss';
 
@@ -60,6 +61,7 @@ export const QueryRunButton = React.forwardRef<
             onEngineIdSelect,
             rowLimit,
             onRowLimitChange,
+            onTestModeChange,
         },
         ref
     ) => {
@@ -104,6 +106,13 @@ export const QueryRunButton = React.forwardRef<
                 />
             ) : null;
 
+        const testModeDOM =
+            <TestModeToggle
+                setTestMode={onTestModeChange}
+            />;
+
+
+
         return (
             <div className="QueryRunButton flex-row ml16">
                 <QueryEngineSelector
@@ -114,6 +123,7 @@ export const QueryRunButton = React.forwardRef<
                     onEngineIdSelect={onEngineIdSelect}
                 />
                 {rowLimitDOM}
+                {testModeDOM}
                 {runButtonDOM}
             </div>
         );
@@ -247,5 +257,50 @@ const QueryLimitSelector: React.FC<{
         >
             <ListMenu items={rowLimitMenuItems} type="select" />
         </Dropdown>
+    );
+};
+
+const TestModeToggle: React.FC<{
+    setTestMode: (isTestMode: boolean) => void;
+}> = ({ setTestMode }) => {
+    //    React.useEffect(() => {
+    //        if (!rowLimitOptions.some((option) => option.value === rowLimit)) {
+    //            setRowLimit(DEFAULT_ROW_LIMIT);
+    //        }
+    //    }, [rowLimit, setRowLimit]);
+    //
+    //    const selectedRowLimitText = React.useMemo(() => {
+    //        if (rowLimit >= 0) {
+    //            return formatNumber(rowLimit);
+    //        }
+    //        return 'none';
+    //    }, [rowLimit]);
+    //
+    //    const rowLimitMenuItems = rowLimitOptions.map((option) => ({
+    //        name: <span>{option.label}</span>,
+    //        onClick: () => setRowLimit(option.value),
+    //        checked: option.value === rowLimit,
+    //    }));
+    //
+    return (
+        <ToggleButton
+            customButtonRenderer={() => (
+                <div
+                    className="flex-center ph4"
+                    aria-label="In test mode, results are approximate but return faster by using sampling"
+                >
+                </div>
+            )}
+            layout={['bottom', 'right']}
+            selected={false}
+            onClick={() => {
+                // TODO: change button display
+                // TODO: Change query area background too?
+                // TODO add analytics trackClick()
+                setTestMode(false) // TODO: pass the actual selected value
+            }}
+        >
+            <Icon name="Check" fill />
+        </ToggleButton >
     );
 };

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
@@ -24,6 +24,7 @@ import { SearchBar } from 'ui/SearchBar/SearchBar';
 import { StatusIcon } from 'ui/StatusIcon/StatusIcon';
 import { Tag } from 'ui/Tag/Tag';
 import { ToggleButton } from 'ui/ToggleButton/ToggleButton';
+import { StyledText } from 'ui/StyledText/StyledText';
 
 import './QueryRunButton.scss';
 
@@ -263,25 +264,8 @@ const QueryLimitSelector: React.FC<{
 const TestModeToggle: React.FC<{
     setTestMode: (isTestMode: boolean) => void;
 }> = ({ setTestMode }) => {
-    //    React.useEffect(() => {
-    //        if (!rowLimitOptions.some((option) => option.value === rowLimit)) {
-    //            setRowLimit(DEFAULT_ROW_LIMIT);
-    //        }
-    //    }, [rowLimit, setRowLimit]);
-    //
-    //    const selectedRowLimitText = React.useMemo(() => {
-    //        if (rowLimit >= 0) {
-    //            return formatNumber(rowLimit);
-    //        }
-    //        return 'none';
-    //    }, [rowLimit]);
-    //
-    //    const rowLimitMenuItems = rowLimitOptions.map((option) => ({
-    //        name: <span>{option.label}</span>,
-    //        onClick: () => setRowLimit(option.value),
-    //        checked: option.value === rowLimit,
-    //    }));
-    //
+    const [selected, setSelected] = React.useState(false);
+    const [backgroundColor, setBackgroundColor] = React.useState('red');
     return (
         <ToggleButton
             customButtonRenderer={() => (
@@ -292,15 +276,23 @@ const TestModeToggle: React.FC<{
                 </div>
             )}
             layout={['bottom', 'right']}
-            selected={false}
+            selected={selected}
+            //color={selected ? 'var(--color-accent)' : 'var(--text-light)'}
+            //color={selected ? 'red' : 'gray'}
+            //color={backgroundColor}
             onClick={() => {
-                // TODO: change button display
+                setSelected(!selected)//;                // TODO: change button display
                 // TODO: Change query area background too?
                 // TODO add analytics trackClick()
-                setTestMode(false) // TODO: pass the actual selected value
-            }}
+                setTestMode(selected)
+                //setBackgroundColor('green')
+            }
+
+            }
         >
-            <Icon name="Check" fill />
+            <StyledText>Test mode</StyledText>
+
+            <Icon name="Check" />
         </ToggleButton >
     );
 };

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
@@ -265,34 +265,21 @@ const TestModeToggle: React.FC<{
     setTestMode: (isTestMode: boolean) => void;
 }> = ({ setTestMode }) => {
     const [selected, setSelected] = React.useState(false);
-    const [backgroundColor, setBackgroundColor] = React.useState('red');
+
     return (
         <ToggleButton
-            customButtonRenderer={() => (
-                <div
-                    className="flex-center ph4"
-                    aria-label="In test mode, results are approximate but return faster by using sampling"
-                >
-                </div>
-            )}
-            layout={['bottom', 'right']}
-            selected={selected}
-            //color={selected ? 'var(--color-accent)' : 'var(--text-light)'}
-            //color={selected ? 'red' : 'gray'}
-            //color={backgroundColor}
+            color={selected ? 'accent' : 'light'}
             onClick={() => {
-                setSelected(!selected)//;                // TODO: change button display
+                setSelected(!selected)
                 // TODO: Change query area background too?
-                // TODO add analytics trackClick()
+                // TODO: add analytics trackClick()
                 setTestMode(selected)
-                //setBackgroundColor('green')
-            }
-
-            }
+            }}
         >
             <StyledText>Test mode</StyledText>
 
-            <Icon name="Check" />
+            <Icon name={selected ? 'Check' : ''} />
+
         </ToggleButton >
     );
 };

--- a/querybook/webapp/lib/web-worker/sql-editor.worker.ts
+++ b/querybook/webapp/lib/web-worker/sql-editor.worker.ts
@@ -15,6 +15,9 @@ context.addEventListener(
         const tokens = tokenize(code, { language });
         const statements = simpleParse(tokens);
 
+        //  The codeAnalysis contains a list of references to tables
+        //  and of table aliases. It is used for downstream linters which need
+        //  to know which  tables are being accessed in a query
         const codeAnalysis: ICodeAnalysis = {
             lineage: findTableReferenceAndAlias(statements),
         };

--- a/querybook/webapp/resource/queryExecution.ts
+++ b/querybook/webapp/resource/queryExecution.ts
@@ -168,7 +168,8 @@ export const TemplatedQueryResource = {
     validateQuery: (
         query: string,
         engineId: number,
-        templatedVariables: TDataDocMetaVariables
+        templatedVariables: TDataDocMetaVariables,
+        validators: Array<string>
     ) =>
         ds.save<IQueryValidationResult[]>(
             '/query/validate/',
@@ -176,6 +177,7 @@ export const TemplatedQueryResource = {
                 query,
                 var_config: templatedVariables,
                 engine_id: engineId,
+                validators: validators,
             },
             {
                 notifyOnError: false,


### PR DESCRIPTION
This is an early draft of an MVP, so the code is messy, there is missing functionality and testing

- Add a button to the UX which allows toggling "test mode" on and off. In test mode, query will be faster but maybe less accurate. For now, that means applying `TABLESAMPLE SYSTEM` to all tables in the query
- Implement a new type of `BaseQueryValidator` called `OptimizingValidator` which applies optimization to query and returns a modified query
- To enable this, change the `/query/validate` endpoint to take in a list of validators, and add a `diff` key to the `QueryValidationResult`, which contains the old query, new query, and opcodes to transform the old query to the new one
- Implement two subclasses of `OptimizingValidator` which respectively add and remove `TABLESAMPLE SYSTEM` to the references to tables in the query
