### PR TITLE
feat: enable impression logging of survey events

### DIFF
--- a/querybook/webapp/components/Survey/Survey.tsx
+++ b/querybook/webapp/components/Survey/Survey.tsx
@@ -2,12 +2,14 @@ import clsx from 'clsx';
 import React from 'react';
 import toast, { Toast } from 'react-hot-toast';
 
+import { ComponentType } from 'const/analytics';
 import {
     ISurvey,
     IUpdateSurveyFormData,
     SurveySurfaceType,
     SurveyTypeToQuestion,
 } from 'const/survey';
+import { useTrackView } from 'hooks/useTrackView';
 import { saveSurveyRespondRecord } from 'lib/survey/triggerLogic';
 import { SurveyResource } from 'resource/survey';
 import { TextButton } from 'ui/Button/Button';
@@ -28,6 +30,11 @@ export const Survey: React.FC<ISurveyProps> = ({
     surfaceMeta = {},
     toastProps,
 }) => {
+    useTrackView(ComponentType.SURVEY, undefined, {
+        surface,
+        meta: surfaceMeta,
+    });
+
     const [survey, setSurvey] = React.useState<ISurvey | null>(null);
     const handleDismiss = React.useCallback(() => {
         toast.dismiss(toastProps.id);

--- a/querybook/webapp/const/analytics.ts
+++ b/querybook/webapp/const/analytics.ts
@@ -20,6 +20,7 @@ export enum ComponentType {
     TABLE_DETAIL_VIEW = 'TABLE_DETAIL_VIEW',
     TABLE_NAVIGATOR_SEARCH = 'TABLE_NAVIGATOR_SEARCH',
     AI_ASSISTANT = 'AI_ASSISTANT',
+    SURVEY = 'SURVEY',
 }
 
 export enum ElementType {

--- a/querybook/webapp/hooks/useTrackView.ts
+++ b/querybook/webapp/hooks/useTrackView.ts
@@ -1,10 +1,14 @@
 import { useEffect } from 'react';
 
-import { ComponentType } from 'const/analytics';
+import { ComponentType, ElementType } from 'const/analytics';
 import { trackView } from 'lib/analytics';
 
-export function useTrackView(component: ComponentType) {
+export function useTrackView(
+    component: ComponentType,
+    element?: ElementType,
+    aux?: object
+) {
     useEffect(() => {
-        trackView(component);
-    }, [component]);
+        trackView(component, element, aux);
+    }, [component, element, aux]);
 }


### PR DESCRIPTION
this is to add logging whenever a survey event triggers, both surface info and meta are logged.