### PR TITLE
fix: only handle the query generation keydown event when not streaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.25.2",
+    "version": "3.25.3",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/components/AIAssistant/AutoFixButton.scss
+++ b/querybook/webapp/components/AIAssistant/AutoFixButton.scss
@@ -1,0 +1,7 @@
+.AutoFixModal {
+    .Modal-box {
+        .Modal-content {
+            min-height: 40vh;
+        }
+    }
+}

--- a/querybook/webapp/components/AIAssistant/QueryGenerationModal.tsx
+++ b/querybook/webapp/components/AIAssistant/QueryGenerationModal.tsx
@@ -91,7 +91,10 @@ export const QueryGenerationModal = ({
 
     const onKeyDown = useCallback(
         (event: React.KeyboardEvent) => {
-            if (matchKeyPress(event, 'Enter')) {
+            if (
+                streamStatus !== StreamStatus.STREAMING &&
+                matchKeyPress(event, 'Enter')
+            ) {
                 startStream();
                 inputRef.current.blur();
                 trackClick({
@@ -105,7 +108,7 @@ export const QueryGenerationModal = ({
                 });
             }
         },
-        [startStream]
+        [streamStatus, startStream]
     );
 
     const questionBarDOM = (

--- a/querybook/webapp/components/AIAssistant/QueryGenerationModal.tsx
+++ b/querybook/webapp/components/AIAssistant/QueryGenerationModal.tsx
@@ -76,7 +76,7 @@ export const QueryGenerationModal = ({
         setTables(uniq([...tablesInQuery, ...tables]));
     }, [tablesInQuery]);
 
-    const { streamStatus, startStream, streamData } = useStream(
+    const { streamStatus, startStream, streamData, cancelStream } = useStream(
         '/ds/ai/generate_query/',
         {
             query_engine_id: engineId,
@@ -151,6 +151,14 @@ export const QueryGenerationModal = ({
                     autoFocus: true,
                 }}
             />
+            {streamStatus === StreamStatus.STREAMING && (
+                <Button
+                    title="Stop Generating"
+                    color="light"
+                    onClick={cancelStream}
+                    className="mr8"
+                />
+            )}
         </div>
     );
 
@@ -186,7 +194,10 @@ export const QueryGenerationModal = ({
 
     return (
         <Modal
-            onHide={onHide}
+            onHide={() => {
+                cancelStream();
+                onHide();
+            }}
             className="QueryGenerationModal"
             bottomDOM={bottomDOM}
         >

--- a/querybook/webapp/lib/datasource.ts
+++ b/querybook/webapp/lib/datasource.ts
@@ -201,6 +201,8 @@ function streamDatasource(
         parser.close();
         onStreamingEnd?.(parser.result);
     });
+
+    return eventSource;
 }
 
 export default {


### PR DESCRIPTION
add support of streaming cancellation
![Capture-2023-06-26-165438](https://github.com/pinterest/querybook/assets/8308723/e2933f2f-1071-4824-a83f-3fc74ccc0d7d)
![Capture-2023-06-26-172035](https://github.com/pinterest/querybook/assets/8308723/f450a39f-f862-467a-9de2-254996c66f08)


also only handle the query generation keydown event when not streaming