### PR TITLE
Add column name suggestions to presto validator

### DIFF
--- a/querybook/server/lib/elasticsearch/search_table.py
+++ b/querybook/server/lib/elasticsearch/search_table.py
@@ -215,3 +215,25 @@ def get_column_name_suggestion(
     }
 
     return get_matching_objects(search_query, ES_CONFIG["tables"]["index_name"], True)
+
+
+def get_table_name_suggestion(fuzzy_full_table_name: str) -> Tuple[Dict, int]:
+    """Given an invalid table name use fuzzy search to search the correctly-spelled table name"""
+    schema_name, fuzzy_table_name = fuzzy_full_table_name.split(".")
+
+    search_query = {
+        "query": {
+            "bool": {
+                "must": [
+                    {"match": {"schema": schema_name}},
+                    {
+                        "match": {
+                            "name": {"query": fuzzy_table_name, "fuzziness": "AUTO"},
+                        }
+                    },
+                ]
+            }
+        },
+    }
+
+    return get_matching_objects(search_query, ES_CONFIG["tables"]["index_name"], True)

--- a/querybook/server/lib/query_analysis/validation/base_query_validator.py
+++ b/querybook/server/lib/query_analysis/validation/base_query_validator.py
@@ -67,6 +67,7 @@ class BaseQueryValidator(ABC):
         query: str,
         uid: int,  # who is doing the syntax check
         engine_id: int,  # which engine they are checking against
+        **kwargs,
     ) -> List[QueryValidationResult]:
         raise NotImplementedError()
 

--- a/querybook/server/lib/query_analysis/validation/validators/base_sqlglot_validator.py
+++ b/querybook/server/lib/query_analysis/validation/validators/base_sqlglot_validator.py
@@ -72,6 +72,22 @@ class BaseSQLGlotValidator(BaseQueryValidator):
         uid: int,
         engine_id: int,
         raw_tokens: List[Token] = None,
-        **kwargs
+        **kwargs,
     ) -> List[QueryValidationResult]:
         raise NotImplementedError()
+
+
+class BaseSQLGlotDecorator(BaseSQLGlotValidator):
+    def __init__(self, validator: BaseQueryValidator):
+        self._validator = validator
+
+    def validate(
+        self,
+        query: str,
+        uid: int,
+        engine_id: int,
+        raw_tokens: List[Token] = None,
+        **kwargs,
+    ):
+        """Override this method to add suggestions to validation results"""
+        return self._validator.validate(query, uid, engine_id, **kwargs)

--- a/querybook/server/lib/query_analysis/validation/validators/base_sqlglot_validator.py
+++ b/querybook/server/lib/query_analysis/validation/validators/base_sqlglot_validator.py
@@ -1,5 +1,5 @@
-from abc import ABCMeta, abstractmethod
-from typing import List, Tuple
+from abc import abstractmethod
+from typing import Any, Dict, List, Tuple
 from sqlglot import Tokenizer
 from sqlglot.tokens import Token
 
@@ -8,9 +8,13 @@ from lib.query_analysis.validation.base_query_validator import (
     QueryValidationResultObjectType,
     QueryValidationSeverity,
 )
+from lib.query_analysis.validation.base_query_validator import BaseQueryValidator
 
 
-class BaseSQLGlotValidator(metaclass=ABCMeta):
+class BaseSQLGlotValidator(BaseQueryValidator):
+    def __init__(self, name: str = "", config: Dict[str, Any] = {}):
+        super(BaseSQLGlotValidator, self).__init__(name, config)
+
     @property
     @abstractmethod
     def message(self) -> str:
@@ -32,6 +36,12 @@ class BaseSQLGlotValidator(metaclass=ABCMeta):
     def _get_query_coordinate_by_index(self, query: str, index: int) -> Tuple[int, int]:
         rows = query[: index + 1].splitlines(keepends=False)
         return len(rows) - 1, len(rows[-1]) - 1
