### PR TITLE
upgrade nodejs from v16 to v18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN rm -rf /var/lib/apt/lists/* \
     build-essential \
     libssl-dev \
     libldap2-dev \
-    && curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
     nodejs \
     && apt-get clean


### PR DESCRIPTION
Got below error when building the docker image due to npm not found, seems like something wrong with nodejs 16 installation. Upgrading to v18 works
```
 => CACHED [ 2/11] RUN rm -rf /var/lib/apt/lists/*     && apt-get update     && DEBIAN_FRONTEND=noninteractive apt-get install --no-insta  0.0s
 => ERROR [ 3/11] RUN npm i -g npm@8.5.0     && npm i -g yarn@^1.22.10     && npm explore npm --global -- npm install node-gyp@9.0.0       0.3s
------
 > [ 3/11] RUN npm i -g npm@8.5.0     && npm i -g yarn@^1.22.10     && npm explore npm --global -- npm install node-gyp@9.0.0     && yarn config set cache-folder /mnt/yarn-cache/cache     && yarn config set yarn-offline-mirror /mnt/yarn-offline-mirror:
#0 0.264 /bin/sh: 1: npm: not found
```


