### PR TITLE
fix: update schedule disabler configs

### DIFF
--- a/querybook/server/tasks/disable_scheduled_docs.py
+++ b/querybook/server/tasks/disable_scheduled_docs.py
@@ -279,7 +279,7 @@ def disable_scheduled_docs(
     disable_if_failed_for_n_runs=5,
     disable_if_no_impression_for_n_days=30,
     skip_if_no_impression_but_non_select=True,
-    skip_if_no_impression_with_export=True
+    skip_if_no_impression_with_export=True,
 ):
     tasks_to_disable = disable_deactivated_scheduled_docs(
         dry_run=dry_run,

--- a/querybook/webapp/components/Task/TaskEditor.tsx
+++ b/querybook/webapp/components/Task/TaskEditor.tsx
@@ -68,7 +68,11 @@ function stringToTypedVal(stringVal: boolean | number | string) {
         return false;
     } else if (!isNaN(Number(stringVal))) {
         return Number(stringVal);
-    } else if ( stringVal === 'null' || stringVal === 'undefined' || stringVal === 'None') {
+    } else if (
+        stringVal === 'null' ||
+        stringVal === 'undefined' ||
+        stringVal === 'None'
+    ) {
         return null;
     } else {
         return stringVal;
@@ -239,7 +243,8 @@ export const TaskEditor: React.FunctionComponent<IProps> = ({
         );
 
         const getKwargPlaceholder = (param: string) =>
-            String(registeredTaskParamList?.[values.task]?.[param]) ?? 'Insert value';
+            String(registeredTaskParamList?.[values.task]?.[param]) ??
+            'Insert value';
 
         const kwargsDOM = (
             <div className="TaskEditor-kwargs mt12">


### PR DESCRIPTION
- adds kwarg options to the disable schedule task
- corrects behavior of `skip_if_no_impression_with_export` and `skip_if_no_impression_but_non_select` to match the semantic meaning of these options. "Skip disabling the datadoc if it has no impression but has an exporter", and "Skip disabling the datadoc if it has no impression but there are non-select queries"
- support for entering null values to kwargs, and improves rendering of non-integer default values for tasks.

Previously, creating this task looked like this:
<img width="800" alt="Screenshot 2024-02-22 at 2 11 23 PM" src="https://github.com/pinterest/querybook/assets/143662801/adccf7b8-cb85-445c-b6f2-8c731f9eef22">

View of creating the task now with kwarg options
<img width="800" alt="Screenshot 2024-02-21 at 12 45 52 PM" src="https://github.com/pinterest/querybook/assets/143662801/9e476fbf-dfa1-40c5-a544-be7fb0278763">