### PR TITLE
Add Username + Password Authentication for Trino Client (fixes #829)

### DIFF
--- a/querybook/server/lib/query_executor/clients/trino.py
+++ b/querybook/server/lib/query_executor/clients/trino.py
@@ -62,17 +62,27 @@ class TrinoClient(ClientBaseClass):
         host = trino_conf.host
         port = 8080 if not trino_conf.port else trino_conf.port
 
-        auth = trino.auth.BasicAuthentication(username, password)
+        if username is not None and password is not None:
+            auth = trino.auth.BasicAuthentication(username, password)
 
-        connection = trino.dbapi.connect(
-            host=host,
-            port=port,
-            catalog=trino_conf.catalog,
-            schema=trino_conf.schema,
-            auth=auth,
-            user=proxy_user if proxy_user else username,
-            http_scheme=trino_conf.protocol,
-        )
+            connection = trino.dbapi.connect(
+                host=host,
+                port=port,
+                catalog=trino_conf.catalog,
+                schema=trino_conf.schema,
+                auth=auth,
+                user=proxy_user if proxy_user else username,
+                http_scheme=trino_conf.protocol,
+            )
+        else:
+            connection = trino.dbapi.connect(
+                host=host,
+                port=port,
+                catalog=trino_conf.catalog,
+                schema=trino_conf.schema,
+                user=proxy_user or username,
+                http_scheme=trino_conf.protocol,
+            )
         self._connection = connection
         super(TrinoClient, self).__init__()
 

--- a/querybook/server/lib/query_executor/clients/trino.py
+++ b/querybook/server/lib/query_executor/clients/trino.py
@@ -62,27 +62,19 @@ class TrinoClient(ClientBaseClass):
         host = trino_conf.host
         port = 8080 if not trino_conf.port else trino_conf.port
 
+        auth = trino.constants.DEFAULT_AUTH
         if username is not None and password is not None:
             auth = trino.auth.BasicAuthentication(username, password)
 
-            connection = trino.dbapi.connect(
-                host=host,
-                port=port,
-                catalog=trino_conf.catalog,
-                schema=trino_conf.schema,
-                auth=auth,
-                user=proxy_user if proxy_user else username,
-                http_scheme=trino_conf.protocol,
-            )
-        else:
-            connection = trino.dbapi.connect(
-                host=host,
-                port=port,
-                catalog=trino_conf.catalog,
-                schema=trino_conf.schema,
-                user=proxy_user or username,
-                http_scheme=trino_conf.protocol,
-            )
+        connection = trino.dbapi.connect(
+            host=host,
+            port=port,
+            catalog=trino_conf.catalog,
+            schema=trino_conf.schema,
+            auth=auth,
+            user=proxy_user if proxy_user else username,
+            http_scheme=trino_conf.protocol,
+        )
         self._connection = connection
         super(TrinoClient, self).__init__()
 

--- a/querybook/server/lib/query_executor/clients/trino.py
+++ b/querybook/server/lib/query_executor/clients/trino.py
@@ -52,6 +52,7 @@ class TrinoClient(ClientBaseClass):
         self,
         connection_string: str,
         username: Optional[str] = None,
+        password: Optional[str] = None,
         proxy_user: Optional[str] = None,
         *args: Any,
         **kwargs: Any,
@@ -61,12 +62,15 @@ class TrinoClient(ClientBaseClass):
         host = trino_conf.host
         port = 8080 if not trino_conf.port else trino_conf.port
 
+        auth = trino.auth.BasicAuthentication(username, password)
+
         connection = trino.dbapi.connect(
             host=host,
             port=port,
             catalog=trino_conf.catalog,
             schema=trino_conf.schema,
-            user=proxy_user or username,
+            auth=auth,
+            user=proxy_user if proxy_user else username,
             http_scheme=trino_conf.protocol,
         )
         self._connection = connection

--- a/querybook/server/lib/query_executor/executor_template/templates.py
+++ b/querybook/server/lib/query_executor/executor_template/templates.py
@@ -73,7 +73,7 @@ trino_executor_template = StructFormField(
         ),
     ),
     ("username", FormField(regex="\\w+")),
-    ("impersonate", FormField(field_type=FormFieldType.Boolean)),
+    ("password", FormField(hidden=True)),
     (
         "proxy_user_id",
         FormField(


### PR DESCRIPTION
Adding username and password authentication for the trino client (fixes https://github.com/pinterest/querybook/issues/829)

Like the presto client-
[querybook/querybook/server/lib/query_executor/clients/presto.py](https://github.com/pinterest/querybook/blob/1e3d01e8a8177f7c4a0031b681f4e1e8d95b3f76/querybook/server/lib/query_executor/clients/presto.py#L12)