### PR TITLE
fix: Add scroll bar to Query Engine Status popover

### DIFF
--- a/querybook/webapp/components/QueryEngineStatusButton/QueryEngineStatusButton.tsx
+++ b/querybook/webapp/components/QueryEngineStatusButton/QueryEngineStatusButton.tsx
@@ -167,7 +167,7 @@ export const QueryEngineStatusButton: React.FC<IProps> = ({
 
         const panelContent = (
             <div className="QueryEngineStatusPopover">
-                <Menu>
+                <Menu height="75vh">
                     <MenuInfoItem>
                         <Timer
                             formatter={timerFormatter}

--- a/querybook/webapp/ui/Menu/Menu.tsx
+++ b/querybook/webapp/ui/Menu/Menu.tsx
@@ -10,7 +10,7 @@ export const Menu = styled.div.attrs<{
 })`
     ${(props) =>
         props.height &&
-        `maxHeight: ${props.height};
+        `max-height: ${props.height};
         overflow-x: hidden;
         overflow-y: auto;`}
     ${(props) => props.boxShadow && 'box-shadow: var(--box-shadow);'}


### PR DESCRIPTION
Environments with many Query Engines break the Query Engine status popover, so this PR adds a `max-height` and a scrollbar to keep everything on the screen.

**Before:** 😿 
![Screen Shot 2023-10-23 at 09 54 25-fullpage](https://github.com/pinterest/querybook/assets/3084806/aef35236-7ae8-4124-9906-29146bcee3f8)

**After:** 😸 
![Screen Shot 2023-10-23 at 09 54 42-fullpage](https://github.com/pinterest/querybook/assets/3084806/cb9d07fb-b997-497f-adb8-fbf2d081c567)
