### PR TITLE
fix: table warning displaying on wrong table

### DIFF
--- a/querybook/webapp/components/DataTableViewWarnings/DataTableViewWarnings.tsx
+++ b/querybook/webapp/components/DataTableViewWarnings/DataTableViewWarnings.tsx
@@ -37,7 +37,7 @@ export const DataTableViewWarnings: React.FC<IProps> = ({
     const createWarning = useCallback(
         (item: IDataTableWarning) =>
             dispatch(
-                createTableWarnings(tableId, item.message, item.severity)
+                createTableWarnings(item.table_id, item.message, item.severity)
             ).then((newWarning) => {
                 setDisplayNewForm(false);
                 return newWarning;
@@ -107,6 +107,7 @@ export const DataTableViewWarnings: React.FC<IProps> = ({
                 <Card title="" width="100%" flexRow>
                     <GenericCRUD<Partial<IDataTableWarning>>
                         item={{
+                            table_id: tableId,
                             message: '',
                             severity: DataTableWarningSeverity.WARNING,
                         }}


### PR DESCRIPTION
This PR fixes a bug where a table warning or error would display on the wrong table. It would display on the table that the page was most recently refreshed on. This bug would only occur when the "Show full view" setting is enabled.

<img width="1138" alt="Screenshot 2023-08-04 at 12 27 00 PM" src="https://github.com/pinterest/querybook/assets/19509030/507b5ae6-6062-435c-8fe0-9cdadf4754e5">

<img width="1040" alt="Screenshot 2023-08-03 at 10 32 42 AM" src="https://github.com/pinterest/querybook/assets/19509030/422c5233-6152-4736-9bfc-2a91cfde1cae">
