### PR TITLE
feat: Auto-load built-in notifiers if configured

### DIFF
--- a/docs_website/docs/integrations/add_notifier.mdx
+++ b/docs_website/docs/integrations/add_notifier.mdx
@@ -12,11 +12,20 @@ Notifiers provide the option for users to be notified upon completion of their q
 -   Slack
 -   Microsoft Teams
 
+## Provided Notifiers
+
+The following notifiers are provided by default, and will automatically enable themselves if the necessary configurations are provided:
+
+-   `EmailNotifier`: Sends an email to the user(s) or email address(es) provided. Requires the `EMAILER_CONN` and `QUERYBOOK_EMAIL_ADDRESS` configurations to be set.
+-   `SlackNotifier`: Sends a message to a Slack channel or user(s). Requires the `QUERYBOOK_SLACK_TOKEN` configuration to be set.
+
+If no notifiers are enabled and configured, a `NoopNotifier` will be used, which logs the notification message to the server logs along with a suggestion to enable a notifier.
+
 ## Implementation
 
-To keep the notification process standardized, the standard notifiers are included under \<project_root>/querybook/server/lib/notify/notifiers,
-but for custom notifiers create them under \<project_root>/plugins/notifier_plugin/.
-All notifiers must inherit from BaseNotifier that lives in \<project_root>/querybook/server/lib/notify/base_notifier.py.
+To keep the notification process standardized, the standard notifiers are included under `/querybook/server/lib/notify/notifiers`,
+but custom notifiers should be created under `/plugins/notifier_plugin/`.
+All notifiers must inherit from `BaseNotifier` that lives in `/querybook/server/lib/notify/base_notifier.py`.
 
 Here are some fields of notifier that you must configure in the setup process:
 
@@ -29,4 +38,20 @@ Here are some fields of notifier that you must configure in the setup process:
 
 If you want to add a notifier that's specific to your own use case, please do so through plugins (See this [Plugin Guide](plugins.mdx) to learn how to setup plugins for Querybook).
 
-Once plugins folder is setup, import the notifier class under `ALL_PLUGIN_NOTIFIERS` in notifier_plugin/**init**.py .
+Once plugins folder is setup, import the notifier class under `ALL_PLUGIN_NOTIFIERS` in `notifier_plugin/__init__.py`.
+
+```python
+from lib.notify.notifier.email_notifier import EmailNotifier
+from lib.notify.notifier.slack_notifier import SlackNotifier
+
+
+ALL_PLUGIN_NOTIFIERS = [
+    EmailNotifier(),
+    SlackNotifier(),
+    # Add your notifier here
+]
+```
+
+:::warning
+If you configure the `ALL_PLUGIN_NOTIFIERS`, the default notifiers will not enabled automatically. You will need to include them in the notifiers list if you want to use them.
+:::

--- a/querybook/server/lib/notify/all_notifiers.py
+++ b/querybook/server/lib/notify/all_notifiers.py
@@ -1,12 +1,24 @@
+from env import QuerybookSettings
+
 from lib.utils.import_helper import import_module_with_default
 from .notifier.email_notifier import EmailNotifier
+from .notifier.noop_notifier import NoopNotifier
+from .notifier.slack_notifier import SlackNotifier
+
+default_notifiers = []
+
+# Auto-load the EmailNotifier / SlackNotifier if configured
+if QuerybookSettings.EMAILER_CONN and QuerybookSettings.QUERYBOOK_EMAIL_ADDRESS:
+    default_notifiers.append(EmailNotifier())
+if QuerybookSettings.QUERYBOOK_SLACK_TOKEN:
+    default_notifiers.append(SlackNotifier())
+
+# If no other notifiers auto-loaded, enable the NoopNotifier
+if not default_notifiers:
+    default_notifiers.append(NoopNotifier())
 
 ALL_PLUGIN_NOTIFIERS = import_module_with_default(
-    "notifier_plugin",
-    "ALL_PLUGIN_NOTIFIERS",
-    default=[
-        EmailNotifier(),
-    ],
+    "notifier_plugin", "ALL_PLUGIN_NOTIFIERS", default=default_notifiers
 )
 
 ALL_NOTIFIERS = ALL_PLUGIN_NOTIFIERS

--- a/querybook/server/lib/notify/notifier/noop_notifier.py
+++ b/querybook/server/lib/notify/notifier/noop_notifier.py
@@ -1,0 +1,27 @@
+from lib.notify.base_notifier import BaseNotifier
+from lib.logger import get_logger
+
+LOG = get_logger(__file__)
+
+
+class NoopNotifier(BaseNotifier):
+    @property
+    def notifier_name(self):
+        return "noop"
+
+    @property
+    def notifier_help(self) -> str:
+        return "Noop notifier does not send any notification. It is used for testing purposes."
+
+    @property
+    def notifier_format(self):
+        return "plaintext"
+
+    def notify_recipients(self, recipients, message):
+        LOG.info(f"📣 Noop notification to {recipients}: {message}")
+        LOG.info(
+            "📣 No notifier is configured, please configure a notifier to receive actual notifications!"
+        )
+
+    def notify(self, user, message):
+        self.notify_recipients(recipients=[user.email], message=message)


### PR DESCRIPTION
Fixes #733:
- configures the two built-in notifiers (Slack, Email) to automatically load themselves if the corresponding configs are set
- adds a `NoopNotifier` that enables itself if no other notifiers are enabled⸺it outputs notifications to the server logs
- updated docs
