### PR TITLE
fix: add a clear_sheet parameter for google sheet exporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.29.0",
+    "version": "3.29.1",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {


### PR DESCRIPTION
Add an option in google sheet exporter to clear the sheet. By default it is `false` (to make it consistent as before)

![Snip20240122_1](https://github.com/pinterest/querybook/assets/8308723/7e518926-346c-4094-8d1f-97443a08f0e8)