+
+    def _get_query_index_by_coordinate(
+        self, query: str, start_line: int, start_ch: int
+    ) -> int:
+        rows = query.splitlines(keepends=True)[:start_line]
+        return sum([len(row) for row in rows]) + start_ch
 
     def _get_query_validation_result(
         self,
@@ -56,7 +66,12 @@ class BaseSQLGlotValidator(metaclass=ABCMeta):
         )
 
     @abstractmethod
-    def get_query_validation_results(
-        self, query: str, raw_tokens: List[Token] = None
+    def validate(
+        self,
+        query: str,
+        uid: int,
+        engine_id: int,
+        raw_tokens: List[Token] = None,
+        **kwargs
     ) -> List[QueryValidationResult]:
         raise NotImplementedError()

--- a/querybook/server/lib/query_analysis/validation/validators/metadata_suggesters.py
+++ b/querybook/server/lib/query_analysis/validation/validators/metadata_suggesters.py
@@ -1,0 +1,150 @@
+from abc import abstractmethod
+import re
+from itertools import chain
+from typing import List
+
+from lib.elasticsearch import search_table
+from lib.query_analysis.lineage import process_query
+from lib.query_analysis.validation.base_query_validator import (
+    QueryValidationResult,
+    QueryValidationSeverity,
+)
+from lib.query_analysis.validation.validators.base_sqlglot_validator import (
+    BaseSQLGlotDecorator,
+)
+from logic.admin import get_query_engine_by_id
+
+
+class BaseColumnNameSuggester(BaseSQLGlotDecorator):
+    @property
+    def severity(self):
+        return QueryValidationSeverity.WARNING  # Unused, severity is not changed
+
+    @property
+    def message(self):
+        return ""  # Unused, message is not changed
+
+    @property
+    @abstractmethod
+    def column_name_error_regex(self):
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_column_name_from_error(self, validation_result: QueryValidationResult):
+        raise NotImplementedError()
+
+    def _is_column_name_error(self, validation_result: QueryValidationResult) -> bool:
+        return bool(re.match(self.column_name_error_regex, validation_result.message))
+
+    def _get_tables_in_query(self, query: str, engine_id: int) -> List[str]:
+        engine = get_query_engine_by_id(engine_id)
+        tables_per_statement, _ = process_query(query, language=engine.language)
+        return list(chain.from_iterable(tables_per_statement))
+
+    def _search_columns_for_suggestion(self, columns: List[str], suggestion: str):
+        """Return the case-sensitive column name by searching the table's columns for the suggestion text"""
+        for col in columns:
+            if col.lower() == suggestion.lower():
+                return col
+        return suggestion
+
+    def _suggest_column_name(
+        self,
+        validation_result: QueryValidationResult,
+        tables_in_query: List[str],
+    ):
+        """Takes validation result and tables in query to update validation result to provide column
+        name suggestion"""
+        fuzzy_column_name = self.get_column_name_from_error(validation_result)
+        if not fuzzy_column_name:
+            return None
+        results, count = search_table.get_column_name_suggestion(
+            fuzzy_column_name, tables_in_query
+        )
+        if count == 1:  # Only suggest column if there's a single match
+            table_result = results[0]
+            highlights = table_result.get("highlight", {}).get("columns", [])
+            if len(highlights) == 1:
+                column_suggestion = self._search_columns_for_suggestion(
+                    table_result.get("columns"), highlights[0]
+                )
+                validation_result.suggestion = column_suggestion
+                validation_result.end_line = validation_result.start_line
+                validation_result.end_ch = (
+                    validation_result.start_ch + len(fuzzy_column_name) - 1
+                )
+
+    def validate(
+        self,
+        query: str,
+        uid: int,
+        engine_id: int,
+        raw_tokens: List[QueryValidationResult] = None,
+        **kwargs,
+    ) -> List[QueryValidationResult]:
+        if raw_tokens is None:
+            raw_tokens = self._tokenize_query(query)
+        validation_results = self._validator.validate(
+            query, uid, engine_id, raw_tokens=raw_tokens
+        )
+        tables_in_query = self._get_tables_in_query(query, engine_id)
+        for result in validation_results:
+            if self._is_column_name_error(result):
+                self._suggest_column_name(result, tables_in_query)
+        return validation_results
+
+
+class BaseTableNameSuggester(BaseSQLGlotDecorator):
+    @property
+    def severity(self):
+        return QueryValidationSeverity.WARNING  # Unused, severity is not changed
+
+    @property
+    def message(self):
+        return ""  # Unused, message is not changed
+
+    @property
+    @abstractmethod
+    def table_name_error_regex(self):
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_full_table_name_from_error(self, validation_result: QueryValidationResult):
+        raise NotImplementedError()
+
+    def _is_table_name_error(self, validation_result: QueryValidationResult) -> bool:
+        return bool(re.match(self.table_name_error_regex, validation_result.message))
+
+    def _suggest_table_name(self, validation_result: QueryValidationResult):
+        """Takes validation result and tables in query to update validation result to provide table
+        name suggestion"""
+        fuzzy_table_name = self.get_full_table_name_from_error(validation_result)
+        if not fuzzy_table_name:
+            return None
+        results, count = search_table.get_table_name_suggestion(fuzzy_table_name)
+        if count > 0:
+            table_result = results[0]  # Get top match
+            table_suggestion = f"{table_result['schema']}.{table_result['name']}"
+            validation_result.suggestion = table_suggestion
+            validation_result.end_line = validation_result.start_line
+            validation_result.end_ch = (
+                validation_result.start_ch + len(fuzzy_table_name) - 1
+            )
+
+    def validate(
+        self,
+        query: str,
+        uid: int,
+        engine_id: int,
+        raw_tokens: List[QueryValidationResult] = None,
+        **kwargs,
+    ) -> List[QueryValidationResult]:
+        if raw_tokens is None:
+            raw_tokens = self._tokenize_query(query)
+        validation_results = self._validator.validate(
+            query, uid, engine_id, raw_tokens=raw_tokens
+        )
+        for result in validation_results:
+            if self._is_table_name_error(result):
+                self._suggest_table_name(result)
+        return validation_results

--- a/querybook/server/lib/query_analysis/validation/validators/presto_explain_validator.py
+++ b/querybook/server/lib/query_analysis/validation/validators/presto_explain_validator.py
@@ -72,6 +72,7 @@ class PrestoExplainValidator(BaseQueryValidator):
         query: str,
         uid: int,  # who is doing the syntax check
         engine_id: int,  # which engine they are checking against
+        **kwargs,
     ) -> List[QueryValidationResult]:
         validation_errors = []
         (

--- a/querybook/server/lib/query_analysis/validation/validators/presto_optimizing_validator.py
+++ b/querybook/server/lib/query_analysis/validation/validators/presto_optimizing_validator.py
@@ -204,23 +204,19 @@ class RegexpLikeValidator(BasePrestoSQLGlotDecorator):
 
 
 class PrestoColumnNameSuggester(BasePrestoSQLGlotDecorator, BaseColumnNameSuggester):
-    @property
-    def column_name_error_regex(self):
-        return r"line \d+:\d+: Column '(.*)' cannot be resolved"
-
     def get_column_name_from_error(self, validation_result: QueryValidationResult):
-        regex_result = re.match(self.column_name_error_regex, validation_result.message)
-        return regex_result.groups()[0]
+        regex_result = re.match(
+            r"line \d+:\d+: Column '(.*)' cannot be resolved", validation_result.message
+        )
+        return regex_result.groups()[0] if regex_result else None
 
 
 class PrestoTableNameSuggester(BasePrestoSQLGlotDecorator, BaseTableNameSuggester):
-    @property
-    def table_name_error_regex(self):
-        return r"line \d+:\d+: Table '(.*)' does not exist"
-
     def get_full_table_name_from_error(self, validation_result: QueryValidationResult):
-        regex_result = re.match(self.table_name_error_regex, validation_result.message)
-        return regex_result.groups()[0]
+        regex_result = re.match(
+            r"line \d+:\d+: Table '(.*)' does not exist", validation_result.message
+        )
+        return regex_result.groups()[0] if regex_result else None
 
 
 class PrestoOptimizingValidator(BaseQueryValidator):

--- a/querybook/server/lib/query_analysis/validation/validators/presto_optimizing_validator.py
+++ b/querybook/server/lib/query_analysis/validation/validators/presto_optimizing_validator.py
@@ -293,7 +293,6 @@ class ColumnNameSuggester(BasePrestoSQLGlotDecorator):
         )
         tables_in_query = self._get_tables_in_query(query, engine_id)
         for result in validation_results:
