### PR TITLE
fix: Board Ownership Transfer did not reassign owner

### DIFF
--- a/querybook/server/logic/board.py
+++ b/querybook/server/logic/board.py
@@ -1,6 +1,5 @@
 import datetime
 
-from sqlalchemy import or_
 from app.db import with_session
 from const.elasticsearch import ElasticsearchItem
 from models.board import Board, BoardItem, BoardEditor
@@ -54,7 +53,7 @@ def update_board(id, commit=True, session=None, **fields):
     board = Board.update(
         id,
         fields=fields,
-        field_names=["name", "description", "public"],
+        field_names=["name", "description", "public", "owner_uid"],
         commit=commit,
         session=session,
     )

--- a/querybook/server/logic/board.py
+++ b/querybook/server/logic/board.py
@@ -1,5 +1,6 @@
 import datetime
 
+from sqlalchemy import or_
 from app.db import with_session
 from const.elasticsearch import ElasticsearchItem
 from models.board import Board, BoardItem, BoardEditor


### PR DESCRIPTION
This PR fixes a bug where when a new owner was assigned for a board, the board's "owner_uid" parameter was not being reassigned. This would result in an error on the second attempt, because an editor would be created for the previous owner but the ownership would not be reassigned. Therefore, it would try to create a second editor, which results in a duplicate entry.

![image (1)](https://github.com/pinterest/querybook/assets/19509030/bc5cdd58-def2-476f-bd6c-7267e4efd68b)
