### PR TITLE
fix: UI Tutorial 8-11 now focuses on page components

### DIFF
--- a/querybook/webapp/components/Search/SearchContainer.tsx
+++ b/querybook/webapp/components/Search/SearchContainer.tsx
@@ -18,6 +18,7 @@ export const SearchContainer: React.FC = () => {
 
     return (
         <IconButton
+            className="SearchContainer"
             icon="Search"
             tooltipPos="right"
             tooltip="Search Queries, Docs, Tables, and Boards"

--- a/querybook/webapp/components/UIGuide/QuerybookSidebarUIGuide.tsx
+++ b/querybook/webapp/components/UIGuide/QuerybookSidebarUIGuide.tsx
@@ -130,8 +130,7 @@ function getQuerybookSidebarTourSteps() {
             ),
         },
         {
-            selector:
-                '.EntitySidebar .sidebar-footer [aria-label="Search Docs/Tables"]',
+            selector: '.EntitySidebar .apps-list .SearchContainer',
             content: (
                 <>
                     <p>This is the Advanced Search for DataDocs and Tables.</p>
@@ -145,7 +144,7 @@ function getQuerybookSidebarTourSteps() {
             ),
         },
         {
-            selector: '.EntitySidebar .sidebar-footer .UserMenu',
+            selector: '.EntitySidebar .apps-list .UserMenu',
             content: (
                 <>
                     <p>
@@ -161,7 +160,7 @@ function getQuerybookSidebarTourSteps() {
             ),
         },
         {
-            selector: '.EntitySidebar .sidebar-footer .QueryEngineStatusButton',
+            selector: '.EntitySidebar .apps-list .QueryEngineStatusButton',
             content: (
                 <>
                     <p>


### PR DESCRIPTION
<img width="413" alt="Screenshot 2023-08-09 at 2 41 00 PM" src="https://github.com/pinterest/querybook/assets/19509030/906da642-f07b-4128-b084-b487ba92104e">
<img width="417" alt="Screenshot 2023-08-09 at 2 40 56 PM" src="https://github.com/pinterest/querybook/assets/19509030/ac15bd2a-1819-471e-aba4-032e1d56d689">
<img width="413" alt="Screenshot 2023-08-09 at 2 40 52 PM" src="https://github.com/pinterest/querybook/assets/19509030/9d509e17-e9e4-4159-9434-f27ed3b873e6">
