### PR TITLE
feat: add @mention to select a table for the command input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.33.1",
+    "version": "3.33.2",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {
@@ -83,6 +83,7 @@
         "react-hot-toast": "^2.4.0",
         "react-json-view": "^1.21.3",
         "react-lazyload": "^3.2.0",
+        "react-mentions": "^4.4.10",
         "react-redux": "7.2.4",
         "react-router-dom": "5.1.2",
         "react-select": "4.3.1",

--- a/querybook/config/elasticsearch.yaml
+++ b/querybook/config/elasticsearch.yaml
@@ -212,7 +212,7 @@ tables:
                 full_name_ngram:
                     type: text
                     analyzer: edge_ngram_lowercase
-                completion_name:
+                completion_name: # to be deprecated
                     type: completion
                     analyzer: keyword
                     contexts:

--- a/querybook/server/datasources/search.py
+++ b/querybook/server/datasources/search.py
@@ -130,20 +130,14 @@ def vector_search_tables(
 
 
 @register("/suggest/<int:metastore_id>/tables/", methods=["GET"])
-def suggest_tables(metastore_id, prefix, limit=10):
+def suggest_tables(metastore_id, keyword, limit=10):
     api_assert(limit is None or limit <= 100, "Requesting too many tables")
     verify_metastore_permission(metastore_id)
 
-    query = construct_suggest_table_query(prefix, limit, metastore_id)
+    query = construct_suggest_table_query(keyword, limit, metastore_id)
     options = get_matching_suggestions(query, ES_CONFIG["tables"]["index_name"])
-    texts = [
-        "{}.{}".format(
-            option.get("_source", {}).get("schema", ""),
-            option.get("_source", {}).get("name", ""),
-        )
-        for option in options
-    ]
-    return texts
+    tables = [option.get("_source", {}).get("full_name") for option in options]
+    return tables
 
 
 # /search/ but it is actually suggest

--- a/querybook/server/lib/elasticsearch/search_utils.py
+++ b/querybook/server/lib/elasticsearch/search_utils.py
@@ -79,8 +79,6 @@ def get_matching_suggestions(query: Union[str, Dict], index_name: str):
         if result is None:
             result = {}
 
-    options = next(iter(result.get("suggest", {}).get("suggest", [])), {}).get(
-        "options", []
-    )
+    options = result.get("hits", {}).get("hits", [])
 
     return options

--- a/querybook/server/lib/elasticsearch/suggest_table.py
+++ b/querybook/server/lib/elasticsearch/suggest_table.py
@@ -1,17 +1,18 @@
 def construct_suggest_table_query(
-    prefix: str,
+    keyword: str,
     limit: int,
     metastore_id: int,
 ):
     return {
-        "suggest": {
-            "suggest": {
-                "text": prefix,
-                "completion": {
-                    "field": "completion_name",
-                    "size": limit,
-                    "contexts": {"metastore_id": metastore_id},
+        "from": 0,
+        "size": limit,
+        "query": {
+            "bool": {
+                "must": {
+                    "match": {"full_name_ngram": {"query": keyword, "operator": "and"}}
                 },
+                "filter": {"match": {"metastore_id": metastore_id}},
             }
         },
+        "_source": ["id", "full_name"],
     }

--- a/querybook/server/logic/elasticsearch.py
+++ b/querybook/server/logic/elasticsearch.py
@@ -601,6 +601,7 @@ def table_to_es(table, fields=None, session=None):
         "name": table_name,
         "full_name": full_name,
         "full_name_ngram": full_name,
+        # To be deprecated: completion_name is not used anymore
         "completion_name": get_completion_name,
         "description": get_table_description,
         "created_at": lambda: DATETIME_TO_UTC(table.created_at),

--- a/querybook/webapp/components/AIAssistant/AICommandBar.tsx
+++ b/querybook/webapp/components/AIAssistant/AICommandBar.tsx
@@ -100,9 +100,10 @@ export const AICommandBar: React.FC<IQueryCellCommandBarProps> = forwardRef(
         useEffect(() => {
             if (!query && mentionedTables.length === 1) {
                 onUpdateQuery(
-                    `SELECT\n  *\nFROM\n  ${mentionedTables[0]}\nLIMIT\n  10`,
+                    `SELECT * FROM ${mentionedTables[0]} LIMIT 10`,
                     false
                 );
+                onFormatQuery();
             }
         }, [mentionedTables]);
 

--- a/querybook/webapp/components/AIAssistant/AICommandBar.tsx
+++ b/querybook/webapp/components/AIAssistant/AICommandBar.tsx
@@ -146,10 +146,6 @@ export const AICommandBar: React.FC<IQueryCellCommandBarProps> = forwardRef(
         }, [command, runCommand, setShowPopupView, commandKwargs]);
 
         const getCommandResultView = () => {
-            if (!commandResult) {
-                return null;
-            }
-
             if (command.name === 'generate' || command.name === 'edit') {
                 return (
                     <AICommandResultView

--- a/querybook/webapp/components/AIAssistant/AICommandInput.scss
+++ b/querybook/webapp/components/AIAssistant/AICommandInput.scss
@@ -6,10 +6,6 @@
     background-color: var(--bg-lightest);
     border-radius: var(--border-radius-sm);
 
-    &:hover {
-        background-color: var(--bg-hover);
-    }
-
     .stars-icon {
         position: relative;
         color: var(--icon);
@@ -41,15 +37,6 @@
         color: var(--color-pink-dark);
     }
 
-    .question-text-area {
-        flex: 1;
-        min-width: auto;
-        line-height: 24px;
-        min-height: 40px;
-        overflow: hidden;
-        padding: 8px 8px;
-    }
-
     .button {
         height: 28px;
         margin: 6px;
@@ -59,6 +46,7 @@
 .AICommandInput-popover {
     border-radius: var(--border-radius-sm);
     overflow: hidden;
+    box-shadow: 0 0px 4px var(--bg-dark);
 
     .command-item {
         display: flex;

--- a/querybook/webapp/components/AIAssistant/AICommandInput.tsx
+++ b/querybook/webapp/components/AIAssistant/AICommandInput.tsx
@@ -198,33 +198,29 @@ export const AICommandInput: React.FC<AICommandInputProps> = forwardRef(
 
         const loadTables = useCallback(
             (
-                keywords: string,
+                keyword: string,
                 callback: (
                     options: Array<{ id: string; display: string }>
                 ) => void
             ) => {
-                if (!keywords) {
+                if (!keyword) {
                     return;
                 }
 
-                SearchTableResource.searchConcise({
-                    metastore_id: metastoreId,
-                    keywords,
-                }).then(({ data }) => {
-                    const filteredTableNames = data.results.filter(
-                        (result) =>
-                            !mentionedTables.includes(
-                                `${result.schema}.${result.name}`
-                            )
-                    );
-                    const tableNameOptions = filteredTableNames.map(
-                        ({ schema, name }) => ({
-                            id: `${schema}.${name}`,
-                            display: `${schema}.${name}`,
-                        })
-                    );
-                    callback(tableNameOptions);
-                });
+                SearchTableResource.suggest(metastoreId, keyword).then(
+                    ({ data }) => {
+                        const filteredTableNames = data.filter(
+                            (table) => !mentionedTables.includes(table)
+                        );
+                        const tableNameOptions = filteredTableNames.map(
+                            (table) => ({
+                                id: table,
+                                display: table,
+                            })
+                        );
+                        callback(tableNameOptions);
+                    }
+                );
             },
             [metastoreId, mentionedTables]
         );

--- a/querybook/webapp/components/AIAssistant/AICommandInput.tsx
+++ b/querybook/webapp/components/AIAssistant/AICommandInput.tsx
@@ -250,7 +250,7 @@ export const AICommandInput: React.FC<AICommandInputProps> = forwardRef(
                     placeholder={
                         command
                             ? command.hint
-                            : 'Ask AI to generate/edit the query. Type @ to select a table. Type / to see more commands. Type Cmd+/ to reset the command.'
+                            : `Ask AI to generate/edit the query. Type @ to select a table. Type / to see more commands. Type ${KeyMap.aiCommandBar.openCommands.key} to reset the command.`
                     }
                     onBlur={() => setShowCommands(false)}
                     inputRef={textareaRef}

--- a/querybook/webapp/components/AIAssistant/AICommandInput.tsx
+++ b/querybook/webapp/components/AIAssistant/AICommandInput.tsx
@@ -218,7 +218,7 @@ export const AICommandInput: React.FC<AICommandInputProps> = forwardRef(
                             )
                     );
                     const tableNameOptions = filteredTableNames.map(
-                        ({ id, schema, name }) => ({
+                        ({ schema, name }) => ({
                             id: `${schema}.${name}`,
                             display: `${schema}.${name}`,
                         })

--- a/querybook/webapp/components/AIAssistant/AICommandResultView.tsx
+++ b/querybook/webapp/components/AIAssistant/AICommandResultView.tsx
@@ -14,6 +14,7 @@ interface IAICommandResultViewProps {
     metastoreId: number;
     originalQuery: string;
     tables: string[];
+    hasMentionedTables: boolean;
     commandResult: Record<string, any>;
     isStreaming: boolean;
     onContinue: () => void;
@@ -28,6 +29,7 @@ export const AICommandResultView = ({
     metastoreId,
     originalQuery,
     tables,
+    hasMentionedTables,
     commandResult,
     isStreaming,
     onContinue,
@@ -98,7 +100,7 @@ export const AICommandResultView = ({
                     setFoundTables(true);
                 }}
             />
-            {foundTables && tables.length > 0 && (
+            {(foundTables || tables.length > 0) && (
                 <div className="mt12">
                     <Button
                         title="Continue"
@@ -133,7 +135,7 @@ export const AICommandResultView = ({
 
     return (
         <div>
-            {tablesDOM}
+            {!hasMentionedTables && tablesDOM}
             {explanation && <div className="mt12">{explanation}</div>}
             {queryDiffDOM}
             {actionButtonsDOM}

--- a/querybook/webapp/components/AIAssistant/AICommandResultView.tsx
+++ b/querybook/webapp/components/AIAssistant/AICommandResultView.tsx
@@ -30,7 +30,7 @@ export const AICommandResultView = ({
     originalQuery,
     tables,
     hasMentionedTables,
-    commandResult,
+    commandResult = {},
     isStreaming,
     onContinue,
     onTablesChange,
@@ -42,7 +42,7 @@ export const AICommandResultView = ({
     const [foundTables, setFoundTables] = useState<boolean>(false);
 
     useEffect(() => {
-        const { type, data } = commandResult;
+        const { type, data = {} } = commandResult;
 
         if (type === 'tables') {
             onTablesChange(data);
@@ -100,7 +100,7 @@ export const AICommandResultView = ({
                     setFoundTables(true);
                 }}
             />
-            {(foundTables || tables.length > 0) && (
+            {foundTables && tables.length > 0 && (
                 <div className="mt12">
                     <Button
                         title="Continue"

--- a/querybook/webapp/const/keyMap.ts
+++ b/querybook/webapp/const/keyMap.ts
@@ -85,6 +85,12 @@ const DEFAULT_KEY_MAP = {
             name: 'Delete current cell',
         },
     },
+    commandBar: {
+        openCommands: {
+            key: 'Cmd-/',
+            name: 'Open commands',
+        },
+    },
     queryEditor: {
         runQuery: {
             key: 'Shift-Enter',

--- a/querybook/webapp/const/keyMap.ts
+++ b/querybook/webapp/const/keyMap.ts
@@ -85,7 +85,7 @@ const DEFAULT_KEY_MAP = {
             name: 'Delete current cell',
         },
     },
-    commandBar: {
+    aiCommandBar: {
         openCommands: {
             key: 'Cmd-/',
             name: 'Open commands',

--- a/querybook/webapp/lib/utils/keyboard.ts
+++ b/querybook/webapp/lib/utils/keyboard.ts
@@ -9,15 +9,15 @@ const specialKeyChecker: Record<string, (e: AllKeyboardEvent) => boolean> = {
     ALT: (event: AllKeyboardEvent) => event.altKey,
     SHIFT: (event: AllKeyboardEvent) => event.shiftKey,
 
-    DELETE: (event: AllKeyboardEvent) => event.keyCode === 8,
-    TAB: (event: AllKeyboardEvent) => event.keyCode === 9,
-    ENTER: (event: AllKeyboardEvent) => event.keyCode === 13,
-    ESC: (event: AllKeyboardEvent) => event.keyCode === 27,
+    DELETE: (event: AllKeyboardEvent) => event.key === 'Backspace',
+    TAB: (event: AllKeyboardEvent) => event.key === 'Tab',
+    ENTER: (event: AllKeyboardEvent) => event.key === 'Enter',
+    ESC: (event: AllKeyboardEvent) => event.key === 'Escape',
 
-    LEFT: (event: AllKeyboardEvent) => event.keyCode === 37,
-    UP: (event: AllKeyboardEvent) => event.keyCode === 38,
-    RIGHT: (event: AllKeyboardEvent) => event.keyCode === 39,
-    DOWN: (event: AllKeyboardEvent) => event.keyCode === 40,
+    LEFT: (event: AllKeyboardEvent) => event.key === 'ArrowLeft',
+    UP: (event: AllKeyboardEvent) => event.key === 'ArrowUp',
+    RIGHT: (event: AllKeyboardEvent) => event.key === 'ArrowRight',
+    DOWN: (event: AllKeyboardEvent) => event.key === 'ArrowDown',
 };
 
 const SpecialKeyToSymbol = {
@@ -54,7 +54,7 @@ export function matchKeyPress(
             if (upperKey in specialKeyChecker) {
                 return specialKeyChecker[upperKey](event);
             } else if (upperKey.length === 1) {
-                return event.keyCode === upperKey.charCodeAt(0);
+                return event.key.toUpperCase() === upperKey;
             }
             return false;
         });

--- a/querybook/webapp/resource/search.ts
+++ b/querybook/webapp/resource/search.ts
@@ -33,9 +33,9 @@ export const SearchTableResource = {
             count: number;
         }>('/search/tables/vector/', { ...params }),
 
-    suggest: (metastoreId: number, prefix: string) =>
+    suggest: (metastoreId: number, keyword: string) =>
         ds.fetch<string[]>(`/suggest/${metastoreId}/tables/`, {
-            prefix,
+            keyword,
         }),
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2707,6 +2707,13 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/runtime@7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
+  integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@^7.0.0":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.4.tgz#dc2e34982eb236803aa27a07fea6857af1b9171d"
@@ -2762,6 +2769,13 @@
   integrity sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==
   dependencies:
     regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.3.4":
+  version "7.24.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.4.tgz#de795accd698007a66ba44add6cc86542aff1edd"
+  integrity sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==
+  dependencies:
+    regenerator-runtime "^0.14.0"
 
 "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6":
   version "7.10.3"
@@ -11837,7 +11851,7 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
-invariant@^2.2.3:
+invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -16115,6 +16129,16 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-mentions@^4.4.10:
+  version "4.4.10"
+  resolved "https://registry.yarnpkg.com/react-mentions/-/react-mentions-4.4.10.tgz#ae6c1e310a405597e83ce786f12c5bfb93b097ce"
+  integrity sha512-JHiQlgF1oSZR7VYPjq32wy97z1w1oE4x10EuhKjPr4WUKhVzG1uFQhQjKqjQkbVqJrmahf+ldgBTv36NrkpKpA==
+  dependencies:
+    "@babel/runtime" "7.4.5"
+    invariant "^2.2.4"
+    prop-types "^15.5.8"
+    substyle "^9.1.0"
+
 react-redux@7.2.4:
   version "7.2.4"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.4.tgz#1ebb474032b72d806de2e0519cd07761e222e225"
@@ -16466,6 +16490,11 @@ regenerator-runtime@^0.13.7:
   version "0.13.7"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regenerator-transform@^0.14.2:
   version "0.14.5"
@@ -17965,6 +17994,14 @@ stylis@^4.0.3:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.10.tgz#446512d1097197ab3f02fb3c258358c3f7a14240"
   integrity sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg==
+
+substyle@^9.1.0:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/substyle/-/substyle-9.4.1.tgz#6a4647f363bc14fecc51aac371d4dbeda082aa50"
+  integrity sha512-VOngeq/W1/UkxiGzeqVvDbGDPM8XgUyJVWjrqeh+GgKqspEPiLYndK+XRcsKUHM5Muz/++1ctJ1QCF/OqRiKWA==
+  dependencies:
+    "@babel/runtime" "^7.3.4"
+    invariant "^2.2.4"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- use "@" to mention what table to use
- if it's a new cell, it will populate a simple select * query for the first mentioned table automatically
- use cmd+/ to reset and open the commands

Also updated the table suggest API to cover non prefix suggestion.

package used: https://github.com/signavio/react-mentions

![text2sql-table](https://github.com/pinterest/querybook/assets/8308723/4e144f09-bd3f-4579-b315-cf934be24875)
