### PR TITLE
fix: crash on stream parser error

### DIFF
--- a/querybook/webapp/lib/datasource.ts
+++ b/querybook/webapp/lib/datasource.ts
@@ -177,7 +177,7 @@ function streamDatasource(
     url: string,
     params?: Record<string, unknown>,
     onStreaming?: (data: { [key: string]: string }) => void,
-    onStreamingEnd?: (data?: { [key: string]: string }) => void
+    onStreamingEnd?: (data: { [key: string]: string }) => void
 ) {
     const eventSource = new EventSource(
         `${url}?params=${JSON.stringify(params)}`
@@ -191,7 +191,7 @@ function streamDatasource(
     eventSource.addEventListener('error', (e) => {
         console.error(e);
         eventSource.close();
-        onStreamingEnd?.();
+        onStreamingEnd?.(parser.result);
         if (e instanceof MessageEvent) {
             toast.error(JSON.parse(e.data).data);
         }


### PR DESCRIPTION
when there is error occurred, we'll also need to pass parser result back, otherwise, it will get undefined error