### PR TITLE
fix: website and docs query_engines links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For general configuration, [click here](docs_website/docs/configurations/general
 -   MySQL
 -   Sqlite
 -   PostgreSQL
--   [and many more...](https://www.querybook.org/docs/setup_guide/connect_to_query_engines#all-query-engines)
+-   [and many more...](https://www.querybook.org/docs/setup_guide/query_engines)
 
 ### Authentication
 

--- a/docs_website/docs/configurations/infra_installation.md
+++ b/docs_website/docs/configurations/infra_installation.md
@@ -54,7 +54,7 @@ If you install the required packages, these integrations will be automatically s
     -   Redshift (via `-r engine/redshift.txt`)
     -   Snowflake (via `-r engine/snowflake.txt`)
     -   Trino (via `-r engine/trino.txt`)
-    -   And [any sqlalchemy supported engines](../setup_guide/connect_to_query_engines.md)
+    -   And [any sqlalchemy supported engines](../setup_guide/query_engines.md)
 -   Metastore:
     -   Hive Metastore (via `-r metastore/hms.txt`)
     -   Hive Metastore with Thrift (install Hive Metastore and Hive)

--- a/docs_website/docs/setup_guide/connect_to_a_query_engine.md
+++ b/docs_website/docs/setup_guide/connect_to_a_query_engine.md
@@ -29,7 +29,7 @@ Here we'll guide you through the process of adding a query engine for **PostgreS
 touch requirements/local.txt
 ```
 
-2. Check the [engine list](https://www.querybook.org/docs/setup_guide/connect_to_query_engines#all-query-engines) and find the package it depends on.
+2. Check the [engine list](https://www.querybook.org/docs/setup_guide/query_engines) and find the package it depends on.
 3. If the required package is not included by default, add it to the `local.txt` file. For `PostgreSQL`, no additional package is needed. Here is an example for `Amazon Redshift`:
 
 ```bash

--- a/docs_website/docs/setup_guide/prod_setup.md
+++ b/docs_website/docs/setup_guide/prod_setup.md
@@ -9,7 +9,7 @@ Once further scalability is desired you can start each service individually in d
 #### Step 1: Choose and Build Docker image
 
 The [public docker image](https://hub.docker.com/r/querybook/querybook) provided only contains a subset of all integrations possible with Querybook.
-To intergrate with your tech stack, please check the [Infra Installations Guide](../configurations/infra_installation.md) and [Query Engines Guide](./connect_to_query_engines.md)
+To intergrate with your tech stack, please check the [Infra Installations Guide](../configurations/infra_installation.md) and [Query Engines Guide](./connect_to_a_query_engine.md)
 to see how to install and use different integrations such as Presto, OAuth, AWS and more.
 
 #### Step 2: Setup Infrastructure

--- a/docs_website/src/components/HomePage/IntegrationsSection/index.jsx
+++ b/docs_website/src/components/HomePage/IntegrationsSection/index.jsx
@@ -34,7 +34,7 @@ export default () => {
                 <br />
                 <p className="flex-center">
                     View the full list of supported databases&nbsp;
-                    <Link to="/docs/setup_guide/connect_to_query_engines">
+                    <Link to="/docs/setup_guide/query_engines">
                         here
                     </Link>
                     .

--- a/querybook/webapp/components/AppAdmin/AdminQueryEngine.tsx
+++ b/querybook/webapp/components/AppAdmin/AdminQueryEngine.tsx
@@ -347,7 +347,7 @@ export const AdminQueryEngine: React.FunctionComponent<IProps> = ({
                                         supports more, click{' '}
                                         <Link
                                             newTab
-                                            to="https://www.querybook.org/docs/setup_guide/connect_to_query_engines/"
+                                            to="https://www.querybook.org/docs/setup_guide/query_engines/"
                                         >
                                             here
                                         </Link>{' '}


### PR DESCRIPTION
Docs were re-organized to splits connect_to_query_engines.md into connect_to_a_query_engine.md and query_engines.md.  Links were not fully updated to align.  This quick PR fixes those links as initially reported in #1365