### PR TITLE
ui: long table name fix

### DIFF
--- a/querybook/webapp/components/Search/SearchResultItem.scss
+++ b/querybook/webapp/components/Search/SearchResultItem.scss
@@ -31,15 +31,8 @@
                 padding-right: var(--padding-sm);
                 align-items: baseline;
 
-                > div:first-child {
-                    flex-grow: 1;
-                    overflow: hidden;
-                    .Text {
-                        width: 100%;
-                        .result-item-title {
-                            overflow-wrap: break-word;
-                        }
-                    }
+                .result-item-title {
+                    overflow-wrap: anywhere;
                 }
 
                 .result-item-timestamp {

--- a/querybook/webapp/components/Search/SearchResultItem.scss
+++ b/querybook/webapp/components/Search/SearchResultItem.scss
@@ -31,10 +31,18 @@
                 padding-right: var(--padding-sm);
                 align-items: baseline;
 
-                .result-item-title {
-                    overflow: hidden;
+                > div:first-child {
+                    overflow-wrap: break-word;
+                    max-width: calc(100% - 140px);
+                    div {
+                        width: 100%;
+                        text-align: left;
+                    }
+                }
+                > div:last-child {
+                    text-align: right;
                     white-space: nowrap;
-                    text-overflow: ellipsis;
+                    min-width: 140px;
                 }
             }
 

--- a/querybook/webapp/components/Search/SearchResultItem.scss
+++ b/querybook/webapp/components/Search/SearchResultItem.scss
@@ -30,16 +30,20 @@
             .result-items-top {
                 padding-right: var(--padding-sm);
                 align-items: baseline;
+                width: 100%;
 
                 > div:first-child {
-                    overflow-wrap: break-word;
-                    max-width: calc(100% - 140px);
-                    div {
+                    flex-grow: 1;
+                    overflow: hidden;
+                    .Text {
                         width: 100%;
-                        text-align: left;
+                        .result-item-title {
+                            overflow-wrap: break-word;
+                        }
                     }
                 }
-                > div:last-child {
+
+                > div:last-child:not(:first-child) {
                     text-align: right;
                     white-space: nowrap;
                     min-width: 140px;

--- a/querybook/webapp/components/Search/SearchResultItem.scss
+++ b/querybook/webapp/components/Search/SearchResultItem.scss
@@ -30,7 +30,6 @@
             .result-items-top {
                 padding-right: var(--padding-sm);
                 align-items: baseline;
-                width: 100%;
 
                 > div:first-child {
                     flex-grow: 1;
@@ -43,7 +42,7 @@
                     }
                 }
 
-                > div:last-child:not(:first-child) {
+                .result-item-timestamp {
                     text-align: right;
                     white-space: nowrap;
                     min-width: 140px;

--- a/querybook/webapp/components/Search/SearchResultItem.tsx
+++ b/querybook/webapp/components/Search/SearchResultItem.tsx
@@ -409,7 +409,7 @@ export const DataTableItem: React.FunctionComponent<IDataTableItemProps> = ({
                     <div className="result-items-top horizontal-space-between">
                         <div className="flex-row">
                             <HighlightTitle
-                                title={`${schema}.${name}${schema}.${name}${schema}.${name}${schema}.${name}`}
+                                title={`${schema}.${name}`}
                                 searchString={searchString}
                             />
                             {goldenIcon}

--- a/querybook/webapp/components/Search/SearchResultItem.tsx
+++ b/querybook/webapp/components/Search/SearchResultItem.tsx
@@ -409,7 +409,7 @@ export const DataTableItem: React.FunctionComponent<IDataTableItemProps> = ({
                     <div className="result-items-top horizontal-space-between">
                         <div className="flex-row">
                             <HighlightTitle
-                                title={`${schema}.${name}${schema}.${name}${schema}.${name}${schema}.${name}${schema}.${name}`}
+                                title={`${schema}.${name}`}
                                 searchString={searchString}
                             />
                             {goldenIcon}

--- a/querybook/webapp/components/Search/SearchResultItem.tsx
+++ b/querybook/webapp/components/Search/SearchResultItem.tsx
@@ -409,7 +409,7 @@ export const DataTableItem: React.FunctionComponent<IDataTableItemProps> = ({
                     <div className="result-items-top horizontal-space-between">
                         <div className="flex-row">
                             <HighlightTitle
-                                title={`${schema}.${name}`}
+                                title={`${schema}.${name}${schema}.${name}${schema}.${name}${schema}.${name}`}
                                 searchString={searchString}
                             />
                             {goldenIcon}

--- a/querybook/webapp/components/Search/SearchResultItem.tsx
+++ b/querybook/webapp/components/Search/SearchResultItem.tsx
@@ -417,7 +417,7 @@ export const DataTableItem: React.FunctionComponent<IDataTableItemProps> = ({
                         <StyledText
                             size="small"
                             color="lightest"
-                            className="result-item-timestamp"
+                            className="result-item-timestamp ml8"
                         >
                             {generateFormattedDate(createdAt, 'X')}
                         </StyledText>

--- a/querybook/webapp/components/Search/SearchResultItem.tsx
+++ b/querybook/webapp/components/Search/SearchResultItem.tsx
@@ -409,12 +409,16 @@ export const DataTableItem: React.FunctionComponent<IDataTableItemProps> = ({
                     <div className="result-items-top horizontal-space-between">
                         <div className="flex-row">
                             <HighlightTitle
-                                title={`${schema}.${name}`}
+                                title={`${schema}.${name}${schema}.${name}${schema}.${name}${schema}.${name}${schema}.${name}`}
                                 searchString={searchString}
                             />
                             {goldenIcon}
                         </div>
-                        <StyledText size="small" color="lightest">
+                        <StyledText
+                            size="small"
+                            color="lightest"
+                            className="result-item-timestamp"
+                        >
                             {generateFormattedDate(createdAt, 'X')}
                         </StyledText>
                     </div>


### PR DESCRIPTION

<img width="732" alt="Screenshot 2023-05-10 at 2 54 24 PM" src="https://github.com/pinterest/querybook/assets/29313935/54ce4369-3466-4d54-ab4f-8c4b011a440b">
<img width="751" alt="Screenshot 2023-05-10 at 2 54 06 PM" src="https://github.com/pinterest/querybook/assets/29313935/e640cd92-4bf6-4f20-a77d-7b21506edaae">
<img width="735" alt="Screenshot 2023-05-10 at 2 53 44 PM" src="https://github.com/pinterest/querybook/assets/29313935/686738bb-48d1-450a-a780-294eaebb3b3a">
<img width="738" alt="Screenshot 2023-05-10 at 2 53 04 PM" src="https://github.com/pinterest/querybook/assets/29313935/f5ca15d2-be0b-44b0-b2c6-46101a37b821">


wrapping long table names/any search res title