### PR TITLE
fix: Fix create task schedule task_type

### DIFF
--- a/querybook/server/logic/schedule.py
+++ b/querybook/server/logic/schedule.py
@@ -65,7 +65,7 @@ def create_task_schedule(
         kwargs=kwargs or {},
         options=options or {},
         enabled=enabled,
-        task_type=get_schedule_task_type(name).value,
+        task_type=get_schedule_task_type(task).value,
     )
 
     session.add(schedule)


### PR DESCRIPTION
Currently Data Doc tasks are being created with `task_type` `"prod"` instead of `"user"`.  

This is because the `get_schedule_task_type()` function expects the Celery task name (`tasks.run_datadoc.run_datadoc`), not the task name (`run_data_doc_#`).