### PR TITLE
fix: showing values from a null value

### DIFF
--- a/querybook/webapp/lib/chart/chart-meta-processing.ts
+++ b/querybook/webapp/lib/chart/chart-meta-processing.ts
@@ -11,13 +11,13 @@ import { IDataChartCellMeta } from 'const/datadoc';
 import {
     ChartDataAggType,
     ChartScaleFormat,
+    chartScaleToChartJSScale,
     ChartScaleType,
     ChartSize,
     ChartValueDisplayType,
     ChartValueSourceType,
     IChartAxisMeta,
     IChartFormValues,
-    chartScaleToChartJSScale,
 } from 'const/dataDocChart';
 import { StatementExecutionDefaultResultSize } from 'const/queryResultLimit';
 import type { DeepPartial } from 'lib/typescript';
@@ -206,7 +206,7 @@ export function mapMetaToChartOptions(
                         return context.chart.data.datasets[context.datasetIndex]
                             .label;
                     }
-                    return value.y;
+                    return value?.y;
                 },
                 display:
                     meta.visual.values?.display === ChartValueDisplayType.TRUE


### PR DESCRIPTION
After aggregation, the value may become null for some categories, which will lead to below exception
![image](https://github.com/pinterest/querybook/assets/8308723/040328e1-86e3-4ac0-b72d-b1143765950a)
