### PR TITLE
fix: store the task type value rather than enum when creating a task

### DIFF
--- a/querybook/server/logic/demo.py
+++ b/querybook/server/logic/demo.py
@@ -72,7 +72,7 @@ def set_up_demo(uid: int, session=None):
             "task": "tasks.update_metastore.update_metastore",
             "cron": "0 0 * * *",
             "args": [metastore_id],
-            "task_type": ScheduleTaskType.PROD,
+            "task_type": ScheduleTaskType.PROD.value,
             "enabled": True,
         },
         # commit=False,

--- a/querybook/server/logic/schedule.py
+++ b/querybook/server/logic/schedule.py
@@ -65,7 +65,7 @@ def create_task_schedule(
         kwargs=kwargs or {},
         options=options or {},
         enabled=enabled,
-        task_type=get_schedule_task_type(name),
+        task_type=get_schedule_task_type(name).value,
     )
 
     session.add(schedule)

--- a/querybook/server/models/schedule.py
+++ b/querybook/server/models/schedule.py
@@ -67,7 +67,9 @@ class TaskSchedule(CRUDMixin, Base):
     no_changes = sql.Column(sql.Boolean, default=False)
 
     task_type = sql.Column(
-        sql.String(length=name_length), nullable=False, default=ScheduleTaskType.PROD
+        sql.String(length=name_length),
+        nullable=False,
+        default=ScheduleTaskType.PROD.value,
     )
 
     def get_cron(self):


### PR DESCRIPTION
The task type was being stored in the db as `"ScheduleTaskType.PROD"` rather than the expected `"prod"`. This was causing newly created tasks to be filtered out in the `AdminTask` component ([link](https://github.com/pinterest/querybook/blob/master/querybook/webapp/components/AppAdmin/AdminTask.tsx#L57-L72)).