### PR TITLE
feat: editor awareness of default schemas

### DIFF
--- a/querybook/server/models/admin.py
+++ b/querybook/server/models/admin.py
@@ -105,6 +105,19 @@ class QueryEngine(CRUDMixin, Base):
         ),
     )
 
+    def get_default_schema(self):
+        default_schema = "default"
+        connection_string = self.executor_params.get("connection_string")
+        try:
+            connection_url = sql.engine.make_url(connection_string)
+        except Exception:
+            connection_url = None
+
+        if connection_url:
+            default_schema = connection_url.database or default_schema
+
+        return default_schema
+
     def to_dict(self):
         # IMPORTANT: do not expose executor params unless it is for admin
         return {
@@ -115,6 +128,7 @@ class QueryEngine(CRUDMixin, Base):
             "metastore_id": self.metastore_id,
             "feature_params": self.get_feature_params(),
             "executor": self.executor,
+            "default_schema": self.get_default_schema(),
         }
 
     def to_dict_admin(self):

--- a/querybook/webapp/components/QueryEditor/BoundQueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/BoundQueryEditor.tsx
@@ -29,6 +29,7 @@ export const BoundQueryEditor = React.forwardRef<
         | 'functionDocumentationByNameByLanguage'
         | 'metastoreId'
         | 'language'
+        | 'defaultSchema'
     > & {
         engine?: IQueryEngine;
         cellId?: number;
@@ -109,6 +110,7 @@ export const BoundQueryEditor = React.forwardRef<
                 }
                 metastoreId={engine?.metastore_id}
                 language={engine?.language}
+                defaultSchema={engine?.default_schema}
             />
         );
 

