### PR TITLE
add lowercase filter to user_content_analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.23.3",
+    "version": "3.23.4",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/config/elasticsearch.yaml
+++ b/querybook/config/elasticsearch.yaml
@@ -166,6 +166,8 @@ tables:
                         tokenizer: standard
                         char_filter:
                             - html_strip
+                        filter:
+                            - lowercase
                     table_name_lowercase:
                         type: custom
                         tokenizer: alphanum_tokenizer
@@ -266,6 +268,8 @@ boards:
                         tokenizer: standard
                         char_filter:
                             - html_strip
+                        filter:
+                            - lowercase
                 normalizer:
                     case_insensitive:
                         type: custom


### PR DESCRIPTION
Table/column/data element/board descriptions are now indexed using a case-sensitive analyzer, which may cause some search queries to fail.

Here we're updating the filter of the analyzer. 

**NOTE**:  all impacted documents will need to be reindexed.