### PR TITLE
feat: Added support for sending custom datadog metrics from querybook

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,26 @@ x-querybook-volumes: &querybook-volumes
     # - file:/opt/store/
 
 services:
+    datadog:
+        image: gcr.io/datadoghq/agent:latest
+        ports:
+            - 8125:8125/udp
+        expose:
+            - 8125/udp
+        environment:
+            DD_DOGSTATSD_NON_LOCAL_TRAFFIC: true
+            DD_USE_DOGSTATSD: true
+            DD_APM_ENABLED: false
+            DD_AC_EXCLUDE: '.*'
+            DD_ENV: 'dev'
+            DD_SERVICE: 'federated-querybook'
+            DD_VERSION: 'latest'
+        env_file:
+            - ./.env.local
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock
+            - /proc/:/host/proc/:ro
+            - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
     web:
         container_name: querybook_web
         image: *querybook-image

--- a/querybook/server/env.py
+++ b/querybook/server/env.py
@@ -135,7 +135,9 @@ class QuerybookSettings(object):
     AI_ASSISTANT_PROVIDER = get_env_config("AI_ASSISTANT_PROVIDER")
     AI_ASSISTANT_CONFIG = get_env_config("AI_ASSISTANT_CONFIG") or {}
 
-    VECTOR_STORE_PROVIDER = get_env_config("VECTOR_STORE_PROVIDER")
-    VECTOR_STORE_CONFIG = get_env_config("VECTOR_STORE_CONFIG") or {}
-    EMBEDDINGS_PROVIDER = get_env_config("EMBEDDINGS_PROVIDER")
-    EMBEDDINGS_CONFIG = get_env_config("EMBEDDINGS_CONFIG") or {}
+    # Datadog
+    DD_AGENT_HOST = get_env_config("DD_AGENT_HOST", optional=True)
+    DD_DOGSTATSD_PORT = int(get_env_config("DD_DOGSTATSD_PORT", optional=True) or 8125)
+    DD_PREFIX = get_env_config("DD_PREFIX", optional=True)
+    DD_SERVICE = get_env_config("DD_SERVICE", optional=True) or "querybook"
+    DD_TAGS = get_env_config("DD_TAGS", optional=True) or []

--- a/querybook/server/lib/celery/celery_stats.py
+++ b/querybook/server/lib/celery/celery_stats.py
@@ -1,0 +1,29 @@
+import time
+import threading
+from lib.stats_logger import stats_logger, ACTIVE_WORKERS, ACTIVE_TASKS
+
+
+def send_stats_logger_metrics(celery):
+    while True:
+        i = celery.control.inspect()
+
+        stats = i.stats() or {}
+        active = i.active() or {}
+
+        active_workers = list(stats.keys())
+        active_tasks = 0
+        for worker in active_workers:
+            if worker in active:
+                if len(active[worker]) > 0:
+                    active_tasks += 1
+
+        stats_logger.gauge(ACTIVE_WORKERS, len(stats))
+        stats_logger.gauge(ACTIVE_TASKS, active_tasks)
+        time.sleep(5)
+
+
+def start_stats_logger_monitor(celery):
+    thread = threading.Thread(
+        target=send_stats_logger_metrics, args=[celery], daemon=True
+    )
+    thread.start()

--- a/querybook/server/lib/celery/celery_stats.py
+++ b/querybook/server/lib/celery/celery_stats.py
@@ -17,7 +17,7 @@ def send_stats_logger_metrics(celery):
                 if len(active[worker]) > 0:
                     active_tasks += 1
 
-        stats_logger.gauge(ACTIVE_WORKERS, len(stats))
+        stats_logger.gauge(ACTIVE_WORKERS, len(active_workers))
         stats_logger.gauge(ACTIVE_TASKS, active_tasks)
         time.sleep(5)
 

