### PR TITLE
fix: init_es.py script not completing due to AttributeError

### DIFF
--- a/querybook/server/logic/elasticsearch.py
+++ b/querybook/server/logic/elasticsearch.py
@@ -697,7 +697,7 @@ def user_to_es(user, fields=None, session=None):
 
 
 @with_session
-def get_users_iter(batch_size=5000, fields=None, session=None):
+def get_users_iter(batch_size=5000, session=None):
     offset = 0
 
     while True:
@@ -709,8 +709,7 @@ def get_users_iter(batch_size=5000, fields=None, session=None):
         LOG.info("\n--User count: {}, offset: {}".format(len(users), offset))
 
         for user in users:
-            expanded_user = user_to_es(user, fields=fields, session=session)
-            yield expanded_user
+            yield user
 
         if len(users) < batch_size:
             break
@@ -723,15 +722,17 @@ def _bulk_insert_users():
     for user in get_users_iter():
         # skip indexing user groups before having the correct permission setup for it.
         if not user.is_group:
-            _insert(index_name, user["id"], user)
+            expanded_user = user_to_es(user, fields=None)
+            _insert(index_name, expanded_user["id"], expanded_user)
 
 
 def _bulk_update_users(fields: Set[str] = None):
     index_name = ES_CONFIG["users"]["index_name"]
 
-    for user in get_users_iter(fields=fields):
-        updated_body = {"doc": user, "doc_as_upsert": True}
-        _update(index_name, user["id"], updated_body)
+    for user in get_users_iter():
+        expanded_user = user_to_es(user, fields=fields)
+        updated_body = {"doc": expanded_user, "doc_as_upsert": True}
+        _update(index_name, expanded_user["id"], updated_body)
 
 
 @with_exception


### PR DESCRIPTION
This PR fixes a small bug in the `querybook.server.logic.elasticsearch._bulk_insert_users()` function. The `get_users_iter` function used to return a `dict` object representation of the users in the database, but the `_bulk_insert_users` function tries to access the `is_group` attribute found in the `User` SQLAlchemy model.

Running this function with users already present in the database (usually through the `init_es.py` script invoked by `--initdb`) results in the following error:
```
Traceback (most recent call last):
  File “<stdin>“, line 1, in <module>
  File “/opt/querybook/querybook/server/logic/elasticsearch.py”, line 725, in _bulk_insert_users
    if not user.is_group:
AttributeError: ‘dict’ object has no attribute ‘is_group’
```

The proposed fix is to return `User` instances from the `get_users_iter` function and then convert them to ElasticSearch compatible `dict` objects in the functions that need it (`_bulk_insert_users()` and `_bulk_update_users(fields: Set[str] = None)`).