### PR TITLE
feat: Add non-streaming support to AI Assistant

### DIFF
--- a/containers/bundled_querybook_config.yaml
+++ b/containers/bundled_querybook_config.yaml
@@ -15,6 +15,7 @@ ELASTICSEARCH_HOST: http://elasticsearch:9200
 #         model_args:
 #             model_name: gpt-3.5-turbo
 #             temperature: 0
+#             streaming: true
 #         reserved_tokens: 1024
 #     table_summary:
 #         model_args:

--- a/querybook/config/querybook_default_config.yaml
+++ b/querybook/config/querybook_default_config.yaml
@@ -92,6 +92,7 @@ AI_ASSISTANT_CONFIG:
         model_args:
             model_name: ~
             temperature: ~
+            streaming: ~
         reserved_tokens: ~
 
 EMBEDDINGS_PROVIDER: ~

--- a/querybook/server/lib/ai_assistant/assistants/openai_assistant.py
+++ b/querybook/server/lib/ai_assistant/assistants/openai_assistant.py
@@ -53,12 +53,14 @@ class OpenAIAssistant(BaseAIAssistant):
 
     def _get_llm(self, ai_command: str, prompt_length: int, callback_handler=None):
         config = self._get_llm_config(ai_command)
-        if not callback_handler:
+
+        if not callback_handler or config.get("streaming") is False:
             # non-streaming
-            return ChatOpenAI(**config)
+            return ChatOpenAI(
+                **{**config, "streaming": False},
+            )
 
         return ChatOpenAI(
-            **config,
-            streaming=True,
-            callback_manager=CallbackManager([callback_handler])
+            **{**config, "streaming": True},
+            callback_manager=CallbackManager([callback_handler]),
         )


### PR DESCRIPTION
This PR allows toggling the [streaming mode](https://api.python.langchain.com/en/latest/chat_models/langchain_openai.chat_models.base.ChatOpenAI.html#langchain_openai.chat_models.base.ChatOpenAI.streaming) of the OpenAIAssistant.  This is required when using a proxy that doesn't support streaming.

The default behavior remains `streaming: true`, but it can now be disabled via the `model_args`:

```
AI_ASSISTANT_PROVIDER: openai
AI_ASSISTANT_CONFIG:
    default:
        model_args:
            model_name: gpt-3.5-turbo
            temperature: 0
            streaming: false
```

I added the option into the config files to help document the feature, but it's completely optional and doesn't need to be specified at all.

When disabled, the LLM result is sent in single chunk when the response is complete.