--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -50,6 +50,7 @@ export interface IQueryEditorProps extends IStyledQueryEditorProps {
     lineWrapping?: boolean;
     readOnly?: boolean;
     language?: string;
+    defaultSchema?: string;
     theme?: string;
     functionDocumentationByNameByLanguage?: FunctionDocumentationCollection;
     metastoreId?: number;
@@ -107,6 +108,7 @@ export const QueryEditor: React.FC<
             lineWrapping = false,
             readOnly,
             language = 'hive',
+            defaultSchema = 'default',
             theme = 'default',
             functionDocumentationByNameByLanguage = {},
             metastoreId,
@@ -136,6 +138,7 @@ export const QueryEditor: React.FC<
         const { codeAnalysis, codeAnalysisRef } = useCodeAnalysis({
             language,
             query: value,
+            defaultSchema
         });
         const autoCompleterRef = useAutoComplete(
             metastoreId,

--- a/querybook/webapp/const/queryEngine.ts
+++ b/querybook/webapp/const/queryEngine.ts
@@ -6,6 +6,7 @@ export interface IQueryEngine {
     name: string;
     language: string;
     description: string;
+    default_schema: string;
 
     metastore_id: number;
     executor: string;

--- a/querybook/webapp/hooks/queryEditor/useCodeAnalysis.ts
+++ b/querybook/webapp/hooks/queryEditor/useCodeAnalysis.ts
@@ -7,9 +7,10 @@ import { analyzeCode } from 'lib/web-worker';
 interface IUseCodeAnalysisParams {
     language: string;
     query: string;
+    defaultSchema: string;
 }
 
-export function useCodeAnalysis({ language, query }: IUseCodeAnalysisParams) {
+export function useCodeAnalysis({ language, query, defaultSchema }: IUseCodeAnalysisParams) {
     /**
      * the ref version is used to pass into functions in codemirror
      * this is to prevent unnecessary codemirror refreshes
@@ -19,13 +20,13 @@ export function useCodeAnalysis({ language, query }: IUseCodeAnalysisParams) {
     const debouncedQuery = useDebounce(query, 500);
 
     useEffect(() => {
-        analyzeCode(debouncedQuery, 'autocomplete', language).then(
+        analyzeCode(debouncedQuery, 'autocomplete', language, defaultSchema).then(
             (codeAnalysis) => {
                 codeAnalysisRef.current = codeAnalysis;
                 setCodeAnalysis(codeAnalysis);
             }
         );
-    }, [debouncedQuery, language]);
+    }, [debouncedQuery, language, defaultSchema]);
 
-    return { codeAnalysisRef, codeAnalysis };
+    return { codeAnalysis, codeAnalysisRef };
 }

--- a/querybook/webapp/lib/sql-helper/sql-autocompleter.ts
+++ b/querybook/webapp/lib/sql-helper/sql-autocompleter.ts
@@ -240,9 +240,12 @@ export class SqlAutoCompleter {
             return [];
         }
 
+        let omit_schema = this.codeAnalysis.lineage.activeSchema || 'default';
+
         const { data: names } = await SearchTableResource.suggest(
             metastoreId,
-            prefix
+            prefix,
+            omit_schema
         );
         return names;
     }

--- a/querybook/webapp/lib/sql-helper/sql-lexer.ts
+++ b/querybook/webapp/lib/sql-helper/sql-lexer.ts
@@ -65,6 +65,7 @@ const contextSensitiveKeyWord = {
     table: 'table',
     update: 'table',
     join: 'table',
+    on: 'column',
     set: 'column',
 
     desc: 'table',
@@ -183,6 +184,7 @@ export interface ILinterWarning extends IRange {
 export interface ILineage {
     references: Record<number, TableToken[]>;
     aliases: Record<number, Record<string, TableToken>>;
+    activeSchema: string;
 }
 
 export interface ICodeAnalysis {
@@ -646,10 +648,13 @@ export function findWithStatementPlaceholder(statement: IToken[]) {
     return placeholders;
 }
 
-export function findTableReferenceAndAlias(statements: IToken[][]) {
-    let defaultSchema = 'default';
+export function findTableReferenceAndAlias(
+    statements: IToken[][],
+    defaultSchema: string = 'default'
+) {
     const references: Record<number, TableToken[]> = {};
     const aliases: Record<number, Record<string, TableToken>> = {};
+    let activeSchema = defaultSchema;
 
     statements.forEach((statement, statementNum) => {
         if (statement.length === 0) {
@@ -679,6 +684,7 @@ export function findTableReferenceAndAlias(statements: IToken[][]) {
             const secondToken = statement[tokenCounter++];
             if (secondToken && secondToken.type === 'VARIABLE') {
                 defaultSchema = secondToken.text;
+                activeSchema = defaultSchema;
             }
         } else {
             const placeholders: Set<string> = new Set(
@@ -807,6 +813,7 @@ export function findTableReferenceAndAlias(statements: IToken[][]) {
     return {
         references,
         aliases,
+        activeSchema,
     };
 }
 

--- a/querybook/webapp/lib/web-worker/index.ts
+++ b/querybook/webapp/lib/web-worker/index.ts
@@ -11,7 +11,8 @@ let sqlEditorWorker = null;
 export function analyzeCode(
     code: string,
     mode = 'autocomplete',
-    language = 'hive'
+    language = 'hive',
+    defaultSchema = 'default'
 ): Promise<ICodeAnalysis> {
     if (!sqlEditorWorker) {
         sqlEditorWorker = new Worker(
@@ -40,6 +41,7 @@ export function analyzeCode(
             mode,
             id,
             language,
+            defaultSchema
         });
     });
 }

--- a/querybook/webapp/lib/web-worker/sql-editor.worker.ts
+++ b/querybook/webapp/lib/web-worker/sql-editor.worker.ts
@@ -11,12 +11,12 @@ const context: Worker = self as any;
 context.addEventListener(
     'message',
     (e) => {
-        const { id, mode, code, language } = e.data;
+        const { id, mode, code, language, defaultSchema } = e.data;
         const tokens = tokenize(code, { language });
         const statements = simpleParse(tokens);
 
         const codeAnalysis: ICodeAnalysis = {
-            lineage: findTableReferenceAndAlias(statements),
+            lineage: findTableReferenceAndAlias(statements, defaultSchema),
         };
 
         if (mode === 'autocomplete') {

--- a/querybook/webapp/resource/search.ts
+++ b/querybook/webapp/resource/search.ts
@@ -33,9 +33,9 @@ export const SearchTableResource = {
             count: number;
         }>('/search/tables/vector/', { ...params }),
 
-    suggest: (metastoreId: number, prefix: string) =>
+    suggest: (metastoreId: number, prefix: string, active_schema: string = 'default') =>
         ds.fetch<string[]>(`/suggest/${metastoreId}/tables/`, {
-            prefix,
+            prefix, active_schema: active_schema
         }),
 };
 


### PR DESCRIPTION
Video Demo/Explanation of Feature: https://youtu.be/w0z4pU_E0bM

### Issue
QueryBook QueryEditor is unaware of QueryEngine Connection URI's Default/Named database/schema

### Resolution (see video for walkthrough):
Add simple get_default_schema method to QueryEngine python model to parse any provided default schema on the connection URI
Make this defaultSchema known to the front-end for Linting, Analysis, and AutoCompletion
Retain support for use statements and explicit schemas when needed, and no-op to implicit "default" schema name when not provided