### PR TITLE
ui: comment db updates

### DIFF
--- a/querybook/server/models/comment.py
+++ b/querybook/server/models/comment.py
@@ -1,0 +1,108 @@
+import sqlalchemy as sql
+from app import db
+from lib.sqlalchemy import CRUDMixin
+from sqlalchemy.orm import relationship
+from const.db import mediumtext_length, name_length, now
+
+Base = db.Base
+
+
+class Comment(CRUDMixin, Base):
+    __tablename__ = "comment"
+
+    id = sql.Column(sql.Integer, primary_key=True)
+
+    created_at = sql.Column(sql.DateTime, default=now)
+    updated_at = sql.Column(sql.DateTime, default=now)
+    created_by = sql.Column(
+        sql.Integer, sql.ForeignKey("user.id", ondelete="SET NULL"), nullable=True
+    )
+
+    text = sql.Column(sql.Text(length=mediumtext_length))
+
+    has_thread = sql.Column(sql.Boolean, default=False)
+
+
+class CommentReaction(CRUDMixin, Base):
+    __tablename__ = "comment_reaction"
+
+    id = sql.Column(sql.Integer, primary_key=True, autoincrement=True)
+    comment_id = sql.Column(
+        sql.Integer,
+        sql.ForeignKey("comment.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+        unique=True,
+    )
+    reaction = sql.Column(
+        sql.String(length=name_length), index=True, unique=True, nullable=False
+    )
+    created_by = sql.Column(
+        sql.Integer, sql.ForeignKey("user.id", ondelete="SET NULL"), nullable=True
+    )
+
+
+class DataTableComment(CRUDMixin, Base):
+    __tablename__ = "data_table_comment"
+
+    id = sql.Column(sql.Integer, primary_key=True, autoincrement=True)
+    data_table_id = sql.Column(
+        sql.Integer,
+        sql.ForeignKey("data_table.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+        unique=True,
+    )
+    comment_id = sql.Column(
+        sql.Integer,
+        sql.ForeignKey("comment.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+
+    data_table = relationship("DataTable", uselist=False)
+    comment = relationship("Comment", uselist=False)
+
+
+class DataCellComment(CRUDMixin, Base):
+    __tablename__ = "data_cell_comment"
+
+    id = sql.Column(sql.Integer, primary_key=True, autoincrement=True)
+    data_cell_id = sql.Column(
+        sql.Integer,
+        sql.ForeignKey("data_cell.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+        unique=True,
+    )
+    comment_id = sql.Column(
+        sql.Integer,
+        sql.ForeignKey("comment.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+
+    data_cell = relationship("DataCell", uselist=False)
+    comment = relationship("Comment", uselist=False)
+
+
+class NestedComment(CRUDMixin, Base):
+    __tablename__ = "nested_comment"
+    id = sql.Column(sql.Integer, primary_key=True, autoincrement=True)
+    parent_comment_id = sql.Column(
+        sql.Integer,
+        sql.ForeignKey("comment.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+        unique=True,
+    )
+    child_comment_id = sql.Column(
+        sql.Integer,
+        sql.ForeignKey("comment.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+
+    child_comment = relationship(
+        "Comment", foreign_keys="NestedComment.child_comment_id", uselist=False
+    )

--- a/querybook/server/models/comment.py
+++ b/querybook/server/models/comment.py
@@ -20,7 +20,12 @@ class Comment(CRUDMixin, Base):
 
     text = sql.Column(sql.Text(length=mediumtext_length))
 
-    has_thread = sql.Column(sql.Boolean, default=False)
+    parent_comment_id = sql.Column(
+        sql.Integer,
+        sql.ForeignKey("comment.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
 
 
 class CommentReaction(CRUDMixin, Base):
@@ -32,11 +37,8 @@ class CommentReaction(CRUDMixin, Base):
         sql.ForeignKey("comment.id", ondelete="CASCADE"),
         index=True,
         nullable=False,
-        unique=True,
     )
-    reaction = sql.Column(
-        sql.String(length=name_length), index=True, unique=True, nullable=False
-    )
+    reaction = sql.Column(sql.String(length=name_length), index=True, nullable=False)
     created_by = sql.Column(
         sql.Integer, sql.ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
@@ -51,13 +53,11 @@ class DataTableComment(CRUDMixin, Base):
         sql.ForeignKey("data_table.id", ondelete="CASCADE"),
         index=True,
         nullable=False,
-        unique=True,
     )
     comment_id = sql.Column(
         sql.Integer,
         sql.ForeignKey("comment.id", ondelete="CASCADE"),
         nullable=False,
-        unique=True,
     )
 
     data_table = relationship("DataTable", uselist=False)
@@ -73,36 +73,12 @@ class DataCellComment(CRUDMixin, Base):
         sql.ForeignKey("data_cell.id", ondelete="CASCADE"),
         index=True,
         nullable=False,
-        unique=True,
     )
     comment_id = sql.Column(
         sql.Integer,
         sql.ForeignKey("comment.id", ondelete="CASCADE"),
         nullable=False,
-        unique=True,
     )
 
     data_cell = relationship("DataCell", uselist=False)
     comment = relationship("Comment", uselist=False)
-
-
-class NestedComment(CRUDMixin, Base):
-    __tablename__ = "nested_comment"
-    id = sql.Column(sql.Integer, primary_key=True, autoincrement=True)
-    parent_comment_id = sql.Column(
-        sql.Integer,
-        sql.ForeignKey("comment.id", ondelete="CASCADE"),
-        index=True,
-        nullable=False,
-        unique=True,
-    )
-    child_comment_id = sql.Column(
-        sql.Integer,
-        sql.ForeignKey("comment.id", ondelete="CASCADE"),
-        nullable=False,
-        unique=True,
-    )
-
-    child_comment = relationship(
-        "Comment", foreign_keys="NestedComment.child_comment_id", uselist=False
-    )

--- a/querybook/server/models/comment.py
+++ b/querybook/server/models/comment.py
@@ -23,7 +23,6 @@ class Comment(CRUDMixin, Base):
     parent_comment_id = sql.Column(
         sql.Integer,
         sql.ForeignKey("comment.id", ondelete="CASCADE"),
-        index=True,
         nullable=True,
     )
 
@@ -35,7 +34,6 @@ class CommentReaction(CRUDMixin, Base):
     comment_id = sql.Column(
         sql.Integer,
         sql.ForeignKey("comment.id", ondelete="CASCADE"),
-        index=True,
         nullable=False,
     )
     reaction = sql.Column(sql.String(length=name_length), index=True, nullable=False)
@@ -51,7 +49,6 @@ class DataTableComment(CRUDMixin, Base):
     data_table_id = sql.Column(
         sql.Integer,
         sql.ForeignKey("data_table.id", ondelete="CASCADE"),
-        index=True,
         nullable=False,
     )
     comment_id = sql.Column(
@@ -71,7 +68,6 @@ class DataCellComment(CRUDMixin, Base):
     data_cell_id = sql.Column(
         sql.Integer,
         sql.ForeignKey("data_cell.id", ondelete="CASCADE"),
-        index=True,
         nullable=False,
     )
     comment_id = sql.Column(

--- a/querybook/server/models/comment.py
+++ b/querybook/server/models/comment.py
@@ -36,7 +36,7 @@ class CommentReaction(CRUDMixin, Base):
         sql.ForeignKey("comment.id", ondelete="CASCADE"),
         nullable=False,
     )
-    reaction = sql.Column(sql.String(length=name_length), index=True, nullable=False)
+    reaction = sql.Column(sql.String(length=name_length), nullable=False)
     created_by = sql.Column(
         sql.Integer, sql.ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
@@ -57,7 +57,6 @@ class DataTableComment(CRUDMixin, Base):
         nullable=False,
     )
 
-    data_table = relationship("DataTable", uselist=False)
     comment = relationship("Comment", uselist=False)
 
 
@@ -76,5 +75,4 @@ class DataCellComment(CRUDMixin, Base):
         nullable=False,
     )
 
-    data_cell = relationship("DataCell", uselist=False)
     comment = relationship("Comment", uselist=False)

--- a/querybook/server/models/datadoc.py
+++ b/querybook/server/models/datadoc.py
@@ -117,6 +117,12 @@ class DataCell(Base):
         order_by="QueryExecution.id.desc()",
     )
 
+    comments = relationship(
+        "Comment",
+        secondary="data_cell_comment",
+        backref=backref("data_cell", uselist=False),
+    )
+
     def to_dict(self, with_query_executions=False):
         item = {
             "id": self.id,

--- a/querybook/server/models/metastore.py
+++ b/querybook/server/models/metastore.py
@@ -207,6 +207,11 @@ class DataTable(CRUDMixin, TruncateString("name", "type", "location"), Base):
     ownership = relationship(
         "DataTableOwnership", uselist=False, cascade="all, delete", passive_deletes=True
     )
+    comments = relationship(
+        "Comment",
+        secondary="data_table_comment",
+        backref=backref("data_table", uselist=False),
+    )
 
     def to_dict(
         self,


### PR DESCRIPTION
meeting requirements below

Support comment and comment threads (1 level)
Each comment can be edited after posted
Each comment can be attached to a datadoc cell, or a whole table (make sure this system is extensible if we want to add commenting elsewhere)
When a cell is cloned or copied, the comment is not copied. When a cell is cut, the comment is moved
Support reactions, like Slack
Support richtext in comments