### PR TITLE
Add monkey patching and api  plugin

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -39,4 +39,4 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install -r requirements/base.txt
                   pip install -r requirements/test.txt
-            - run: PYTHONPATH=querybook/server:querybook/plugins ./querybook/scripts/run_test --python
+            - run: PYTHONPATH=querybook/server:plugins ./querybook/scripts/run_test --python

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -39,4 +39,4 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install -r requirements/base.txt
                   pip install -r requirements/test.txt
-            - run: PYTHONPATH=querybook/server ./querybook/scripts/run_test --python
+            - run: PYTHONPATH=querybook/server:querybook/plugins ./querybook/scripts/run_test --python

--- a/docs_website/docs/integrations/plugins.md
+++ b/docs_website/docs/integrations/plugins.md
@@ -61,11 +61,22 @@ Web page plugin allows you to inject custom js, css to Querybook. Place your cus
 Lineage plugin allows you to extend Querybook to fetch lineage information from a custom data lineage backend. Please check [Add Lineage guide](./add_lineage.md) for more details.
 
 ### Event Logger Plugin
+
 By default, Querybook supports printing/storing event logs(e.g. API requests, frontend instrumentation logs and etc) to console and mysql db. If you'd like to store event logs to somewhere else, you can add a custom event logger. Please check [Add Event Logger guide](./add_event_logger.md) for more details.
 
 ### DAG Exporter Plugin (Experimental)
 
 DAG Exporters allow users to create a workflow from Query Cells in DataDocs. Querybook by default provides "demo_dag_exporter" code as an example but it needs to included in the plugin exporter to be used and does not work out of the box. Please Check [Add DAG Exporter guide](./add_dag_exporter.md) to learn how to add a dag exporter.
+
+### API Plugin
+
+API plugin allows you to add new or override existing API endpoints. Please check the folder of `querybook/plugins/api_plugin` for example.
+
+
+### Monkey Patch Plugin
+
+Similar to API plugin, monkey patch plugin allows you to override an existing API module or function. Please check the folder of `querybook/plugins/monkey_patch_plugin` for example.
+
 
 ## Installing Plugins
 

--- a/docs_website/docs/integrations/plugins.md
+++ b/docs_website/docs/integrations/plugins.md
@@ -70,12 +70,12 @@ DAG Exporters allow users to create a workflow from Query Cells in DataDocs. Que
 
 ### API Plugin
 
-API plugin allows you to add new or override existing API endpoints. Please check the folder of `querybook/plugins/api_plugin` for example.
+The API plugin enables you to create new or modify existing API endpoints. For examples of its usage, please refer to the `querybook/plugins/api_plugin` folder.
 
 
 ### Monkey Patch Plugin
 
-Similar to API plugin, monkey patch plugin allows you to override an existing API module or function. Please check the folder of `querybook/plugins/monkey_patch_plugin` for example.
+Similar to the API plugin, the monkey patch plugin allows you to override or modify existing modules or functions. To see examples of how it works, please check the `querybook/plugins/monkey_patch_plugin` folder.
 
 
 ## Installing Plugins

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.23.2",
+    "version": "3.23.3",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/plugins/api_plugin/__init__.py
+++ b/plugins/api_plugin/__init__.py
@@ -1,0 +1,1 @@
+from . import test  # noqa: F401

--- a/plugins/api_plugin/test.py
+++ b/plugins/api_plugin/test.py
@@ -1,0 +1,9 @@
+from app.datasource import register
+
+
+@register("/api_plugin/test/")
+def demo_api_plugin():
+    """This is a test API to demo how to add a new API endpoint.
+    For overridding an existing API endpoint, please use the same path but different function name.
+    """
+    return "This is a response from the API plugin!"

--- a/plugins/monkey_patch_plugin/__init__.py
+++ b/plugins/monkey_patch_plugin/__init__.py
@@ -1,0 +1,2 @@
+def patch():
+    pass

--- a/plugins/monkey_patch_plugin/__init__.py
+++ b/plugins/monkey_patch_plugin/__init__.py
@@ -1,2 +1,5 @@
-def patch():
-    pass
+# NOTE: If you want to add or override an API endpoint, please use API plugin instead.
+
+# from .demo import patch as demo_patch
+#
+# demo_patch()

