### PR TITLE
fix: Metastore ACL support for wildcard prefix match

### DIFF
--- a/querybook/server/lib/metastore/utils.py
+++ b/querybook/server/lib/metastore/utils.py
@@ -29,6 +29,8 @@ class MetastoreTableACLChecker(object):
             for schema_table in self._tables_by_schema[schema]:
                 if schema_table == table or schema_table == "*":
                     return True
+                elif schema_table.endswith("*") and table.startswith(schema_table[:-1]):
+                    return True
         return False
 
     def is_table_valid(

--- a/querybook/webapp/components/AppAdmin/AdminMetastore.tsx
+++ b/querybook/webapp/components/AppAdmin/AdminMetastore.tsx
@@ -11,12 +11,14 @@ import history from 'lib/router-history';
 import { generateFormattedDate } from 'lib/utils/datetime';
 import { AdminMetastoreResource } from 'resource/admin/metastore';
 import { TextButton } from 'ui/Button/Button';
+import { InfoButton } from 'ui/Button/InfoButton';
 import { Card } from 'ui/Card/Card';
 import { SimpleField } from 'ui/FormikField/SimpleField';
 import { GenericCRUD } from 'ui/GenericCRUD/GenericCRUD';
 import { Icon } from 'ui/Icon/Icon';
 import { Level } from 'ui/Level/Level';
 import { Loading } from 'ui/Loading/Loading';
+import { Markdown } from 'ui/Markdown/Markdown';
 import {
     getDefaultFormValue,
     SmartForm,
@@ -302,10 +304,23 @@ export const AdminMetastore: React.FunctionComponent<IProps> = ({
                             </div>
                         )}
                         <div className="AdminForm-section">
-                            <div className="AdminForm-section-top flex-row">
+                            <div className="AdminForm-section-top flex-row horizontal-space-between">
                                 <div className="AdminForm-section-title">
                                     ACL Control
                                 </div>
+                                <InfoButton layout={['bottom', 'right']}>
+                                    <Markdown>{`Access Control Lists (ACL)
+are used to limit access to tables in the metastore. If no ACL rules are specified,
+all schemas/tables are allowed.  Either an allowlist or a denylist can be configured.
+
+Each value in the list should be in one of the following formats:
+
+- \`schema.*\`: Allow or deny all tables in a schema
+- \`schema.table*\`: Allow or deny all tables in a schema matching a prefix
+- \`schema.table\`: Allow or deny a specific table
+
+This feature affects both the metastore sync and the query engine.`}</Markdown>
+                                </InfoButton>
                             </div>
                             <div className="AdminForm-section-content">
                                 {getMetastoreACLControlDOM(


### PR DESCRIPTION
Adds support for wildcard prefixes on table names in the ACL rules.  E.g. `querybook2.query_*` matches any tables in the `querybook2` schema starting with `query_`.

Also added a helper tooltip to the admin UI to document the supported formats, since I don't think there's any other documentation on how to use this feature.

![Screenshot 2024-03-11 at 3 14 50 PM](https://github.com/pinterest/querybook/assets/3084806/cccf187c-8cbe-4807-9230-d64f621b777c)
