### PR TITLE
fix: Update runservice worker scripts to disable unneeded features

### DIFF
--- a/querybook/scripts/runservice
+++ b/querybook/scripts/runservice
@@ -15,7 +15,7 @@ case "$SERVICE_NAME" in
     COMMAND="python3 querybook/server/runweb.py"
     ;;
 "worker")
-    COMMAND="watchmedo auto-restart -d querybook -p '*.py' -R -- celery -A tasks.all_tasks worker --loglevel=DEBUG"
+    COMMAND="watchmedo auto-restart -d querybook -p '*.py' -R -- celery -A tasks.all_tasks worker -E --without-heartbeat --without-gossip --without-mingle --loglevel=DEBUG"
     ;;
 "scheduler")
     COMMAND="watchmedo auto-restart -d querybook -p '*.py' -R -- celery -A tasks.all_tasks beat -S scheduler.DatabaseScheduler --loglevel=INFO"
@@ -30,7 +30,7 @@ case "$SERVICE_NAME" in
     COMMAND="uwsgi --ini uwsgi.ini"
     ;;
 "prod_worker")
-    COMMAND="celery -A tasks.all_tasks worker"
+    COMMAND="celery -A tasks.all_tasks worker -E --without-heartbeat --without-gossip --without-mingle"
     ;;
 "prod_scheduler")
     COMMAND="celery -A tasks.all_tasks beat -S scheduler.DatabaseScheduler"


### PR DESCRIPTION
We've encountered issues where workers would stop receiving tasks after an error message like this:

```
consumer: Connection to broker lost. Trying to re-establish the connection...
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/celery/worker/consumer/consumer.py", line 332, in start
    blueprint.start(self)
```

I was able to reproduce this locally via Docker by manually bouncing the Redis container.

After some research, we came across suggestions to disable the heartbeat/gossip/mingle features of Celery.  In my local testing it appears this change eliminates (or at least reduces) the issue where the workers cannot reconnect to Redis after a connection failure.

We have been running this in production for over a month and everything works as expected, including Flower.