### PR TITLE
fix: added new "preformatted" transform option to properly display newlines in query results

### DIFF
--- a/querybook/webapp/lib/query-result/detector.ts
+++ b/querybook/webapp/lib/query-result/detector.ts
@@ -61,6 +61,12 @@ const columnDetectors: IColumnDetector[] = [
             return false;
         },
     },
+    {
+        type: 'multiline',
+        priority: 0.05,
+        checker: (colName: string, values: any[]) =>
+            detectTypeForValues(values, (value) => value.includes('\n')),
+    },
 ]
     .concat(window.CUSTOM_COLUMN_DETECTORS ?? [])
     .sort((a, b) => b.priority - a.priority) as IColumnDetector[];

--- a/querybook/webapp/lib/query-result/transformer.tsx
+++ b/querybook/webapp/lib/query-result/transformer.tsx
@@ -81,6 +81,16 @@ const queryResultTransformers: IColumnTransformer[] = [
         transform: (v: string): React.ReactNode => v.toLocaleUpperCase(),
     },
     {
+        key: 'preformatted',
+        name: 'Preformatted',
+        appliesToType: ['multiline'],
+        priority: 0,
+        auto: true,
+        transform: (v: string): React.ReactNode => (
+            <div className={'preformatted'}>{v}</div>
+        ),
+    },
+    {
         key: 'url',
         name: 'Url Links',
         appliesToType: ['url'],


### PR DESCRIPTION
This also includes a new "multiline" column type which is assigned when a string contains newlines (\n)

<img width="192" alt="Screenshot 2023-09-14 at 11 03 44 AM" src="https://github.com/pinterest/querybook/assets/19509030/6ba9add2-6bf0-494b-a281-4d4a1077ce95">
