### PR TITLE
feat: tune table search ranking

### DIFF
--- a/querybook/server/lib/elasticsearch/search_table.py
+++ b/querybook/server/lib/elasticsearch/search_table.py
@@ -35,27 +35,17 @@ def _match_table_word_fields(fields):
 
 
 def _match_table_phrase_queries(fields, keywords):
-    phrase_queries = []
-
-    for field in fields:
-        if field == "table_name":
-            phrase_queries.append(
-                {"match_phrase": {"full_name": {"query": keywords, "boost": 10}}}
-            )
-        elif field == "column":
-            phrase_queries.append({"match_phrase": {"columns": {"query": keywords}}})
-
-    # boost the matches from data element descritpions if there are no search fields specified
-    if len(phrase_queries) == 0:
-        phrase_queries.append(
-            {
-                "match_phrase": {
-                    "data_element_descriptions": {"query": keywords, "boost": 10}
-                }
+    # boos score for phrase match
+    return [
+        {"match_phrase": {"full_name": {"query": keywords, "boost": 1}}},
+        {"match_phrase": {"description": {"query": keywords, "boost": 1}}},
+        {"match_phrase": {"column_descriptions": {"query": keywords, "boost": 1}}},
+        {
+            "match_phrase": {
+                "data_element_descriptions": {"query": keywords, "boost": 1}
             }
-        )
-
-    return phrase_queries
+        },
+    ]
 
 
 def construct_tables_query(

--- a/querybook/server/lib/elasticsearch/search_table.py
+++ b/querybook/server/lib/elasticsearch/search_table.py
@@ -35,7 +35,15 @@ def _match_table_word_fields(fields):
 
 
 def _match_table_phrase_queries(fields, keywords):
-    phrase_queries = []
+    # always boost the matches from data element descritpions, as they usually have the most relevant information
+    phrase_queries = [
+        {
+            "match_phrase": {
+                "data_element_descriptions": {"query": keywords, "boost": 10}
+            }
+        }
+    ]
+
     for field in fields:
         if field == "table_name":
             phrase_queries.append(
@@ -90,10 +98,10 @@ def construct_tables_query(
     keywords_query = {
         "function_score": {
             "query": keywords_query,
-            "boost_mode": "multiply",
+            "boost_mode": "sum",
             "script_score": {
                 "script": {
-                    "source": "1 + (doc['importance_score'].value + (doc['golden'].value ? 1 : 0))"
+                    "source": "doc['importance_score'].value * 10 + (doc['golden'].value ? 10 : 0)"
                 }
             },
         }

--- a/querybook/server/lib/elasticsearch/search_table.py
+++ b/querybook/server/lib/elasticsearch/search_table.py
@@ -35,14 +35,7 @@ def _match_table_word_fields(fields):
 
 
 def _match_table_phrase_queries(fields, keywords):
-    # always boost the matches from data element descritpions, as they usually have the most relevant information
-    phrase_queries = [
-        {
-            "match_phrase": {
-                "data_element_descriptions": {"query": keywords, "boost": 10}
-            }
-        }
-    ]
+    phrase_queries = []
 
     for field in fields:
         if field == "table_name":
@@ -51,6 +44,17 @@ def _match_table_phrase_queries(fields, keywords):
             )
         elif field == "column":
             phrase_queries.append({"match_phrase": {"columns": {"query": keywords}}})
+
+    # boost the matches from data element descritpions if there are no search fields specified
+    if len(phrase_queries) == 0:
+        phrase_queries.append(
+            {
+                "match_phrase": {
+                    "data_element_descriptions": {"query": keywords, "boost": 10}
+                }
+            }
+        )
+
     return phrase_queries
 
 


### PR DESCRIPTION
Adjust the table search rank score
 - Add more weights for high `importance_score` and `golden` tables
 - Change the boost mode from `multiply` to `sum` to honor more on the `script_score` 
 - Boost phrase matches from table name, table/column/data_element descriptions`