### PR TITLE
fix: Fix DataDoc cell move down button

### DIFF
--- a/querybook/webapp/components/DataDoc/DataDoc.scss
+++ b/querybook/webapp/components/DataDoc/DataDoc.scss
@@ -108,16 +108,19 @@
                     }
 
                     .block-crud-buttons {
+                        // Use opacity to prevent layout shift
                         opacity: 0;
+
+                        // Physically remove the cell header buttons to prevent
+                        // them from stealing hover events from the footer buttons
+                        &.is-header {
+                            display: none;
+                        }
+
                         top: -17px;
                         position: relative;
                         text-align: center;
                         margin: 0px 8px;
-
-                        &.active,
-                        &:hover {
-                            opacity: 1;
-                        }
 
                         .block-left-buttons-wrapper {
                             position: absolute;
@@ -153,13 +156,10 @@
                     transition: opacity 0.2s ease-out;
                 }
 
-                &:hover .add-new-line-button {
-                    opacity: 1;
-                }
-
                 &:hover {
                     .data-doc-cell-divider-container {
                         .block-crud-buttons {
+                            display: flex;
                             opacity: 1;
                         }
                     }

--- a/querybook/webapp/components/DataDoc/DataDocCellControl.tsx
+++ b/querybook/webapp/components/DataDoc/DataDocCellControl.tsx
@@ -97,7 +97,11 @@ export const DataDocCellControl: React.FunctionComponent<IProps> = ({
     const handlePasteCell = useBoundFunc(pasteCellAt, index);
     const handleDeleteCell = useBoundFunc(deleteCellAt, index);
     const handleMoveCellClick = useCallback(
-        () => moveCellAt(index, isHeader ? index - 1 : index + 1),
+        () =>
+            moveCellAt(
+                isHeader ? index : index - 1,
+                isHeader ? index - 1 : index
+            ),
         [moveCellAt, index, isHeader]
     );
 
@@ -262,6 +266,8 @@ export const DataDocCellControl: React.FunctionComponent<IProps> = ({
             className={clsx({
                 'block-crud-buttons': true,
                 'flex-center': true,
+                // Exclude the first header to prevent layout shift when it is hidden
+                'is-header': isHeader && index !== 0,
                 active,
             })}
         >


### PR DESCRIPTION
DataDoc cells have ⏫ ⏬ buttons to move them up or down in the DataDoc, but it's impossible to click on the ⏬ button because the next cell's ⏫ button always gets in the way.

Each cell has a header and a footer row of buttons, and the footer row overlaps the header row of the next cell.  They are set to `opacity: 0` unless the cell is being hovered over, so you never see both at the same time.  However, the issue is that elements on the page are automatically stacked bottom up, so that as you move down the page, each element stacks on top of earlier elements. Hovering doesn't care about order, so both the footer and the next header are both receiving the `:hover` style at the same time, and the stacking order puts the header on top of the footer, so you can't click the ⏬ button.

I fixed this issue by switching to `display: none`for just the header rows, which prevents them from receiving hover events.  Then I moved the `:hover` to the `.data-doc-cell-container-pair` itself, instead of the button row.  This means if you hover over a cell, the header/footers appear, and you can mouse over either without losing focus to nearby cells.  Once you move past the headers and into another cell, the header/footer flips to the newly-hovered cell.

I left the footer rows (and the first header) using `opacity: 0` to prevent layout shift: if both used `display: none`, the cells would move around as you hover.  This could be solved by adding additional margin to the cells and negative margin to the header/footers, but this approach was easier.

Here is a video of the change in action:

https://github.com/pinterest/querybook/assets/3084806/83dbf2e0-57e2-48bc-8302-14793c42943c


Finally⸺the down logic in `moveCellAt()` was broken so I implemented the easiest fix, adjusting the index calculations.   The actual issue is that the index is "wrong" for the footer buttons.  You can see that in this screenshot, where I show the value of the `index` field next to the buttons:

![Screenshot 2024-02-14 at 2 29 40 PM](https://github.com/pinterest/querybook/assets/3084806/988b5ee2-8067-493b-aab9-b35fd7c41988)

I assume that is intentional, and changing the `index` would require changes in all the other cell operations, so this seemed like the best fix.
