### PR TITLE
Fix: query title disappears when opening a datadoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.25.1",
+    "version": "3.25.2",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/components/QueryCellTitle/QueryCellTitle.tsx
+++ b/querybook/webapp/components/QueryCellTitle/QueryCellTitle.tsx
@@ -38,8 +38,10 @@ export const QueryCellTitle: React.FC<IQueryCellTitleProps> = ({
     const { data: title } = streamData;
 
     useEffect(() => {
-        onChange(title);
-    }, [title]);
+        if (streamStatus === StreamStatus.STREAMING && title) {
+            onChange(title);
+        }
+    }, [streamStatus, title]);
 
     const handleTitleGenerationClick = useCallback(() => {
         startStream();

--- a/querybook/webapp/components/QueryCellTitle/QueryCellTitle.tsx
+++ b/querybook/webapp/components/QueryCellTitle/QueryCellTitle.tsx
@@ -38,7 +38,7 @@ export const QueryCellTitle: React.FC<IQueryCellTitleProps> = ({
     const { data: title } = streamData;
 
     useEffect(() => {
-        if (streamStatus === StreamStatus.STREAMING && title) {
+        if (streamStatus !== StreamStatus.NOT_STARTED && title) {
             onChange(title);
         }
     }, [streamStatus, title]);


### PR DESCRIPTION
Fix it by only update the title when is streaming and title is not empty