### PR TITLE
fix: Store group description in `public_info`

### DIFF
--- a/querybook/server/logic/user.py
+++ b/querybook/server/logic/user.py
@@ -148,7 +148,7 @@ def create_or_update_user_group(user_group: UserGroup, commit=True, session=None
         "fullname": user_group.display_name,
         "email": user_group.email,
         "is_group": True,
-        "properties": {"description": user_group.description},
+        "properties": {"public_info": {"description": user_group.description}},
     }
 
     if not group:


### PR DESCRIPTION
Currently, `create_or_update_user_group()` sets the group description directly inside the `properties` dict, but only the values of the `public_info` key are exposed via the API.

This change stores the description in the correct location so that the UI can display it.