### PR TITLE
ui: Add icon to table links

### DIFF
--- a/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.scss
+++ b/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.scss
@@ -23,4 +23,9 @@
     .raw-metastore-info{
         word-break: break-all;
     }
+    .data-table-table-links {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+    }
 }

--- a/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
+++ b/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
@@ -41,6 +41,7 @@ import { Message } from 'ui/Message/Message';
 import { ShowMoreText } from 'ui/ShowMoreText/ShowMoreText';
 
 import { DataTableViewOverviewSection } from './DataTableViewOverviewSection';
+import { Link2 } from 'lucide-react';
 
 import './DataTableViewOverview.scss';
 
@@ -133,6 +134,14 @@ export const DataTableViewOverview: React.FC<
     const tableLinksDOM = (table.table_links ?? []).map((link, index) => (
         <div key={index}>
             <Link to={link.url} newTab>
+                <Link2
+                    size={20}
+                    style={{
+                        position: 'relative',
+                        top: '5px',
+                        paddingRight: '5px',
+                    }}
+                />
                 {link.label ?? link.url}
             </Link>
             <br />

--- a/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
+++ b/querybook/webapp/components/DataTableViewOverview/DataTableViewOverview.tsx
@@ -25,7 +25,7 @@ import {
 } from 'const/metastore';
 import { useMounted } from 'hooks/useMounted';
 import { Nullable } from 'lib/typescript';
-import { isValidUrl, titleize } from 'lib/utils';
+import { titleize } from 'lib/utils';
 import { generateFormattedDate } from 'lib/utils/datetime';
 import { getAppName } from 'lib/utils/global';
 import { getHumanReadableByteSize } from 'lib/utils/number';
@@ -41,7 +41,7 @@ import { Message } from 'ui/Message/Message';
 import { ShowMoreText } from 'ui/ShowMoreText/ShowMoreText';
 
 import { DataTableViewOverviewSection } from './DataTableViewOverviewSection';
-import { Link2 } from 'lucide-react';
+import { Icon } from 'ui/Icon/Icon';
 
 import './DataTableViewOverview.scss';
 
@@ -133,15 +133,8 @@ export const DataTableViewOverview: React.FC<
 
     const tableLinksDOM = (table.table_links ?? []).map((link, index) => (
         <div key={index}>
-            <Link to={link.url} newTab>
-                <Link2
-                    size={20}
-                    style={{
-                        position: 'relative',
-                        top: '5px',
-                        paddingRight: '5px',
-                    }}
-                />
+            <Link to={link.url} newTab className="data-table-table-links">
+                <Icon name="Link" size={12} />
                 {link.label ?? link.url}
             </Link>
             <br />
@@ -193,15 +186,9 @@ export const DataTableViewOverview: React.FC<
 
     const otherPropertiesDOM = Object.entries(customProperties)
         .filter(([key]) => !pinnedCustomProperties.includes(key))
-        .map(([key, value]) => {
-            return (
-                <KeyContentDisplayLink
-                    key={key}
-                    keyString={key}
-                    value={value}
-                />
-            );
-        });
+        .map(([key, value]) => (
+            <KeyContentDisplayLink key={key} keyString={key} value={value} />
+        ));
 
     const rawMetastoreInfoDOM = table.hive_metastore_description ? (
         <pre className="raw-metastore-info">


### PR DESCRIPTION
- Add link icon to table links to make link attachments more obvious
![Screenshot 2024-05-17 at 5 11 52 PM](https://github.com/pinterest/querybook/assets/41878611/e6863088-95ac-4383-a286-e9a57849b8b9)
