### PR TITLE
fix: move workflow link to source query tab

### DIFF
--- a/querybook/webapp/components/DataTableViewSourceQuery/DataTableViewSourceQuery.scss
+++ b/querybook/webapp/components/DataTableViewSourceQuery/DataTableViewSourceQuery.scss
@@ -22,4 +22,7 @@
             border-radius: var(--border-radius);
         }
     }
+    .DataTableViewSourceQuery-workflow {
+        margin-bottom: 12px;
+    }
 }

--- a/querybook/webapp/components/DataTableViewSourceQuery/DataTableViewSourceQuery.tsx
+++ b/querybook/webapp/components/DataTableViewSourceQuery/DataTableViewSourceQuery.tsx
@@ -5,6 +5,7 @@ import {
     IDataTable,
     ILineageCollection,
 } from 'const/metastore';
+import { isValidUrl } from 'lib/utils';
 import { getAppName } from 'lib/utils/global';
 import { getWithinEnvUrl } from 'lib/utils/query-string';
 import { Button } from 'ui/Button/Button';
@@ -91,7 +92,7 @@ export const DataTableViewSourceQuery: React.FunctionComponent<IProps> = ({
                         Workflow
                     </Title>
                 </div>
-                {/https?:\/\/[^\s]+/.test(workflowValue.trim()) ? (
+                {isValidUrl(workflowValue) ? (
                     <Link to={workflowValue} newTab>
                         {workflowValue}
                     </Link>

--- a/querybook/webapp/components/DataTableViewSourceQuery/DataTableViewSourceQuery.tsx
+++ b/querybook/webapp/components/DataTableViewSourceQuery/DataTableViewSourceQuery.tsx
@@ -82,19 +82,24 @@ export const DataTableViewSourceQuery: React.FunctionComponent<IProps> = ({
     });
 
     const customProperties = table.custom_properties ?? {};
-    const workflowValue = customProperties['workflow']?.toString() ?? null;
-    const workflowDOM = workflowValue ? (
-        <div className="DataTableViewSourceQuery-workflow">
-            <div className="data-table-workflow">
-                <Title size="med" className="mb12">
-                    Workflow
-                </Title>
+    const workflowValue = customProperties['workflow'];
+    const workflowDOM =
+        workflowValue && typeof workflowValue === 'string' ? (
+            <div className="DataTableViewSourceQuery-workflow">
+                <div className="data-table-workflow">
+                    <Title size="med" className="mb12">
+                        Workflow
+                    </Title>
+                </div>
+                {/https?:\/\/[^\s]+/.test(workflowValue.trim()) ? (
+                    <Link to={workflowValue} newTab>
+                        {workflowValue}
+                    </Link>
+                ) : (
+                    workflowValue
+                )}
             </div>
-            <Link to={workflowValue} newTab>
-                {workflowValue}
-            </Link>
-        </div>
-    ) : null;
+        ) : null;
 
     const errorDOM =
         jobMetadataIds.length > 0 ? null : (

--- a/querybook/webapp/components/DataTableViewSourceQuery/DataTableViewSourceQuery.tsx
+++ b/querybook/webapp/components/DataTableViewSourceQuery/DataTableViewSourceQuery.tsx
@@ -34,6 +34,7 @@ export const DataTableViewSourceQuery: React.FunctionComponent<IProps> = ({
     dataJobMetadataById,
 }) => {
     const [showOldJobMetadata, setShowOldJobMetadata] = useState(false);
+
     const jobMetadataIds = useMemo(
         () =>
             Array.from(
@@ -80,6 +81,21 @@ export const DataTableViewSourceQuery: React.FunctionComponent<IProps> = ({
         );
     });
 
+    const customProperties = table.custom_properties ?? {};
+    const workflowValue = customProperties['workflow']?.toString() ?? null;
+    const workflowDOM = workflowValue ? (
+        <div className="DataTableViewSourceQuery-workflow">
+            <div className="data-job-source-query-top">
+                <Title size="med" className="mb12">
+                    Workflow
+                </Title>
+            </div>
+            <Link to={workflowValue} newTab>
+                {workflowValue}
+            </Link>
+        </div>
+    ) : null;
+
     const errorDOM =
         jobMetadataIds.length > 0 ? null : (
             <EmptyText className="m24">
@@ -100,6 +116,7 @@ export const DataTableViewSourceQuery: React.FunctionComponent<IProps> = ({
     return (
         <div className="DataTableViewSourceQuery">
             {parentDOM}
+            {workflowDOM}
             {errorDOM}
             {showMoreDOM}
         </div>

--- a/querybook/webapp/components/DataTableViewSourceQuery/DataTableViewSourceQuery.tsx
+++ b/querybook/webapp/components/DataTableViewSourceQuery/DataTableViewSourceQuery.tsx
@@ -85,7 +85,7 @@ export const DataTableViewSourceQuery: React.FunctionComponent<IProps> = ({
     const workflowValue = customProperties['workflow']?.toString() ?? null;
     const workflowDOM = workflowValue ? (
         <div className="DataTableViewSourceQuery-workflow">
-            <div className="data-job-source-query-top">
+            <div className="data-table-workflow">
                 <Title size="med" className="mb12">
                     Workflow
                 </Title>
@@ -115,8 +115,8 @@ export const DataTableViewSourceQuery: React.FunctionComponent<IProps> = ({
 
     return (
         <div className="DataTableViewSourceQuery">
-            {parentDOM}
             {workflowDOM}
+            {parentDOM}
             {errorDOM}
             {showMoreDOM}
         </div>


### PR DESCRIPTION
### [ER-7007] Minor Querybook Improvements for Tier 1 tables
-  Currently all Tier 1 tables have a link to the workflow creating the table. However this information is not included under the Source Query tab

#### Test Plan

Added workflow link to bottom of source query tab

![Screenshot 2024-05-01 at 11 25 32 PM](https://github.com/pinterest/querybook/assets/41878611/c8fea8ee-4b3c-4e84-8359-949fc5b2ac94)
