### PR TITLE
fix: Metastore sync tables with a single transaction

### DIFF
--- a/querybook/server/lib/metastore/base_metastore_loader.py
+++ b/querybook/server/lib/metastore/base_metastore_loader.py
@@ -400,7 +400,10 @@ class BaseMetastoreLoader(metaclass=ABCMeta):
                 )
 
             delete_column_not_in_metastore(
-                table_id, set(map(lambda c: c.name, columns)), session=session
+                table_id,
+                set(map(lambda c: c.name, columns)),
+                commit=False,
+                session=session,
             )
 
             for column in columns:
@@ -630,11 +633,14 @@ def delete_table_not_in_metastore(schema_id, table_names, session=None):
 
 
 @with_session
-def delete_column_not_in_metastore(table_id, column_names, session=None):
+def delete_column_not_in_metastore(table_id, column_names, commit=True, session=None):
     db_columns = get_column_by_table_id(table_id, session=session)
 
     for column in db_columns:
         if column.name not in column_names:
             delete_column(id=column.id, commit=False, session=session)
             LOG.info("deleted column %d" % column.id)
-    session.commit()
+    if commit:
+        session.commit()
+    else:
+        session.flush()

--- a/querybook/server/logic/metastore.py
+++ b/querybook/server/logic/metastore.py
@@ -351,7 +351,9 @@ def create_table_warnings(
                 "message": message,
                 "severity": severity,
                 "table_id": table_id,
-            }
+            },
+            commit=False,
+            session=session,
         )
     if commit:
         session.commit()

--- a/querybook/server/logic/tag.py
+++ b/querybook/server/logic/tag.py
@@ -133,12 +133,13 @@ def create_table_tags(
 
         # update or create a new tag if not exist
         create_or_update_tag(
-            tag_name=tag.name, meta=meta, commit=commit, session=session
+            tag_name=tag.name, meta=meta, commit=False, session=session
         )
 
         # add a new tag_item to associate with the table
         TagItem.create(
             {"tag_name": tag.name, "table_id": table_id, "uid": None},
+            commit=False,
             session=session,
         )
 
@@ -176,12 +177,13 @@ def create_column_tags(
 
         # update or create a new tag if not exist
         create_or_update_tag(
-            tag_name=tag.name, meta=meta, commit=commit, session=session
+            tag_name=tag.name, meta=meta, commit=False, session=session
         )
 
         # add a new tag_item to associate with the table
         TagItem.create(
             {"tag_name": tag.name, "column_id": column_id, "uid": None},
+            commit=False,
             session=session,
         )
 


### PR DESCRIPTION
We were facing some database perf issues, so I looked into it and the SQL query with the most waits was `INSERT INTO 'data_table_warnings'`:

<img width="1154" alt="Screenshot 2024-07-12 at 10 37 24 AM" src="https://github.com/user-attachments/assets/dbf0a72f-12d7-40f6-a640-0eb012d03f3d">

We recently updated our metastore loader code to automatically add warnings to certain tables during the sync.  That explains why we're seeing it now, but it didn't seem right so I looked into it.

While most of the metastore sync executes as a single transaction per table, I realized data table warnings are being committed immediately.  I enabled database logging in SQLAlchemy and ran through the metastore sync, which helped identify a few other areas where separate transactions were being committed.

This PR fixes every case of a separate transaction in the `base_metastore_loader`'s `_create_table_table` function that I could detect.

1. Where necessary, I added a `commit` arg to functions that were missing it (and passing `commit=False` during the sync)
2. Functions that have a `commit` arg should always pass `commit=False` to all sub-query functions, since they (optionally) commit at the end of the function
 
With these changes, each table creates a single transaction that is committed (or rolled back) at the completion of the `_create_table_table()` function.

We deployed this change to production late on July 30th, and the load dropped significantly; all the `row_lock_waits` are gone:

![Screenshot 2024-08-02 at 10 33 16 AM](https://github.com/user-attachments/assets/97c078ff-ab44-4b27-a5d2-96fa81ebc7a1)

Moreover, the metastore loader task runs 100% faster now:

<img width="748" alt="Screenshot 2024-08-02 at 5 19 24 PM" src="https://github.com/user-attachments/assets/bb4a77e8-a325-44c6-81b0-a9be714edac9">


Note: to enable database logging, add `echo=True` to the `create_engine()` call in `db.py`.  This let me know exactly when transactions were being committed.