-            # "Column .* cannot be resolved" -> to get all name errors
             if self._is_column_name_error(result):
                 column_suggestion = self._get_column_name_suggestion(
                     result, query, tables_in_query, raw_tokens

--- a/querybook/server/lib/query_analysis/validation/validators/presto_optimizing_validator.py
+++ b/querybook/server/lib/query_analysis/validation/validators/presto_optimizing_validator.py
@@ -233,7 +233,7 @@ class ColumnNameSuggester(BasePrestoSQLGlotDecorator):
 
     def _is_column_name_error(self, validation_result: QueryValidationResult) -> bool:
         return bool(
-            re.match(r"Column .* cannot be resolved", validation_result.message)
+            re.search(r"Column .* cannot be resolved", validation_result.message)
         )
 
     def _get_column_name_from_position(

--- a/querybook/tests/test_lib/test_query_analysis/test_validation/test_validators/test_presto_optimizing_validator.py
+++ b/querybook/tests/test_lib/test_query_analysis/test_validation/test_validators/test_presto_optimizing_validator.py
@@ -1,5 +1,6 @@
 from typing import List
 from unittest import TestCase
+from unittest.mock import patch, MagicMock
 
 from lib.query_analysis.validation.base_query_validator import (
     QueryValidationResult,
@@ -8,6 +9,7 @@ from lib.query_analysis.validation.base_query_validator import (
 )
 from lib.query_analysis.validation.validators.presto_optimizing_validator import (
     ApproxDistinctValidator,
+    ColumnNameSuggester,
     RegexpLikeValidator,
     UnionAllValidator,
     PrestoOptimizingValidator,
@@ -15,6 +17,11 @@ from lib.query_analysis.validation.validators.presto_optimizing_validator import
 
 
 class BaseValidatorTestCase(TestCase):
+    def _get_explain_validator_mock(self):
+        explain_validator_mock = MagicMock()
+        explain_validator_mock.validate.return_value = []
+        return explain_validator_mock
+
     def _verify_query_validation_results(
         self,
         validation_results: List[QueryValidationResult],
@@ -75,12 +82,12 @@ class BaseValidatorTestCase(TestCase):
 
 class UnionAllValidatorTestCase(BaseValidatorTestCase):
     def setUp(self):
-        self._validator = UnionAllValidator()
+        self._validator = UnionAllValidator(self._get_explain_validator_mock())
 
     def test_basic_union(self):
         query = "SELECT * FROM a \nUNION SELECT * FROM b"
         self._verify_query_validation_results(
-            self._validator.get_query_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [
                 self._get_union_all_validation_result(
                     1,
@@ -94,7 +101,7 @@ class UnionAllValidatorTestCase(BaseValidatorTestCase):
     def test_multiple_unions(self):
         query = "SELECT * FROM a \nUNION SELECT * FROM b \nUNION SELECT * FROM c"
         self._verify_query_validation_results(
-            self._validator.get_query_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [
                 self._get_union_all_validation_result(
                     1,
@@ -113,26 +120,24 @@ class UnionAllValidatorTestCase(BaseValidatorTestCase):
 
     def test_union_all(self):
         query = "SELECT * FROM a UNION ALL SELECT * FROM b"
-        self._verify_query_validation_results(
-            self._validator.get_query_validation_results(query), []
-        )
+        self._verify_query_validation_results(self._validator.validate(query, 0, 0), [])
 
 
 class ApproxDistinctValidatorTestCase(BaseValidatorTestCase):
     def setUp(self):
-        self._validator = ApproxDistinctValidator()
+        self._validator = ApproxDistinctValidator(self._get_explain_validator_mock())
 
     def test_basic_count_distinct(self):
         query = "SELECT COUNT(DISTINCT x) FROM a"
         self._verify_query_validation_results(
-            self._validator.get_query_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [self._get_approx_distinct_validation_result(0, 7, 0, 20)],
         )
 
     def test_count_not_followed_by_distinct(self):
         query = "SELECT \nCOUNT * FROM a"
         self._verify_query_validation_results(
-            self._validator.get_query_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [],
         )
 
@@ -141,7 +146,7 @@ class ApproxDistinctValidatorTestCase(BaseValidatorTestCase):
             "SELECT \nCOUNT(DISTINCT y) FROM a UNION SELECT \nCOUNT(DISTINCT x) FROM b"
         )
         self._verify_query_validation_results(
-            self._validator.get_query_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [
                 self._get_approx_distinct_validation_result(1, 0, 1, 13),
                 self._get_approx_distinct_validation_result(2, 0, 2, 13),
@@ -153,7 +158,7 @@ class ApproxDistinctValidatorTestCase(BaseValidatorTestCase):
             "SELECT \nCOUNT(DISTINCT a), b FROM table_a WHERE \nCOUNT(DISTINCT a) > 10"
         )
         self._verify_query_validation_results(
-            self._validator.get_query_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [
                 self._get_approx_distinct_validation_result(1, 0, 1, 13),
                 self._get_approx_distinct_validation_result(2, 0, 2, 13),
@@ -163,12 +168,12 @@ class ApproxDistinctValidatorTestCase(BaseValidatorTestCase):
 
 class RegexpLikeValidatorTestCase(BaseValidatorTestCase):
     def setUp(self):
-        self._validator = RegexpLikeValidator()
+        self._validator = RegexpLikeValidator(self._get_explain_validator_mock())
 
     def test_basic_combine_case(self):
         query = "SELECT * from a WHERE \nx LIKE 'foo' OR x LIKE \n'bar'"
         self._verify_query_validation_results(
-            self._validator.get_query_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [
                 self._get_regexp_like_validation_result(
                     1, 0, 2, 4, "REGEXP_LIKE(x, 'foo|bar')"
@@ -179,14 +184,14 @@ class RegexpLikeValidatorTestCase(BaseValidatorTestCase):
     def test_and_clause(self):
         query = "SELECT * from a WHERE \nx LIKE 'foo%' AND x LIKE \n'%bar'"
         self._verify_query_validation_results(
-            self._validator.get_query_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [],
         )
 
     def test_more_than_two_phrases(self):
         query = "SELECT * from a WHERE \nx LIKE 'foo' OR x LIKE 'bar' OR x LIKE \n'baz'"
         self._verify_query_validation_results(
-            self._validator.get_query_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [
                 self._get_regexp_like_validation_result(
                     1, 0, 2, 4, "REGEXP_LIKE(x, 'foo|bar|baz')"
@@ -197,7 +202,7 @@ class RegexpLikeValidatorTestCase(BaseValidatorTestCase):
     def test_different_column_names(self):
         query = "SELECT * from a WHERE \nx LIKE 'foo' OR y LIKE 'bar'"
         self._verify_query_validation_results(
-            self._validator.get_query_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [],
         )
 
@@ -206,7 +211,7 @@ class RegexpLikeValidatorTestCase(BaseValidatorTestCase):
             "SELECT * from a WHERE \nx LIKE 'foo' OR x LIKE \n'bar' AND y LIKE 'foo'"
         )
         self._verify_query_validation_results(
-            self._validator.get_query_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [
                 self._get_regexp_like_validation_result(
                     1, 0, 2, 4, "REGEXP_LIKE(x, 'foo|bar')"
@@ -217,7 +222,7 @@ class RegexpLikeValidatorTestCase(BaseValidatorTestCase):
     def test_multiple_suggestions(self):
         query = "SELECT * from a WHERE \nx LIKE 'foo' OR x LIKE \n'bar' AND \ny LIKE 'foo' OR y LIKE \n'bar'"
         self._verify_query_validation_results(
-            self._validator.get_query_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [
                 self._get_regexp_like_validation_result(
                     1, 0, 2, 4, "REGEXP_LIKE(x, 'foo|bar')"
@@ -231,72 +236,209 @@ class RegexpLikeValidatorTestCase(BaseValidatorTestCase):
     def test_phrase_not_match(self):
         query = "SELECT * from a WHERE x LIKE 'foo' OR x = 'bar'"
         self._verify_query_validation_results(
-            self._validator.get_query_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [],
+        )
+
+
+class ColumnNameSuggesterTestCase(BaseValidatorTestCase):
+    def setUp(self):
+        self._validator = ColumnNameSuggester(MagicMock())
+
+    def test__is_column_name_error(self):
+        self.assertEqual(
+            self._validator._is_column_name_error(
+                QueryValidationResult(
+                    0,
+                    0,
+                    QueryValidationSeverity.WARNING,
+                    "Line 0:1 Column 'happyness' cannot be resolved",
+                )
+            ),
+            True,
+        )
+        self.assertEqual(
+            self._validator._is_column_name_error(
+                QueryValidationResult(
+                    0,
+                    0,
+                    QueryValidationSeverity.WARNING,
+                    "Line 0:1 Table 'world_happiness_rank' does not exist",
+                )
+            ),
+            False,
+        )
+
+    def test_search_columns_for_suggestion(self):
+        self.assertEqual(
+            self._validator._search_columns_for_suggestion(
+                ["HappinessRank", "Country", "Region"], "country"
+            ),
+            "Country",
+        )
+        self.assertEqual(
+            self._validator._search_columns_for_suggestion(
+                ["HappinessRank, Region"], "country"
+            ),
+            "country",
+        )
+
+    @patch(
+        "lib.elasticsearch.search_table.get_column_name_suggestion",
+    )
+    def test__get_column_name_suggestion(self, mock_get_column_name_suggestion):
+        validation_result = QueryValidationResult(
+            0,
+            7,
+            QueryValidationSeverity.WARNING,
+            "Line 0:1 Column 'happynessrank' cannot be resolved",
+        )
+        query = "select happynessrank from main.world_happiness_report;"
+        # Test too many tables matched
+        mock_get_column_name_suggestion.return_value = [
+            [
+                {
+                    "columns": ["HappinessRank"],
+                    "highlight": {"columns": ["happinessrank"]},
+                },
+                {
+                    "columns": ["HappinessRank"],
+                    "highlight": {"columns": ["happinessrank1"]},
+                },
+            ],
+            2,
+        ]
+        self.assertEqual(
+            self._validator._get_column_name_suggestion(
+                validation_result,
+                query,
+                ["main.world_happiness_report"],
+            ),
+            None,
+        )
+
+        # Test too many columns in a table matched
+        mock_get_column_name_suggestion.return_value = [
+            [
+                {
+                    "columns": ["HappinessRank", "HappinessRank1"],
+                    "highlight": {"columns": ["happinessrank", "happinessrank1"]},
+                },
+            ],
+            1,
+        ]
+        self.assertEqual(
+            self._validator._get_column_name_suggestion(
+                validation_result,
+                query,
+                ["main.world_happiness_report"],
+            ),
+            None,
+        )
+
+        # Test single column matched
+        mock_get_column_name_suggestion.return_value = [
+            [
+                {
+                    "columns": ["HappinessRank", "HappinessRank1"],
+                    "highlight": {"columns": ["happinessrank"]},
+                },
+            ],
+            1,
+        ]
+        self.assertEqual(
+            self._validator._get_column_name_suggestion(
+                validation_result,
+                query,
+                ["main.world_happiness_report"],
+            ),
+            "HappinessRank",
+        )
+
+        # Test no search results
+        mock_get_column_name_suggestion.return_value = [
+            [],
+            0,
+        ]
+        self.assertEqual(
+            self._validator._get_column_name_suggestion(
+                validation_result,
+                query,
+                ["main.world_happiness_report"],
+            ),
+            None,
         )
 
 
 class PrestoOptimizingValidatorTestCase(BaseValidatorTestCase):
     def setUp(self):
+        super(PrestoOptimizingValidatorTestCase, self).setUp()
+        patch_validator = patch.object(
+            ColumnNameSuggester,
+            "validate",
+            return_value=[],
+        )
+        patch_validator.start()
+        self.addCleanup(patch_validator.stop)
         self._validator = PrestoOptimizingValidator("")
 
     def test_union_and_count_distinct(self):
         query = "SELECT \nCOUNT( DISTINCT x) from a \nUNION select \ncount(distinct y) from b"
         self._verify_query_validation_results(
-            self._validator._get_sql_glot_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [
-                self._get_union_all_validation_result(2, 0, 2, 4),
                 self._get_approx_distinct_validation_result(1, 0, 1, 14),
                 self._get_approx_distinct_validation_result(3, 0, 3, 13),
+                self._get_union_all_validation_result(2, 0, 2, 4),
             ],
         )
 
     def test_union_and_regexp_like(self):
         query = "SELECT * from a WHERE \nx like 'foo' or x like \n'bar' \nUNION select * from b where y like 'foo' AND x like 'bar'"
         self._verify_query_validation_results(
-            self._validator._get_sql_glot_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [
-                self._get_union_all_validation_result(3, 0, 3, 4),
                 self._get_regexp_like_validation_result(
                     1, 0, 2, 4, "REGEXP_LIKE(x, 'foo|bar')"
                 ),
+                self._get_union_all_validation_result(3, 0, 3, 4),
             ],
         )
 
     def test_count_distinct_and_regexp_like(self):
         query = "SELECT \nCOUNT( DISTINCT x) from a WHERE \nx LIKE 'foo' or x like \n'bar' and y like 'foo'"
         self._verify_query_validation_results(
-            self._validator._get_sql_glot_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [
-                self._get_approx_distinct_validation_result(1, 0, 1, 14),
                 self._get_regexp_like_validation_result(
                     2, 0, 3, 4, "REGEXP_LIKE(x, 'foo|bar')"
                 ),
+                self._get_approx_distinct_validation_result(1, 0, 1, 14),
             ],
         )
 
     def test_all_errors(self):
         query = "SELECT \nCOUNT( DISTINCT x) from a WHERE \nx LIKE 'foo' or x like \n'bar' and y like 'foo' \nUNION select * from b"
         self._verify_query_validation_results(
-            self._validator._get_sql_glot_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [
-                self._get_union_all_validation_result(4, 0, 4, 4),
-                self._get_approx_distinct_validation_result(1, 0, 1, 14),
                 self._get_regexp_like_validation_result(
                     2, 0, 3, 4, "REGEXP_LIKE(x, 'foo|bar')"
                 ),
+                self._get_approx_distinct_validation_result(1, 0, 1, 14),
+                self._get_union_all_validation_result(4, 0, 4, 4),
             ],
         )
 
     def test_extra_whitespace(self):
         query = "SELECT \n  COUNT( DISTINCT x) from a WHERE \n\t  x LIKE 'foo' or x like \n'bar' and y like 'foo' \n     UNION select * from b"
         self._verify_query_validation_results(
-            self._validator._get_sql_glot_validation_results(query),
+            self._validator.validate(query, 0, 0),
             [
-                self._get_union_all_validation_result(4, 5, 4, 9),
-                self._get_approx_distinct_validation_result(1, 2, 1, 16),
                 self._get_regexp_like_validation_result(
                     2, 3, 3, 4, "REGEXP_LIKE(x, 'foo|bar')"
                 ),
+                self._get_approx_distinct_validation_result(1, 2, 1, 16),
+                self._get_union_all_validation_result(4, 5, 4, 9),
             ],
         )


### PR DESCRIPTION
Add column name suggestions to presto optimizing validator:
  1. determine if error message returned by presto explain validator is a column name error by searching the regex 
  2. if so, get invalid column name, and use elasticsearch fuzzy search to search for the correct column name in all of the tables used in the query
  3. if only 1 result is returned by the elasticsearch query (meaning that there is one possible correct column name) - return that column name as a suggestion

