### PR TITLE
chore: Update pip install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,9 @@ RUN pip install -r requirements/base.txt \
     pip install -r requirements/${PACKAGE}; \
     done \
     fi \
-    && pip install -r requirements/local.txt || true
+    && if [ -f requirements/local.txt ]; then \
+    pip install -r requirements/local.txt; \
+    fi
 
 COPY package.json yarn.lock ./
 RUN yarn install --pure-lockfile


### PR DESCRIPTION
Previously, the `pip install` command in the Dockerfile ended in `|| true`, so it never failed.  I think the purpose was to make `local.txt` optional, but it also covers up any errors installing packages.

This removes `|| true` and instead makes `local.txt` optional by checking to see if the file exists.