### PR TITLE
fix: Ignore monkey patch/api plugin import error

### DIFF
--- a/querybook/server/datasources/__init__.py
+++ b/querybook/server/datasources/__init__.py
@@ -18,7 +18,10 @@ from . import data_element
 from . import ai_assistant
 
 # Keep this at the end of imports to make sure the plugin APIs override the default ones
-import api_plugin
+try:
+    import api_plugin
+except ImportError:
+    pass  # No api_plugin found
 
 # Flake8 :(
 admin

--- a/querybook/server/lib/patch.py
+++ b/querybook/server/lib/patch.py
@@ -31,7 +31,10 @@ def monkey_patch_disable_watchdog():
 
 def monkey_patch_plugin():
     """This enables monkey patching any module or function through the monkey_patch_plugin."""
-    import monkey_patch_plugin  # noqa: F401
+    try:
+        import monkey_patch_plugin  # noqa: F401
+    except ImportError:
+        pass  # No monkey_patch_plugin found
 
 
 def patch_all():


### PR DESCRIPTION
If the module doesn't exist, it will cause the service failure. Here we'll catch the error and just ignore it.