### PR TITLE
fix: Fix DataDoc contents overflow in non-Chrome browsers

### DIFF
--- a/querybook/webapp/components/DataDoc/DataDoc.scss
+++ b/querybook/webapp/components/DataDoc/DataDoc.scss
@@ -37,6 +37,8 @@
         flex: 0 1 var(--max-width);
         padding: 36px 8px 36px 16px;
 
+        overflow-x: auto;
+
         .data-doc-header {
             padding: 0px 12px 8px;
             color: var(--text-light);


### PR DESCRIPTION
DataDocs with wide result tables cause the entire page to scroll horizontally:

**Before:**
![Screenshot 2023-09-20 at 16-58-53 World Happiness Report (2015-2019) - Querybook](https://github.com/pinterest/querybook/assets/3084806/1fd3788f-e5de-427b-8c5d-2d4f42fbfab9)

This isn't an issue in Chrome because there's a special case hardcoded for it in [DataDocContentContainer](https://github.com/pinterest/querybook/blob/master/querybook/webapp/components/DataDoc/DataDocContentContainer.tsx#L7).

This PR fixes the issue by enabling overflow for `.data-doc-content-container`, and doesn't break anything for Chrome.

Tested this change in Firefox and Safari.

**After:**
![Screenshot 2023-09-20 at 17-09-32 World Happiness Report (2015-2019) - Querybook](https://github.com/pinterest/querybook/assets/3084806/eb8eda29-f2da-4349-a058-616a224cea66)