--- a/plugins/monkey_patch_plugin/demo.py
+++ b/plugins/monkey_patch_plugin/demo.py
@@ -1,0 +1,17 @@
+# from app.db import with_session
+# from logic import demo as demo_logic
+
+# old_set_up_demo = demo_logic.set_up_demo
+
+
+# @with_session
+# def set_up_demo(uid, session=None):
+#     ret = old_set_up_demo(uid, session=session)
+
+#     # Your logic here, e.g. add some extra engines
+
+#     return ret
+
+
+# def patch():
+#     demo_logic.set_up_demo = set_up_demo

--- a/querybook/server/datasources/__init__.py
+++ b/querybook/server/datasources/__init__.py
@@ -17,6 +17,9 @@ from . import event_log
 from . import data_element
 from . import ai_assistant
 
+# Keep this at the end of imports to make sure the plugin APIs override the default ones
+import api_plugin
+
 # Flake8 :(
 admin
 dag_exporter
@@ -36,3 +39,4 @@ tag
 event_log
 data_element
 ai_assistant
+api_plugin

--- a/querybook/server/datasources/admin.py
+++ b/querybook/server/datasources/admin.py
@@ -3,7 +3,6 @@ from flask_login import current_user
 from app.datasource import register, admin_only, api_assert
 from app.db import DBSession
 from const.admin import AdminOperation, AdminItemType
-from const.schedule import ScheduleTaskType
 from datasources.admin_audit_log import with_admin_audit_log
 from env import QuerybookSettings
 
@@ -21,11 +20,8 @@ from lib.query_analysis.validation.all_validators import ALL_QUERY_VALIDATORS_BY
 from logic import admin as logic
 from logic import user as user_logic
 from logic import environment as environment_logic
-from logic import schedule as schedule_logic
-from logic import metastore as metastore_logic
 from logic import demo as demo_logic
 from models.admin import Announcement, QueryMetastore, QueryEngine, AdminAuditLog
-from models.schedule import TaskSchedule
 
 
 @register(

--- a/querybook/server/datasources/admin.py
+++ b/querybook/server/datasources/admin.py
@@ -262,7 +262,6 @@ def get_all_query_metastore_loaders_admin():
 )
 @admin_only
 def get_all_query_metastores_admin():
-
     with DBSession() as session:
         metastores = logic.get_all_query_metastore(session=session)
         metastores_dict = [metastore.to_dict_admin() for metastore in metastores]
@@ -552,114 +551,7 @@ def get_api_access_tokens_admin():
 @register("/admin/demo_set_up/", methods=["POST"])
 @admin_only
 def exec_demo_set_up():
-    with DBSession() as session:
-        environment = environment_logic.create_environment(
-            name="demo_environment",
-            description="Demo environment",
-            image="",
-            public=True,
-            commit=False,
-            session=session,
-        )
-
-        local_db_conn = "sqlite:///demo/demo_data.db"
-        metastore_id = QueryMetastore.create(
-            {
-                "name": "demo_metastore",
-                "metastore_params": {
-                    "connection_string": local_db_conn,
-                },
-                "loader": "SqlAlchemyMetastoreLoader",
-                "acl_control": {},
-            },
-            commit=False,
-            session=session,
-        ).id
-
-        engine_id = QueryEngine.create(
-            {
-                "name": "sqlite",
-                "description": "SQLite Engine",
-                "language": "sqlite",
-                "executor": "sqlalchemy",
-                "executor_params": {
-                    "connection_string": local_db_conn,
-                },
-                "environment_id": environment.id,
-                "metastore_id": metastore_id,
-            },
-            commit=False,
-            session=session,
-        ).id
-
-        logic.add_query_engine_to_environment(
-            environment.id, engine_id, commit=False, session=session
-        )
-
-        task_schedule_id = TaskSchedule.create(
-            {
-                "name": "update_metastore_{}".format(metastore_id),
-                "task": "tasks.update_metastore.update_metastore",
-                "cron": "0 0 * * *",
-                "args": [metastore_id],
-                "task_type": ScheduleTaskType.PROD,
-                "enabled": True,
-            },
-            # commit=False,
-            session=session,
-        ).id
-        schedule_logic.run_and_log_scheduled_task(
-            scheduled_task_id=task_schedule_id, wait_to_finish=True, session=session
-        )
-
-        golden_table = metastore_logic.get_table_by_name(
-            schema_name="main",
-            name="world_happiness_2019",
-            metastore_id=metastore_id,
-            session=session,
-        )
-        if golden_table:
-            metastore_logic.update_table(
-                id=golden_table.id, golden=True, session=session
-            )
-            metastore_logic.update_table_information(
-                data_table_id=golden_table.id,
-                description="The World Happiness Report is a landmark survey of the state of global happiness. The first report was published in 2012, the second in 2013, the third in 2015, and the fourth in the 2016 Update. The World Happiness 2017, which ranks 155 countries by their happiness levels, was released at the United Nations at an event celebrating International Day of Happiness on March 20th. The report continues to gain global recognition as governments, organizations and civil society increasingly use happiness indicators to inform their policy-making decisions. Leading experts across fields – economics, psychology, survey analysis, national statistics, health, public policy and more – describe how measurements of well-being can be used effectively to assess the progress of nations. The reports review the state of happiness in the world today and show how the new science of happiness explains personal and national variations in happiness.",
-                session=session,
-            )
-            demo_logic.create_demo_table_stats(
-                table_id=golden_table.id, uid=current_user.id, session=session
-            )
-            score_column = metastore_logic.get_column_by_name(
-                name="Score", table_id=golden_table.id, session=session
-            )
-            demo_logic.create_demo_table_column_stats(
-                column_id=score_column.id, uid=current_user.id, session=session
-            )
-
-        demo_logic.create_demo_data_elements(metastore_id, session=session)
-        demo_logic.create_demo_tags(metastore_id, session=session)
-
-        schedule_logic.run_and_log_scheduled_task(
-            scheduled_task_id=task_schedule_id, session=session
-        )
-
-        demo_logic.create_demo_lineage(metastore_id, current_user.id, session=session)
-
-        data_doc_id = demo_logic.create_demo_data_doc(
-            environment_id=environment.id,
-            engine_id=engine_id,
-            uid=current_user.id,
-            session=session,
-        )
-
-        if data_doc_id:
-            session.commit()
-
-            return {
-                "environment": environment.name,
-                "data_doc_id": data_doc_id,
-            }
+    return demo_logic.set_up_demo(current_user.id)
 
 
 admin_item_type_values = set(item.value for item in AdminItemType)

