### PR TITLE
fix: modify trigger for query_authoring survey

### DIFF
--- a/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
+++ b/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
@@ -102,7 +102,7 @@ interface IState {
     query: string;
     meta: IDataQueryCellMeta;
 
-    modified: boolean;
+    modifiedAt: number;
     focused: boolean;
     selectedRange: ISelectedRange;
     queryCollapsedOverride: boolean;
@@ -127,7 +127,7 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
         this.state = {
             query: props.query,
             meta: props.meta,
-            modified: false,
+            modifiedAt: 0,
             focused: false,
             selectedRange: null,
             queryCollapsedOverride: null,
@@ -349,7 +349,7 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
         this.setState(
             {
                 query,
-                modified: true,
+                modifiedAt: Date.now(),
             },
             () => {
                 this.onChangeDebounced({ context: query });
@@ -432,7 +432,8 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
                     )
                 ).id;
 
-                if (this.state.modified) {
+                // Only trigger survey if the query is modified within 5 minutes
+                if (Date.now() - this.state.modifiedAt < 5 * 60 * 1000) {
                     triggerSurvey(SurveySurfaceType.QUERY_AUTHORING, {
                         query_execution_id: queryId,
                         cell_id: this.props.cellId,

--- a/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
+++ b/querybook/webapp/components/DataDocQueryCell/DataDocQueryCell.tsx
@@ -102,6 +102,7 @@ interface IState {
     query: string;
     meta: IDataQueryCellMeta;
 
+    modified: boolean;
     focused: boolean;
     selectedRange: ISelectedRange;
     queryCollapsedOverride: boolean;
@@ -126,6 +127,7 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
         this.state = {
             query: props.query,
             meta: props.meta,
+            modified: false,
             focused: false,
             selectedRange: null,
             queryCollapsedOverride: null,
@@ -347,6 +349,7 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
         this.setState(
             {
                 query,
+                modified: true,
             },
             () => {
                 this.onChangeDebounced({ context: query });
@@ -429,10 +432,12 @@ class DataDocQueryCellComponent extends React.PureComponent<IProps, IState> {
                     )
                 ).id;
 
-                triggerSurvey(SurveySurfaceType.QUERY_AUTHORING, {
-                    query_execution_id: queryId,
-                    cell_id: this.props.cellId,
-                });
+                if (this.state.modified) {
+                    triggerSurvey(SurveySurfaceType.QUERY_AUTHORING, {
+                        query_execution_id: queryId,
+                        cell_id: this.props.cellId,
+                    });
+                }
 
                 return queryId;
             }


### PR DESCRIPTION
Current:
The survey triggers on any cell execution. It means you can just open a DataDoc, hit Run button and the survey will show up asking how easy it was to create the query (and no query authoring happened). 


Updated as: 
Survey asking for query_authoring experience is shown only after user created new or modified existing query and ran it. 

