### PR TITLE
fix: Fix email notifications to multiple email addresses

### DIFF
--- a/querybook/server/lib/notify/notifier/email_notifier.py
+++ b/querybook/server/lib/notify/notifier/email_notifier.py
@@ -33,11 +33,11 @@ class EmailNotifier(BaseNotifier):
             msg["Subject"] = subject
             msg["Date"] = date
             msg["From"] = from_email
-            msg["To"] = ",".join(recipients)
+            msg["To"] = ", ".join(recipients)
             msg.attach(MIMEText(message, "html"))
 
             smtp = smtplib.SMTP(QuerybookSettings.EMAILER_CONN)
-            smtp.sendmail(msg["From"], msg["To"], msg.as_string())
+            smtp.sendmail(msg["From"], recipients, msg.as_string())
         except Exception as e:
             LOG.info(e)
 


### PR DESCRIPTION
This fixes an issue with sending notifications to multiple email addresses (not users) at once.  The first email address would get the email, and the email would look like it was sent to all recipients, but it would not actually be delivered to the other email addresses.  `smtp.sendmail()` needs a list of addresses rather than the joined string in the message header.

This doesn't apply to any Querybook users who are added to the notification, because they are notified individually.

This StackOverflow helps explain the issue and the fix: https://stackoverflow.com/q/8856117.

![Screenshot 2024-04-11 at 2 48 08 PM](https://github.com/pinterest/querybook/assets/3084806/cc90a498-56f3-4d56-a7c0-3abcea069953)
