### PR TITLE
fix: move to first match on search term change

### DIFF
--- a/querybook/webapp/components/SearchAndReplace/CodeMirrorSearchHighlighter.tsx
+++ b/querybook/webapp/components/SearchAndReplace/CodeMirrorSearchHighlighter.tsx
@@ -61,7 +61,7 @@ export const CodeMirrorSearchHighlighter: React.FC<{
                 }
             );
         }
-    }, [currentSearchResultIndex]);
+    }, [currentSearchItem]);
 
     return null;
 };

--- a/querybook/webapp/components/SearchAndReplace/SearchAndReplaceBar.tsx
+++ b/querybook/webapp/components/SearchAndReplace/SearchAndReplaceBar.tsx
@@ -142,15 +142,11 @@ export const SearchAndReplaceBar = React.forwardRef<
         }));
 
         const noPrevRes = React.useMemo(
-            () =>
-                searchResults.length === 0 ||
-                currentSearchResultIndex <= searchResults.length,
+            () => searchResults.length <= 1,
             [searchResults.length, currentSearchResultIndex]
         );
         const noNextRes = React.useMemo(
-            () =>
-                searchResults.length === 0 ||
-                currentSearchResultIndex >= searchResults.length,
+            () => searchResults.length <= 1,
             [searchResults.length, currentSearchResultIndex]
         );
 

--- a/querybook/webapp/components/SearchAndReplace/SearchAndReplaceBar.tsx
+++ b/querybook/webapp/components/SearchAndReplace/SearchAndReplaceBar.tsx
@@ -143,11 +143,11 @@ export const SearchAndReplaceBar = React.forwardRef<
 
         const noPrevRes = React.useMemo(
             () => searchResults.length <= 1,
-            [searchResults.length, currentSearchResultIndex]
+            [searchResults.length]
         );
         const noNextRes = React.useMemo(
             () => searchResults.length <= 1,
-            [searchResults.length, currentSearchResultIndex]
+            [searchResults.length]
         );
 
         const searchRow = (


### PR DESCRIPTION
Previously, there was a bug that prevented the focus moving to the first match after the search term was updated (it moved the index of the first match of the previous term instead). 

This PR also includes a change that allows you to continuously scroll through match results (i.e. clicking "Previous Result" on the first match moves to the last match and vice versa). 


https://github.com/pinterest/querybook/assets/5560701/b80ee033-1ed8-48fb-8311-6d7193808d3e

