### PR TITLE
fix: use match_phrase_prefix on full_name field for table suggestion

### DIFF
--- a/querybook/server/lib/ai_assistant/assistants/openai_assistant.py
+++ b/querybook/server/lib/ai_assistant/assistants/openai_assistant.py
@@ -13,6 +13,7 @@ OPENAI_MODEL_CONTEXT_WINDOW_SIZE = {
     "gpt-3.5-turbo-16k": 16385,
     "gpt-4": 8192,
     "gpt-4-32k": 32768,
+    "gpt-4-turbo": 128000,
 }
 DEFAULT_MODEL_NAME = "gpt-3.5-turbo"
 

--- a/querybook/server/lib/elasticsearch/suggest_table.py
+++ b/querybook/server/lib/elasticsearch/suggest_table.py
@@ -8,9 +8,7 @@ def construct_suggest_table_query(
         "size": limit,
         "query": {
             "bool": {
-                "must": {
-                    "match": {"full_name_ngram": {"query": keyword, "operator": "and"}}
-                },
+                "must": [{"match_phrase_prefix": {"full_name": {"query": keyword}}}],
                 "filter": {"match": {"metastore_id": metastore_id}},
             }
         },


### PR DESCRIPTION
previously we were using `full_name_ngram`, which only works for 3 or more chars. 

Here we use `full_name` , and only match for phrase prefix to ensure performance.