### PR TITLE
Revert "fix: Fix DataDoc contents overflow in non-Chrome browsers (#1332)"

### DIFF
--- a/querybook/webapp/components/DataDoc/DataDoc.scss
+++ b/querybook/webapp/components/DataDoc/DataDoc.scss
@@ -37,8 +37,6 @@
         flex: 0 1 var(--max-width);
         padding: 36px 8px 36px 16px;
 
-        overflow-x: auto;
-
         .data-doc-header {
             padding: 0px 12px 8px;
             color: var(--text-light);


### PR DESCRIPTION
This reverts commit 18c86a6010fbc9d4fa8e708f8ca3343718915a6a.

It caused datadoc with many data cells can't be fully loaded 

@baumandm 