### PR TITLE
fix: add native sum column analyzer

### DIFF
--- a/querybook/webapp/lib/query-result/analyzer.ts
+++ b/querybook/webapp/lib/query-result/analyzer.ts
@@ -9,6 +9,19 @@ function arrToBigNumber(values: any[]) {
 
 export const columnStatsAnalyzers: IColumnStatsAnalyzer[] = [
     {
+        key: 'sum',
+        name: 'Sum',
+        appliesToType: ['number'],
+        generator: (values: any[]) => {
+            const bigNumberArray = arrToBigNumber(values);
+            const sum = bigNumberArray.reduce(
+                (s, value) => s.plus(value),
+                new BigNumber(0)
+            );
+            return sum.toFormat(2);
+        },
+    },
+    {
         key: 'average',
         name: 'Average',
         appliesToType: ['number'],


### PR DESCRIPTION
I know that there's the option to add custom column analyzers, but I think sum is common enough to be supported natively and appear at the top of the Quick Insights view of a column.

<img width="588" alt="Screenshot 2024-03-01 at 11 42 57 AM" src="https://github.com/pinterest/querybook/assets/143662801/14154a92-3705-442f-80da-20ec5e2c75d2">