### PR TITLE
feat: Injectable Secrets into the Helm Chart

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -30,3 +30,11 @@ Create chart name and version as used by the chart label.
 {{- define "querybook.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{/*
+Return secret name to be used based on provided values.
+*/}}
+{{- define "querybook.secrets" -}}
+{{- $inputSecret := print (include "querybook.fullname" .) "-secret" -}}
+{{- default $inputSecret .Values.existingSecret | quote -}}
+{{- end -}}

--- a/helm/templates/scheduler/scheduler-deployment.yaml
+++ b/helm/templates/scheduler/scheduler-deployment.yaml
@@ -38,22 +38,22 @@ spec:
             - name: FLASK_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "querybook.fullname" . }}-secret
+                  name: {{ template "querybook.secrets" . }}
                   key: FLASK_SECRET_KEY
             - name: DATABASE_CONN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "querybook.fullname" . }}-secret
+                  name: {{ template "querybook.secrets" . }}
                   key: DATABASE_CONN
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "querybook.fullname" . }}-secret
+                  name: {{ template "querybook.secrets" . }}
                   key: REDIS_URL
             - name: ELASTICSEARCH_HOST
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "querybook.fullname" . }}-secret
+                  name: {{ template "querybook.secrets" . }}
                   key: ELASTICSEARCH_HOST
             {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key | quote}}

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,3 +15,4 @@ data:
   DATABASE_CONN: {{ .Values.secret.database_conn | toString | b64enc }}
   REDIS_URL: {{ .Values.secret.redis_url | toString | b64enc }}
   ELASTICSEARCH_HOST: {{ .Values.secret.elasticsearch_host | toString | b64enc }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -147,3 +147,7 @@ secret:
   database_conn: mysql+pymysql://test:passw0rd@mysql:3306/querybook2?charset=utf8mb4
   redis_url:  redis://redis:6379/0
   elasticsearch_host: elasticsearch:9200
+
+# existingSecret -- Use an existing Secret which contains the above secret values in the same format and base64 encoded.
+## If set, this parameter takes precedence over "secret".
+existingSecret:


### PR DESCRIPTION
Fixes: https://github.com/pinterest/querybook/issues/1259
Allows a user to specify the name of an existing Kubernetes Secret, or defaults to the secret specified in `values.yaml`