### PR TITLE
fix: s3 table upload location

### DIFF
--- a/docs_website/docs/changelog/breaking_change.md
+++ b/docs_website/docs/changelog/breaking_change.md
@@ -7,12 +7,21 @@ slug: /changelog
 
 Here are the list of breaking changes that you should be aware of when updating Querybook:
 
+## v3.29.0
+
+Made below changes for `S3BaseExporter` (csv table uploader feature):
+
+-   Both `s3_path` and `use_schema_location` are optional now
+-   If none is provided, or `use_schema_location=False`, the table will be created as managed table, whose location will be determined by the query engine.
+
 ## v3.27.0
+
 Updated properties of `QueryValidationResult` object. `line` and `ch` are replaced with `start_line` and `start_ch` respectively.
 
 ## v3.22.0
 
 Updated the charset of table `data_element` to `utf8mb4`. For those mysql db's default charset is not utf8, please run below sql to update it if needed.
+
 ```sql
 ALTER TABLE data_element CONVERT TO CHARACTER SET utf8mb4
 ```

--- a/docs_website/docs/changelog/breaking_change.md
+++ b/docs_website/docs/changelog/breaking_change.md
@@ -13,6 +13,7 @@ Made below changes for `S3BaseExporter` (csv table uploader feature):
 
 -   Both `s3_path` and `use_schema_location` are optional now
 -   If none is provided, or `use_schema_location=False`, the table will be created as managed table, whose location will be determined by the query engine.
+-   Previously `use_schema_location=True` will create managed table, and now it creates external table.
 
 ## v3.27.0
 

--- a/docs_website/docs/integrations/add_table_upload.md
+++ b/docs_website/docs/integrations/add_table_upload.md
@@ -51,7 +51,7 @@ Available options:
     Checkout here for examples in SparkSQL: https://spark.apache.org/docs/latest/sql-ref-syntax-ddl-create-table-hiveformat.html#examples
     For Trino/Presto, it would be the WITH statement: https://trino.io/docs/current/sql/create-table.html
 
-If neither s3_path nor use_schema_location is supplied, it will be treated same as `use_schema_location=False``, and it will be created as managed table.
+If neither s3_path nor use_schema_location is supplied, it will be treated same as `use_schema_location=False`, and it will be created as managed table.
 
 ### S3 Parquet exporter
 

--- a/docs_website/docs/integrations/add_table_upload.md
+++ b/docs_website/docs/integrations/add_table_upload.md
@@ -42,16 +42,16 @@ Included by default: No
 
 Available options:
 
-Either s3_path or use_schema_location must be supplied.
-
--   s3_path (str): if supplied, will use it as the root path for upload. Must be the full s3 path like s3://bucket/key, the trailing / is optional.
--   use_schema_location (boolean):
+-   s3_path (str, optional): if supplied, will use it as the root path for upload. Must be the full s3 path like s3://bucket/key, the trailing / is optional.
+-   use_schema_location (boolean, optional):
     if true, the upload root path is inferred by locationUri specified by the schema/database in HMS. To use this option, the engine must be connected to a metastore that uses
     HMSMetastoreLoader (or its derived class).
     if false, it will be created as managed table, whose location will be determined automatically by the query engine.
 -   table_properties (List[str]): list of table properties passed, this must be query engine specific.
     Checkout here for examples in SparkSQL: https://spark.apache.org/docs/latest/sql-ref-syntax-ddl-create-table-hiveformat.html#examples
     For Trino/Presto, it would be the WITH statement: https://trino.io/docs/current/sql/create-table.html
+
+If neither s3_path nor use_schema_location is supplied, it will be treated same as `use_schema_location=False``, and it will be created as managed table.
 
 ### S3 Parquet exporter
 

--- a/docs_website/docs/integrations/add_table_upload.md
+++ b/docs_website/docs/integrations/add_table_upload.md
@@ -48,6 +48,7 @@ Either s3_path or use_schema_location must be supplied.
 -   use_schema_location (boolean):
     if true, the upload root path is inferred by locationUri specified by the schema/database in HMS. To use this option, the engine must be connected to a metastore that uses
     HMSMetastoreLoader (or its derived class).
+    if false, it will be created as managed table, whose location will be determined automatically by the query engine.
 -   table_properties (List[str]): list of table properties passed, this must be query engine specific.
     Checkout here for examples in SparkSQL: https://spark.apache.org/docs/latest/sql-ref-syntax-ddl-create-table-hiveformat.html#examples
     For Trino/Presto, it would be the WITH statement: https://trino.io/docs/current/sql/create-table.html

