### PR TITLE
fix: some small changes and fixes for AI assistant

### DIFF
--- a/containers/bundled_querybook_config.yaml
+++ b/containers/bundled_querybook_config.yaml
@@ -13,25 +13,21 @@ ELASTICSEARCH_HOST: http://elasticsearch:9200
 # AI_ASSISTANT_CONFIG:
 #     default:
 #         model_args:
-#             model_name: gpt-3.5-turbo-16k
+#             model_name: gpt-3.5-turbo
 #             temperature: 0
-#         context_length: 16384
-#         reserved_tokens: 2048
+#         reserved_tokens: 1024
 #     table_summary:
 #         model_args:
-#             model_name: gpt-3.5-turbo-16k
+#             model_name: gpt-3.5-turbo
 #             temperature: 0
-#         context_length: 16384
 #     sql_summary:
 #         model_args:
-#             model_name: gpt-3.5-turbo-16k
+#             model_name: gpt-3.5-turbo
 #             temperature: 0
-#         context_length: 16384
 #     table_select:
 #         model_args:
-#             model_name: gpt-3.5-turbo-16k
+#             model_name: gpt-3.5-turbo
 #             temperature: 0
-#         context_length: 16384
 
 # Uncomment below to enable vector store to support embedding based table search.
 # Please check langchain doc for the configs of each provider.

--- a/docs_website/docs/integrations/add_ai_assistant.md
+++ b/docs_website/docs/integrations/add_ai_assistant.md
@@ -16,15 +16,17 @@ The AI Assistant plugin will allow users to do title generation, text to sql and
 
 Please follow below steps to enable AI assistant plugin:
 
-1. [Optional] Create your own AI assistant provider if needed. Please refer to `querybook/server/lib/ai_assistant/openai_assistant.py` as an example.
+1. Add `langchain` package dependency by adding `-r ai/langchain.txt` to `requirements/local.txt`.
 
-2. Add your provider in `plugins/ai_assistant_plugin/__init__.py`
+2. [Optional] Create your own AI assistant provider if needed. Please refer to `querybook/server/lib/ai_assistant/openai_assistant.py` as an example.
 
-3. Add configs in the `querybook_config.yaml`. Please refer to `containers/bundled_querybook_config.yaml` as an example. Please also check the model's official doc for all avaialbe model args.
+3. Add your provider in `plugins/ai_assistant_plugin/__init__.py`
+
+4. Add configs in the `querybook_config.yaml`. Please refer to `containers/bundled_querybook_config.yaml` as an example. Please also check the model's official doc for all avaialbe model args.
 
     - Dont forget to set proper environment variables for your provider. e.g. for openai, you'll need `OPENAI_API_KEY`.
 
-4. Enable it in `querybook/config/querybook_public_config.yaml`
+5. Enable it in `querybook/config/querybook_public_config.yaml`
 
 ## Vector Store Plugin
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.28.0",
+    "version": "3.28.1",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/config/querybook_default_config.yaml
+++ b/querybook/config/querybook_default_config.yaml
@@ -92,11 +92,7 @@ AI_ASSISTANT_CONFIG:
         model_args:
             model_name: ~
             temperature: ~
-        context_length: ~
         reserved_tokens: ~
-    table_select:
-        fetch_k: ~
-        top_n: ~
 
 EMBEDDINGS_PROVIDER: ~
 EMBEDDINGS_CONFIG: ~

--- a/querybook/server/datasources/search.py
+++ b/querybook/server/datasources/search.py
@@ -17,7 +17,6 @@ from lib.elasticsearch.search_utils import (
 from lib.elasticsearch.suggest_table import construct_suggest_table_query
 from lib.elasticsearch.suggest_user import construct_suggest_user_query
 from lib.elasticsearch.search_utils import ES_CONFIG
-from logic import vector_store as vs_logic
 
 LOG = get_logger(__file__)
 
@@ -123,6 +122,9 @@ def vector_search_tables(
     keywords,
     filters=None,
 ):
+    # delayed import only if vector search is enabled
+    from logic import vector_store as vs_logic
+
     verify_metastore_permission(metastore_id)
     return vs_logic.search_tables(metastore_id, keywords, filters)
 

--- a/querybook/server/lib/ai_assistant/assistants/openai_assistant.py
+++ b/querybook/server/lib/ai_assistant/assistants/openai_assistant.py
@@ -9,6 +9,15 @@ from lib.logger import get_logger
 LOG = get_logger(__file__)
 
 
+OPENAI_MODEL_CONTEXT_WINDOW_SIZE = {
+    "gpt-3.5-turbo": 4097,
+    "gpt-3.5-turbo-16k": 16385,
+    "gpt-4": 8192,
+    "gpt-4-32k": 32768,
+}
+DEFAULT_MODEL_NAME = "gpt-3.5-turbo"
+
+
 class OpenAIAssistant(BaseAIAssistant):
     """To use it, please set the following environment variable:
     OPENAI_API_KEY: OpenAI API key
@@ -18,10 +27,16 @@ class OpenAIAssistant(BaseAIAssistant):
     def name(self) -> str:
         return "openai"
 
+    def _get_context_length_by_model(self, model_name: str) -> int:
+        return (
+            OPENAI_MODEL_CONTEXT_WINDOW_SIZE.get(model_name)
+            or OPENAI_MODEL_CONTEXT_WINDOW_SIZE[DEFAULT_MODEL_NAME]
+        )
+
     def _get_default_llm_config(self):
         default_config = super()._get_default_llm_config()
         if not default_config.get("model_name"):
-            default_config["model_name"] = "gpt-3.5-turbo"
+            default_config["model_name"] = DEFAULT_MODEL_NAME
 
         return default_config
 
@@ -36,7 +51,7 @@ class OpenAIAssistant(BaseAIAssistant):
 
         return super()._get_error_msg(error)
 
-    def _get_llm(self, ai_command: str, callback_handler=None):
+    def _get_llm(self, ai_command: str, prompt_length: int, callback_handler=None):
         config = self._get_llm_config(ai_command)
         if not callback_handler:
             # non-streaming

--- a/querybook/webapp/components/AIAssistant/AutoFixButton.tsx
+++ b/querybook/webapp/components/AIAssistant/AutoFixButton.tsx
@@ -27,6 +27,7 @@ const useSQLFix = () => {
     });
 
     const {
+        data: unformattedData,
         explanation,
         fix_suggestion: suggestion,
         fixed_query: rawFixedQuery,
@@ -37,7 +38,7 @@ const useSQLFix = () => {
     return {
         socket,
         fixed: Object.keys(data).length > 0, // If has data, then it has been fixed
-        explanation,
+        explanation: explanation || unformattedData,
         suggestion,
         fixedQuery,
     };


### PR DESCRIPTION
 - move the "from logic import vector_store as vs_logic" as delayed import to fix the issue of can't find langchain module when ai assistant is not enabled
 - when the response format of auto fix is not as expected, show the unformatted response anyway
 - Try to not include table/column description or other metadadata if prompt is too long
 - Pass prompt length to `_get_llm`, so it can be used to determine which llm model to use
 - Fix for some cases the table name in the vector store is not a full table name.
 - update the docs of installing langchain package