--- a/querybook/server/lib/celery/celery_stats.py
+++ b/querybook/server/lib/celery/celery_stats.py
@@ -7,15 +7,13 @@ def send_stats_logger_metrics(celery):
     while True:
         i = celery.control.inspect()
 
-        stats = i.stats() or {}
         active = i.active() or {}
 
-        active_workers = list(stats.keys())
+        active_workers = list(active.keys())
         active_tasks = 0
         for worker in active_workers:
             if worker in active:
-                if len(active[worker]) > 0:
-                    active_tasks += 1
+                active_tasks += len(active[worker])
 
         stats_logger.gauge(ACTIVE_WORKERS, len(active_workers))
         stats_logger.gauge(ACTIVE_TASKS, active_tasks)

--- a/querybook/server/lib/stats_logger/__init__.py
+++ b/querybook/server/lib/stats_logger/__init__.py
@@ -7,8 +7,12 @@ API_REQUESTS = "api.requests"
 WS_CONNECTIONS = "ws.connections"
 SQL_SESSION_FAILURES = "sql_session.failures"
 TASK_FAILURES = "task.failures"
+TASK_SUCCESSES = "task.successes"
+TASK_RECEIVED = "task.received"
 REDIS_OPERATIONS = "redis.operations"
 QUERY_EXECUTIONS = "query.executions"
+ACTIVE_WORKERS = "celery.active_workers"
+ACTIVE_TASKS = "celery.active_tasks"
 
 
 logger_name = QuerybookSettings.STATS_LOGGER_NAME

--- a/querybook/server/lib/stats_logger/all_stats_loggers.py
+++ b/querybook/server/lib/stats_logger/all_stats_loggers.py
@@ -1,4 +1,6 @@
 from lib.utils.import_helper import import_module_with_default
+
+from .loggers.datadog_stats_logger import DatadogStatsLogger
 from .loggers.null_stats_logger import NullStatsLogger
 from .loggers.console_stats_logger import ConsoleStatsLogger
 
@@ -8,11 +10,19 @@ ALL_PLUGIN_STATS_LOGGERS = import_module_with_default(
     default=[],
 )
 
-ALL_STATS_LOGGERS = [NullStatsLogger(), ConsoleStatsLogger()] + ALL_PLUGIN_STATS_LOGGERS
+ALL_STATS_LOGGERS = [
+    NullStatsLogger(),
+    ConsoleStatsLogger(),
+    DatadogStatsLogger(),
+] + ALL_PLUGIN_STATS_LOGGERS
 
 
 def get_stats_logger_class(name: str):
     for logger in ALL_STATS_LOGGERS:
         if logger.logger_name == name:
+            if hasattr(logger, "initialize") and callable(
+                getattr(logger, "initialize")
+            ):
+                logger.initialize()
             return logger
     raise ValueError(f"Unknown stats logger name {name}")

--- a/querybook/server/lib/stats_logger/loggers/datadog_stats_logger.py
+++ b/querybook/server/lib/stats_logger/loggers/datadog_stats_logger.py
@@ -65,4 +65,4 @@ class DatadogStatsLogger(BaseStatsLogger):
         )
 
     def gauge(self, key: str, value: float, tags: dict[str, str] = None) -> None:
-        statsd.set(self.metric_prefix_helper(key), value, tags=self.tag_helper(tags))
+        statsd.gauge(self.metric_prefix_helper(key), value, tags=self.tag_helper(tags))

