### PR TITLE
Hotfix: version fix on python-engineio to debug uWSGI socket issue

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,7 @@ alembic==1.8.1
 
 gevent-websocket==0.10.1
 flask-socketio==5.3.1
+python-engineio>=4.7.1
 
 # Query templating
 Jinja2==3.1.2  # From Flask


### PR DESCRIPTION
fix: https://github.com/pinterest/querybook/issues/1319
related to: https://github.com/miguelgrinberg/python-engineio/issues/330

`python-engineio` (version between v4.5.1 and v4.7.0) has some bug on socket close logic.

Due to this issue, Querybook webserver got the error below all the time.
```
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
  File "/usr/local/lib/python3.9/site-packages/engineio/socket.py", line 223, in writer
    ws.close()
  File "/usr/local/lib/python3.9/site-packages/engineio/async_drivers/gevent_uwsgi.py", line 70, in close
    uwsgi.disconnect()
SystemError: you can call uwsgi api function only from the main callable
2023-09-01T11:35:50Z <Thread at 0x7f63a8909040: writer> failed with SystemError

Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 831, in gevent._gevent_cgreenlet.Greenlet.join
  File "src/gevent/greenlet.py", line 857, in gevent._gevent_cgreenlet.Greenlet.join
  File "src/gevent/greenlet.py", line 846, in gevent._gevent_cgreenlet.Greenlet.join
  File "src/gevent/_greenlet_primitives.py", line 61, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 61, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 65, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_gevent_c_greenlet_primitives.pxd", line 35, in gevent._gevent_c_greenlet_primitives._greenlet_switch
  File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
  File "/usr/local/lib/python3.9/site-packages/engineio/socket.py", line 223, in writer
    ws.close()
  File "/usr/local/lib/python3.9/site-packages/engineio/async_drivers/gevent_uwsgi.py", line 70, in close
    uwsgi.disconnect()
SystemError: you can call uwsgi api function only from the main callable
```

This issue has been solved by `python-engineio` version 4.7.1 (released just 5 hours ago).

I deployed and tested Querybook with this version, and the issue was solved.

