### PR TITLE
fix: Migrate to new Nodesource repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ ARG EXTRA_PIP_INSTALLS=""
 
 ## Install Querybook package requirements + NodeJS
 # Installing build-essential and python-dev for uwsgi
-RUN rm -rf /var/lib/apt/lists/* \
+RUN mkdir -p /etc/apt/keyrings && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && rm -rf /var/lib/apt/lists/* \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
     libsasl2-dev \
@@ -16,8 +18,6 @@ RUN rm -rf /var/lib/apt/lists/* \
     build-essential \
     libssl-dev \
     libldap2-dev \
-    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
-    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
     nodejs \
     && apt-get clean
 


### PR DESCRIPTION
The Docker build was failing this morning with an error:

```
#10 15.97 E: Failed to fetch https://deb.nodesource.com/node_16.x/pool/main/n/nodejs/nodejs_16.20.2-deb-1nodesource1_amd64.deb  404  Not Found [IP: 104.22.4.26 443]
```

Per [this issue](https://github.com/nodesource/distributions/issues/1631), it might be fixed on their side now.  But since Nodesource has a new repository and the installation scripts `setup_XX.x` are no longer supported, I've updated to use the new repository to avoid future issues.

I've adapted the instructions here: https://github.com/nodesource/distributions/wiki/How-to-migrate-to-the-new-repository