### PR TITLE
fix: typo in QuerybookSidebarUIGuide

### DIFF
--- a/querybook/webapp/components/UIGuide/QuerybookSidebarUIGuide.tsx
+++ b/querybook/webapp/components/UIGuide/QuerybookSidebarUIGuide.tsx
@@ -80,7 +80,7 @@ function getQuerybookSidebarTourSteps() {
                 <>
                     <p>
                         This is the Adhoc Editor for running simple queries. It
-                        will show you an query editor in the workspace.
+                        will show you a query editor in the workspace.
                     </p>
                     <hr />
                     <p>


### PR DESCRIPTION
Found a typo in the Sidebar guide.

![Sidebar guide](https://github.com/pinterest/querybook/assets/82800212/ca3fc662-db0e-41f7-b7c5-cdbcb0a57ccb)
