### PR TITLE
fix: cast table max upload size to int

### DIFF
--- a/querybook/server/app/flask_app.py
+++ b/querybook/server/app/flask_app.py
@@ -42,7 +42,7 @@ def make_flask_app():
         )
 
     if QuerybookSettings.TABLE_MAX_UPLOAD_SIZE is not None:
-        app.config["MAX_CONTENT_LENGTH"] = QuerybookSettings.TABLE_MAX_UPLOAD_SIZE
+        app.config["MAX_CONTENT_LENGTH"] = int(QuerybookSettings.TABLE_MAX_UPLOAD_SIZE)
 
     return app
 


### PR DESCRIPTION
Environment variables are loaded in as strings, which results in the following error for loading `QuerybookSettings.TABLE_MAX_UPLOAD_SIZE`

```querybook_web            | [2023-11-16 Thu 14:18:16] - /opt/querybook/querybook/server/app/datasource.py - ERROR   "'>' not supported between instances of 'int' and 'str'"
querybook_web            | Traceback (most recent call last):
querybook_web            |   File "/opt/querybook/querybook/server/app/datasource.py", line 84, in handler
querybook_web            |     results = fn(**kwargs)
querybook_web            |   File "/opt/querybook/querybook/server/datasources/event_log.py", line 18, in log_frontend_event
querybook_web            |     events = json.loads(flask.request.data)
```


This fix casts the table max upload size variable to an int before applying it to the flask app config