--- a/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
+++ b/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
@@ -101,6 +101,12 @@ class HMSMetastoreLoader(BaseMetastoreLoader):
     def get_schema_location(self, schema_name: str) -> str:
         return self.hmc.get_database(schema_name).locationUri
 
+    def get_table_location(self, schema_name: str, table_name: str) -> str:
+        try:
+            return self.hmc.get_table(schema_name, table_name).sd.location
+        except NoSuchObjectException:
+            return None
+
     def _get_hmc(self, metastore_dict):
         return HiveMetastoreClient(
             hmss_ro_addrs=metastore_dict["metastore_params"]["hms_connection"]

--- a/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
+++ b/querybook/server/lib/metastore/loaders/hive_metastore_loader.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 from clients.hms_client import HiveMetastoreClient
 from const.metastore import DataColumn, DataTable
@@ -101,7 +101,7 @@ class HMSMetastoreLoader(BaseMetastoreLoader):
     def get_schema_location(self, schema_name: str) -> str:
         return self.hmc.get_database(schema_name).locationUri
 
-    def get_table_location(self, schema_name: str, table_name: str) -> str:
+    def get_table_location(self, schema_name: str, table_name: str) -> Union[None, str]:
         try:
             return self.hmc.get_table(schema_name, table_name).sd.location
         except NoSuchObjectException:

--- a/querybook/server/lib/table_upload/exporter/s3_exporter.py
+++ b/querybook/server/lib/table_upload/exporter/s3_exporter.py
@@ -79,14 +79,7 @@ class S3BaseExporter(BaseTableUploadExporter):
         schema_name, table_name = self._fq_table_name
         if "s3_path" in self._exporter_config:
             s3_path: str = self._exporter_config["s3_path"]
-
-            return (
-                sanitize_s3_url(s3_path)
-                + "/"
-                + schema_name
-                + "/"
-                + table_name
-            )
+            return sanitize_s3_url(s3_path) + "/" + schema_name + "/" + table_name
 
         query_engine = get_query_engine_by_id(self._engine_id, session=session)
         metastore = get_metastore_loader(query_engine.metastore_id, session=session)

--- a/querybook/server/lib/table_upload/exporter/s3_exporter.py
+++ b/querybook/server/lib/table_upload/exporter/s3_exporter.py
@@ -131,7 +131,7 @@ class S3BaseExporter(BaseTableUploadExporter):
     def _get_table_create_query(self, session=None) -> str:
         query_engine = get_query_engine_by_id(self._engine_id, session=session)
         schema_name, table_name = self._fq_table_name
-        is_managed = self._exporter_config.get("use_schema_location") == False
+        is_managed = self._exporter_config.get("use_schema_location") is False
         return get_create_table_statement(
             language=query_engine.language,
             table_name=table_name,

--- a/querybook/webapp/components/TableUploader/TableUploaderForm.tsx
+++ b/querybook/webapp/components/TableUploader/TableUploaderForm.tsx
@@ -78,9 +78,13 @@ export const TableUploaderForm: React.FC<ITableUploaderFormProps> = ({
             });
 
             // sometimes there will be sync delay between the metastore and querybook
-            // skip the redirect if the table has not been synced over.
+            // skip the redirection if the table has not been synced over.
             if (tableId) {
                 navigateWithinEnv(`/table/${tableId}`);
+            } else {
+                toast(
+                    'Waiting for the table to be synced over from the metastore.'
+                );
             }
             onHide();
         },

--- a/querybook/webapp/components/TableUploader/TableUploaderForm.tsx
+++ b/querybook/webapp/components/TableUploader/TableUploaderForm.tsx
@@ -77,7 +77,11 @@ export const TableUploaderForm: React.FC<ITableUploaderFormProps> = ({
                 error: 'Fail to create table',
             });
 
-            navigateWithinEnv(`/table/${tableId}`);
+            // sometimes there will be sync delay between the metastore and querybook
+            // skip the redirect if the table has not been synced over.
+            if (tableId) {
+                navigateWithinEnv(`/table/${tableId}`);
+            }
             onHide();
         },
         [onHide]


### PR DESCRIPTION
 - Explicitly call out that the table is managed when `use_schema_location=False` for s3 table uploader. 
 - Get the actual table location from metastore for data uploading for managed tables
 - Fix the logic of checking `is_external`. Previously `is_external` will be `False` when `use_schema_location` is True, which supposed to be True (external table), as it is specifying location.
   ```is_external = not self._exporter_config.get("use_schema_location", False)```