### PR TITLE
fix: Support serialized JSON environment variables

### DIFF
--- a/querybook/config/querybook_default_config.yaml
+++ b/querybook/config/querybook_default_config.yaml
@@ -4,7 +4,8 @@ FLASK_SECRET_KEY: ~
 # Url of the querybook site, used for auth callback and notifications
 PUBLIC_URL: ''
 # Use this config to set cache policy of flask, see https://pythonhosted.org/Flask-Cache/ for details
-FLASK_CACHE_CONFIG: '{"CACHE_TYPE": "simple"}'
+FLASK_CACHE_CONFIG:
+    CACHE_TYPE: 'simple'
 
 # --------------- Celery ---------------
 REDIS_URL: ~

--- a/querybook/server/env.py
+++ b/querybook/server/env.py
@@ -14,6 +14,17 @@ class MissingConfigException(Exception):
     pass
 
 
+def is_json(value):
+    """
+    Check if a given value is a valid JSON serialized dict or list
+    """
+    try:
+        parsed = json.loads(value)
+        return isinstance(parsed, (dict, list))
+    except ValueError:
+        return False
+
+
 def get_env_config(name, optional=True):
     found = True
     val = None
@@ -32,6 +43,9 @@ def get_env_config(name, optional=True):
         raise MissingConfigException(
             "{} is required to start the process.".format(name)
         )
+    # Check for string-serialized JSON dicts/lists
+    if isinstance(val, str) and is_json(val):
+        val = json.loads(val)
     return val
 
 
@@ -40,7 +54,8 @@ class QuerybookSettings(object):
     PRODUCTION = os.environ.get("production", "false") == "true"
     PUBLIC_URL = get_env_config("PUBLIC_URL")
     FLASK_SECRET_KEY = get_env_config("FLASK_SECRET_KEY", optional=False)
-    FLASK_CACHE_CONFIG = json.loads(get_env_config("FLASK_CACHE_CONFIG"))
+    FLASK_CACHE_CONFIG = get_env_config("FLASK_CACHE_CONFIG")
+
     # Celery
     REDIS_URL = get_env_config("REDIS_URL", optional=False)
 
@@ -117,7 +132,7 @@ class QuerybookSettings(object):
 
     DB_MAX_UPLOAD_SIZE = int(get_env_config("DB_MAX_UPLOAD_SIZE"))
 
-    GOOGLE_CREDS = json.loads(get_env_config("GOOGLE_CREDS") or "null")
+    GOOGLE_CREDS = get_env_config("GOOGLE_CREDS")
 
     # Logging
     LOG_LOCATION = get_env_config("LOG_LOCATION")


### PR DESCRIPTION
Some of the newer AI configs expect a `dict`, with the assumption that a custom `querybook_config.yaml` file is mounted into the Docker volume.  Unfortunately that's not straightforward in our deployment, so we're exclusively using environment variables.  As a workaround we've hardcoded the `dict` type configs into our Docker image, which is less flexible.

To address this, this PR adds support for deserializing JSON dicts/lists in configs.  It handles deserializing for both environment variables and YAML configs, so it should be backwards compatible with existing config files.

An example config:
```env
AI_ASSISTANT_CONFIG='{ "default": { "model_args": { "model_name": "gpt-3.5-turbo", "temperature": 0.2 }}}'
```

Two configs already expected serialized JSON: `FLASK_CACHE_CONFIG` and `GOOGLE_CREDS`.  Now they can be specified as either string-serialized JSON (like before) or a `dict`.

Note: I restricted this to `dict` and `list` types to avoid issues with `int` or `bool` types, e.g. where Querybook expects a value of `"true"` not `true`.  I didn't want to go through the entire code base to update all of those.