--- a/querybook/server/lib/patch.py
+++ b/querybook/server/lib/patch.py
@@ -29,6 +29,16 @@ def monkey_patch_disable_watchdog():
     reloader_loops["auto"] = reloader_loops["stat"]
 
 
+def monkey_patch_plugin():
+    """This enables monkey patching any module or function through the monkey_patch_plugin"""
+    from lib.utils.import_helper import import_module_with_default
+
+    patch = import_module_with_default("monkey_patch_plugin", "patch", default=None)
+    if patch is not None:
+        patch()
+
+
 def patch_all():
     monkey_patch_gevent_websocket()
     monkey_patch_disable_watchdog()
+    monkey_patch_plugin()

--- a/querybook/server/lib/patch.py
+++ b/querybook/server/lib/patch.py
@@ -30,12 +30,8 @@ def monkey_patch_disable_watchdog():
 
 
 def monkey_patch_plugin():
-    """This enables monkey patching any module or function through the monkey_patch_plugin"""
-    from lib.utils.import_helper import import_module_with_default
-
-    patch = import_module_with_default("monkey_patch_plugin", "patch", default=None)
-    if patch is not None:
-        patch()
+    """This enables monkey patching any module or function through the monkey_patch_plugin."""
+    import monkey_patch_plugin
 
 
 def patch_all():

--- a/querybook/server/lib/patch.py
+++ b/querybook/server/lib/patch.py
@@ -31,7 +31,7 @@ def monkey_patch_disable_watchdog():
 
 def monkey_patch_plugin():
     """This enables monkey patching any module or function through the monkey_patch_plugin."""
-    import monkey_patch_plugin
+    import monkey_patch_plugin  # noqa: F401
 
 
 def patch_all():

--- a/querybook/server/logic/demo.py
+++ b/querybook/server/logic/demo.py
@@ -1,19 +1,131 @@
 from app.db import with_session
 
-from logic import (
-    metastore as m_logic,
-    datadoc as data_doc_logic,
-    user as user_logic,
-    tag as tag_logic,
-    data_element as de_logic,
-)
-
 from const.data_element import (
     DataElementTuple,
     DataElementAssociationTuple,
     DataElementAssociationType,
 )
+from const.schedule import ScheduleTaskType
 from lib.lineage.utils import lineage as lineage_logic