--- a/querybook/server/lib/stats_logger/loggers/datadog_stats_logger.py
+++ b/querybook/server/lib/stats_logger/loggers/datadog_stats_logger.py
@@ -1,0 +1,68 @@
+from lib.stats_logger.base_stats_logger import BaseStatsLogger
+from datadog import initialize, statsd
+from env import QuerybookSettings
+from lib.logger import get_logger
+
+LOG = get_logger(__file__)
+
+
+class DatadogStatsLogger(BaseStatsLogger):
+    metric_prefix = ""
+    dd_tags = []
+
+    def metric_prefix_helper(self, key):
+        return self.metric_prefix + "." + key
+
+    def tag_helper(self, tags):
+        if tags:
+            return [f"{k}:{v}" for k, v in tags.items()]
+        return []
+
+    def initialize(self):
+        if QuerybookSettings.DD_AGENT_HOST and QuerybookSettings.DD_DOGSTATSD_PORT:
+            LOG.info("Initializing Datadog")
+
+            self.dd_tags = (
+                QuerybookSettings.DD_TAGS.split(",")
+                if QuerybookSettings.DD_TAGS
+                else []
+            )
+            self.metric_prefix = (
+                QuerybookSettings.DD_PREFIX or QuerybookSettings.DD_SERVICE
+            )
+
+            options = {
+                "statsd_host": QuerybookSettings.DD_AGENT_HOST,
+                "statsd_port": QuerybookSettings.DD_DOGSTATSD_PORT,
+                "statsd_constant_tags": self.dd_tags,
+            }
+
+            initialize(**options)
+        else:
+            LOG.info("Datadog environment variables are not set")
+
+    @property
+    def logger_name(self) -> str:
+        return "datadog"
+
+    def incr(self, key: str, tags: dict[str, str] = None) -> None:
+        statsd.increment(
+            self.metric_prefix_helper(key),
+            1,
+            tags=self.tag_helper(tags),
+        )
+
+    def decr(self, key: str, tags: dict[str, str] = None) -> None:
+        statsd.decrement(
+            self.metric_prefix_helper(key),
+            1,
+            tags=self.tag_helper(tags),
+        )
+
+    def timing(self, key: str, value: float, tags: dict[str, str] = None) -> None:
+        statsd.histogram(
+            self.metric_prefix_helper(key), value, tags=self.tag_helper(tags)
+        )
+
+    def gauge(self, key: str, value: float, tags: dict[str, str] = None) -> None:
+        statsd.set(self.metric_prefix_helper(key), value, tags=self.tag_helper(tags))

--- a/querybook/server/tasks/all_tasks.py
+++ b/querybook/server/tasks/all_tasks.py
@@ -15,8 +15,6 @@ from lib.stats_logger import (
     TASK_FAILURES,
     TASK_SUCCESSES,
     TASK_RECEIVED,
-    ACTIVE_WORKERS,
-    ACTIVE_TASKS,
     stats_logger,
 )
 from lib.celery.celery_stats import start_stats_logger_monitor
@@ -95,5 +93,3 @@ def handle_task_received(sender, signal, *args, **kwargs):
 def start_celery_stats_logging(sender=None, conf=None, **kwargs):
     LOG.info("Starting Celery Beat")
     start_stats_logger_monitor(celery)
-    stats_logger.gauge(ACTIVE_WORKERS, 0)
-    stats_logger.gauge(ACTIVE_TASKS, 0)

--- a/requirements/datadog/datadog.txt
+++ b/requirements/datadog/datadog.txt
@@ -1,0 +1,2 @@
+datadog==0.47.0
+ddtrace==2.0.2

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -28,3 +28,6 @@
 
 # AI Assistant
 -r ai/langchain.txt
+
+# Datadog
+-r datadog/datadog.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,3 +8,4 @@ moto==2.2.4
 -r exporter/gspread.txt
 -r parser/sqlglot.txt
 -r ai/langchain.txt
+-r datadog/datadog.txt


### PR DESCRIPTION
This PR includes the setup of `dogstatsd`, a python library used for sending metrics to Datadog as well as the creation of a new stats logger, `DatadogStatsLogger`.

In addition, it includes 5 metrics: `celery.active_workers`, `celery.active_tasks`, `task.received`, `task.failures`, and `task.successes`

The first 2 metrics are sent to datadog every 5 seconds by opening a new thread which continuously runs the `send_stats_logger_metrics` function. The other 3 metrics are triggered by event handlers so they are sent whenever a task is received by a worker, a task fails, or a task succeeds.