+from logic import (
+    admin as admin_logic,
+    environment as environment_logic,
+    metastore as m_logic,
+    datadoc as data_doc_logic,
+    user as user_logic,
+    tag as tag_logic,
+    data_element as de_logic,
+    schedule as schedule_logic,
+)
+from models.admin import QueryMetastore, QueryEngine
+from models.schedule import TaskSchedule
+
+
+@with_session
+def set_up_demo(uid: int, session=None):
+    environment = environment_logic.create_environment(
+        name="demo_environment",
+        description="Demo environment",
+        image="",
+        public=True,
+        commit=False,
+        session=session,
+    )
+
+    local_db_conn = "sqlite:///demo/demo_data.db"
+    metastore_id = QueryMetastore.create(
+        {
+            "name": "demo_metastore",
+            "metastore_params": {
+                "connection_string": local_db_conn,
+            },
+            "loader": "SqlAlchemyMetastoreLoader",
+            "acl_control": {},
+        },
+        commit=False,
+        session=session,
+    ).id
+
+    engine_id = QueryEngine.create(
+        {
+            "name": "sqlite",
+            "description": "SQLite Engine",
+            "language": "sqlite",
+            "executor": "sqlalchemy",
+            "executor_params": {
+                "connection_string": local_db_conn,
+            },
+            "environment_id": environment.id,
+            "metastore_id": metastore_id,
+        },
+        commit=False,
+        session=session,
+    ).id
+
+    admin_logic.add_query_engine_to_environment(
+        environment.id, engine_id, commit=False, session=session
+    )
+
+    task_schedule_id = TaskSchedule.create(
+        {
+            "name": "update_metastore_{}".format(metastore_id),
+            "task": "tasks.update_metastore.update_metastore",
+            "cron": "0 0 * * *",
+            "args": [metastore_id],
+            "task_type": ScheduleTaskType.PROD,
+            "enabled": True,
+        },
+        # commit=False,
+        session=session,
+    ).id
+    schedule_logic.run_and_log_scheduled_task(
+        scheduled_task_id=task_schedule_id, wait_to_finish=True, session=session
+    )
+
+    golden_table = m_logic.get_table_by_name(
+        schema_name="main",
+        name="world_happiness_2019",
+        metastore_id=metastore_id,
+        session=session,
+    )
+    if golden_table:
+        m_logic.update_table(id=golden_table.id, golden=True, session=session)
+        m_logic.update_table_information(
+            data_table_id=golden_table.id,
+            description="The World Happiness Report is a landmark survey of the state of global happiness. The first report was published in 2012, the second in 2013, the third in 2015, and the fourth in the 2016 Update. The World Happiness 2017, which ranks 155 countries by their happiness levels, was released at the United Nations at an event celebrating International Day of Happiness on March 20th. The report continues to gain global recognition as governments, organizations and civil society increasingly use happiness indicators to inform their policy-making decisions. Leading experts across fields – economics, psychology, survey analysis, national statistics, health, public policy and more – describe how measurements of well-being can be used effectively to assess the progress of nations. The reports review the state of happiness in the world today and show how the new science of happiness explains personal and national variations in happiness.",
+            session=session,
+        )
+        create_demo_table_stats(table_id=golden_table.id, uid=uid, session=session)
+        score_column = m_logic.get_column_by_name(
+            name="Score", table_id=golden_table.id, session=session
+        )
+        create_demo_table_column_stats(
+            column_id=score_column.id, uid=uid, session=session
+        )
+
+    create_demo_data_elements(metastore_id, session=session)
+    create_demo_tags(metastore_id, session=session)
+
+    schedule_logic.run_and_log_scheduled_task(
+        scheduled_task_id=task_schedule_id, session=session
+    )
+
+    create_demo_lineage(metastore_id, uid, session=session)
+
+    data_doc_id = create_demo_data_doc(
+        environment_id=environment.id,
+        engine_id=engine_id,
+        uid=uid,
+        session=session,
+    )
+
+    if data_doc_id:
+        session.commit()
+
+        return {
+            "environment": environment.name,
+            "data_doc_id": data_doc_id,
+        }
 
 
 @with_session
@@ -129,7 +241,11 @@ def create_demo_data_doc(environment_id, engine_id, uid, session=None):
         environment_id=environment_id,
         owner_uid=uid,
         title="World Happiness Report (2015-2019)",
-        meta={"Region": "Western Europe"},
+        meta={
+            "variables": [
+                {"name": "Region", "type": "string", "value": "Western Europe"}
+            ]
+        },
         session=session,
     ).id
     # create cells


### PR DESCRIPTION
Adding a monkey patch and api plugin, so that people can override some of the api endpoints and functions to meet their needs. E.g. for the demo setup, we may want to have a different setup internally.