### PR TITLE
ui: Modify user settings for editor to enable query suggestions

### DIFF
--- a/querybook/config/user_setting.yaml
+++ b/querybook/config/user_setting.yaml
@@ -50,6 +50,14 @@ show_full_view:
         - disabled
     helper: Instead of modal, show full view when opening table/execution/snippet
 
+query_suggestions:
+    default: disabled
+    tab: editor
+    options:
+        - enabled
+        - disabled
+    helper: Enable to receive inline LLM generated query suggestions as you type from within the editor.
+
 editor_font_size:
     default: medium
     tab: editor

--- a/querybook/config/user_setting.yaml
+++ b/querybook/config/user_setting.yaml
@@ -50,7 +50,7 @@ show_full_view:
         - disabled
     helper: Instead of modal, show full view when opening table/execution/snippet
 
-copilot_suggestions:
+query_suggestions:
     default: disabled
     tab: editor
     options:

--- a/querybook/config/user_setting.yaml
+++ b/querybook/config/user_setting.yaml
@@ -50,13 +50,13 @@ show_full_view:
         - disabled
     helper: Instead of modal, show full view when opening table/execution/snippet
 
-query_suggestions:
+copilot_suggestions:
     default: disabled
     tab: editor
     options:
         - enabled
         - disabled
-    helper: Enable to receive inline LLM generated query suggestions as you type from within the editor.
+    helper: (Experimental) Enable to receive inline AI generated query suggestions as you type from within the editor.
 
 editor_font_size:
     default: medium

--- a/querybook/webapp/components/QueryEditor/BoundQueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/BoundQueryEditor.tsx
@@ -55,7 +55,7 @@ export const BoundQueryEditor = React.forwardRef<
             options,
             fontSize,
             autoCompleteType,
-            copilotSuggestionsEnabled,
+            queryAISuggestionsEnabled,
         } = useUserQueryEditorConfig(searchContext);
         const combinedOptions = useMemo(
             () => ({
@@ -109,7 +109,7 @@ export const BoundQueryEditor = React.forwardRef<
                 theme={codeEditorTheme}
                 autoCompleteType={autoCompleteType}
                 fontSize={fontSize}
-                querySuggestionsEnabled={copilotSuggestionsEnabled}
+                queryAISuggestionsEnabled={queryAISuggestionsEnabled}
                 getTableByName={fetchDataTable}
                 functionDocumentationByNameByLanguage={
                     functionDocumentationByNameByLanguage

--- a/querybook/webapp/components/QueryEditor/BoundQueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/BoundQueryEditor.tsx
@@ -55,7 +55,7 @@ export const BoundQueryEditor = React.forwardRef<
             options,
             fontSize,
             autoCompleteType,
-            querySuggestionsEnabled,
+            copilotSuggestionsEnabled,
         } = useUserQueryEditorConfig(searchContext);
         const combinedOptions = useMemo(
             () => ({
@@ -109,7 +109,7 @@ export const BoundQueryEditor = React.forwardRef<
                 theme={codeEditorTheme}
                 autoCompleteType={autoCompleteType}
                 fontSize={fontSize}
-                querySuggestionsEnabled={querySuggestionsEnabled}
+                querySuggestionsEnabled={copilotSuggestionsEnabled}
                 getTableByName={fetchDataTable}
                 functionDocumentationByNameByLanguage={
                     functionDocumentationByNameByLanguage

--- a/querybook/webapp/components/QueryEditor/BoundQueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/BoundQueryEditor.tsx
@@ -49,8 +49,14 @@ export const BoundQueryEditor = React.forwardRef<
         const editorRef = useForwardedRef<IQueryEditorHandles>(ref);
 
         // Code Editor related Props
-        const { codeEditorTheme, keyMap, options, fontSize, autoCompleteType } =
-            useUserQueryEditorConfig(searchContext);
+        const {
+            codeEditorTheme,
+            keyMap,
+            options,
+            fontSize,
+            autoCompleteType,
+            querySuggestionsEnabled,
+        } = useUserQueryEditorConfig(searchContext);
         const combinedOptions = useMemo(
             () => ({
                 ...options,
@@ -103,6 +109,7 @@ export const BoundQueryEditor = React.forwardRef<
                 theme={codeEditorTheme}
                 autoCompleteType={autoCompleteType}
                 fontSize={fontSize}
+                querySuggestionsEnabled={querySuggestionsEnabled}
                 getTableByName={fetchDataTable}
                 functionDocumentationByNameByLanguage={
                     functionDocumentationByNameByLanguage

--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -57,7 +57,7 @@ export interface IQueryEditorProps extends IStyledQueryEditorProps {
     keyMap?: CodeMirrorKeyMap;
     className?: string;
     autoCompleteType?: AutoCompleteType;
-    querySuggestionsEnabled?: boolean;
+    copilotSuggestionsEnabled?: boolean;
 
     /**
      * If provided, then the container component will handle the fullscreen logic
@@ -116,7 +116,7 @@ export const QueryEditor: React.FC<
             keyMap = {},
             className,
             autoCompleteType = 'all',
-            querySuggestionsEnabled,
+            copilotSuggestionsEnabled,
             onFullScreen,
 
             onChange,
@@ -623,9 +623,9 @@ export const QueryEditor: React.FC<
             (editor: CodeMirror.Editor) => {
                 editorRef.current = editor;
 
-                if (querySuggestionsEnabled) {
+                if (copilotSuggestionsEnabled) {
                     // Enable copilot suggestion feature
-                    editor.querySuggestions();
+                    editor.copilotSuggestions();
                 }
 
                 // There is a strange bug where codemirror would start with the wrong height (on Execs tab)

--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -624,7 +624,7 @@ export const QueryEditor: React.FC<
                 editorRef.current = editor;
 
                 if (queryAISuggestionsEnabled) {
-                    // Enable copilot suggestion feature
+                    // Enable query ai suggestion feature
                     editor.queryAISuggestions();
                 }
 

--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -23,8 +23,6 @@ import {
 import { useAutoComplete } from 'hooks/queryEditor/useAutoComplete';
 import { useCodeAnalysis } from 'hooks/queryEditor/useCodeAnalysis';
 import { useLint } from 'hooks/queryEditor/useLint';
-import { useUserQueryEditorConfig } from 'hooks/redux/useUserQueryEditorConfig';
-import { useUserQueryEditorConfig } from 'hooks/redux/useUserQueryEditorConfig';
 import { useDebouncedFn } from 'hooks/useDebouncedFn';
 import CodeMirror, { CodeMirrorKeyMap } from 'lib/codemirror';
 import { SQL_JINJA_MODE } from 'lib/codemirror/codemirror-mode';
@@ -59,7 +57,6 @@ export interface IQueryEditorProps extends IStyledQueryEditorProps {
     keyMap?: CodeMirrorKeyMap;
     className?: string;
     autoCompleteType?: AutoCompleteType;
-    querySuggestionsEnabled?: boolean;
     querySuggestionsEnabled?: boolean;
 
     /**
@@ -119,7 +116,6 @@ export const QueryEditor: React.FC<
             keyMap = {},
             className,
             autoCompleteType = 'all',
-            querySuggestionsEnabled,
             querySuggestionsEnabled,
             onFullScreen,
 
@@ -541,16 +537,6 @@ export const QueryEditor: React.FC<
                 onTablesChange?.(tablesMap);
             });
         }, [codeAnalysis]);
-
-        useEffect(() => {
-            if (querySuggestionsEnabled) {
-                // Enable copilot suggestion feature
-                enableCopilotSuggestions();
-            } else {
-                // Disable copilot suggestion feature
-                disableCopilotSuggestions();
-            }
-        }, [querySuggestionsEnabled]);
 
         useImperativeHandle(
             ref,

--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -57,7 +57,7 @@ export interface IQueryEditorProps extends IStyledQueryEditorProps {
     keyMap?: CodeMirrorKeyMap;
     className?: string;
     autoCompleteType?: AutoCompleteType;
-    copilotSuggestionsEnabled?: boolean;
+    queryAISuggestionsEnabled?: boolean;
 
     /**
      * If provided, then the container component will handle the fullscreen logic
@@ -116,7 +116,7 @@ export const QueryEditor: React.FC<
             keyMap = {},
             className,
             autoCompleteType = 'all',
-            copilotSuggestionsEnabled,
+            queryAISuggestionsEnabled,
             onFullScreen,
 
             onChange,
@@ -623,9 +623,9 @@ export const QueryEditor: React.FC<
             (editor: CodeMirror.Editor) => {
                 editorRef.current = editor;
 
-                if (copilotSuggestionsEnabled) {
+                if (queryAISuggestionsEnabled) {
                     // Enable copilot suggestion feature
-                    editor.copilotSuggestions();
+                    editor.queryAISuggestions();
                 }
 
                 // There is a strange bug where codemirror would start with the wrong height (on Execs tab)
@@ -635,7 +635,7 @@ export const QueryEditor: React.FC<
                     editor.refresh();
                 }, 50);
             },
-            [querySuggestionsEnabled]
+            [queryAISuggestionsEnabled]
         );
 
         const onBeforeChange = useCallback(

--- a/querybook/webapp/hooks/redux/useUserQueryEditorConfig.ts
+++ b/querybook/webapp/hooks/redux/useUserQueryEditorConfig.ts
@@ -17,7 +17,7 @@ export function useUserQueryEditorConfig(
     keyMap: CodeMirrorKeyMap;
     options: CodeMirror.EditorConfiguration;
     autoCompleteType: AutoCompleteType;
-    querySuggestionsEnabled: boolean;
+    copilotSuggestionsEnabled: boolean;
 } {
     const editorSettings = useShallowSelector((state: IStoreState) => ({
         theme: getCodeEditorTheme(state.user.computedSettings['theme']),
@@ -27,8 +27,8 @@ export function useUserQueryEditorConfig(
             ],
         autoComplete: state.user.computedSettings['auto_complete'],
         tab: state.user.computedSettings['tab'],
-        querySuggestionsEnabled:
-            state.user.computedSettings['query_suggestions'] === 'enabled',
+        copilotSuggestionsEnabled:
+            state.user.computedSettings['copilot_suggestions'] === 'enabled',
     }));
     const indentWithTabs = editorSettings.tab === 'tab';
     const tabSize =
@@ -109,6 +109,6 @@ export function useUserQueryEditorConfig(
         // From: https://github.com/codemirror/CodeMirror/issues/988
         keyMap,
         options,
-        querySuggestionsEnabled: editorSettings.querySuggestionsEnabled,
+        copilotSuggestionsEnabled: editorSettings.copilotSuggestionsEnabled,
     };
 }

--- a/querybook/webapp/hooks/redux/useUserQueryEditorConfig.ts
+++ b/querybook/webapp/hooks/redux/useUserQueryEditorConfig.ts
@@ -17,6 +17,7 @@ export function useUserQueryEditorConfig(
     keyMap: CodeMirrorKeyMap;
     options: CodeMirror.EditorConfiguration;
     autoCompleteType: AutoCompleteType;
+    querySuggestionsEnabled: boolean;
 } {
     const editorSettings = useShallowSelector((state: IStoreState) => ({
         theme: getCodeEditorTheme(state.user.computedSettings['theme']),
@@ -26,6 +27,8 @@ export function useUserQueryEditorConfig(
             ],
         autoComplete: state.user.computedSettings['auto_complete'],
         tab: state.user.computedSettings['tab'],
+        querySuggestionsEnabled:
+            state.user.computedSettings['query_suggestions'] === 'enabled',
     }));
     const indentWithTabs = editorSettings.tab === 'tab';
     const tabSize =
@@ -106,5 +109,6 @@ export function useUserQueryEditorConfig(
         // From: https://github.com/codemirror/CodeMirror/issues/988
         keyMap,
         options,
+        querySuggestionsEnabled: editorSettings.querySuggestionsEnabled,
     };
 }

--- a/querybook/webapp/hooks/redux/useUserQueryEditorConfig.ts
+++ b/querybook/webapp/hooks/redux/useUserQueryEditorConfig.ts
@@ -17,7 +17,7 @@ export function useUserQueryEditorConfig(
     keyMap: CodeMirrorKeyMap;
     options: CodeMirror.EditorConfiguration;
     autoCompleteType: AutoCompleteType;
-    copilotSuggestionsEnabled: boolean;
+    queryAISuggestionsEnabled: boolean;
 } {
     const editorSettings = useShallowSelector((state: IStoreState) => ({
         theme: getCodeEditorTheme(state.user.computedSettings['theme']),
@@ -27,8 +27,8 @@ export function useUserQueryEditorConfig(
             ],
         autoComplete: state.user.computedSettings['auto_complete'],
         tab: state.user.computedSettings['tab'],
-        copilotSuggestionsEnabled:
-            state.user.computedSettings['copilot_suggestions'] === 'enabled',
+        queryAISuggestionsEnabled:
+            state.user.computedSettings['query_suggestions'] === 'enabled',
     }));
     const indentWithTabs = editorSettings.tab === 'tab';
     const tabSize =
@@ -109,6 +109,6 @@ export function useUserQueryEditorConfig(
         // From: https://github.com/codemirror/CodeMirror/issues/988
         keyMap,
         options,
-        copilotSuggestionsEnabled: editorSettings.copilotSuggestionsEnabled,
+        queryAISuggestionsEnabled: editorSettings.queryAISuggestionsEnabled,
     };
 }

--- a/querybook/webapp/lib/codemirror/codemirror-copilot.ts
+++ b/querybook/webapp/lib/codemirror/codemirror-copilot.ts
@@ -1,0 +1,9 @@
+import CodeMirror from 'codemirror';
+
+CodeMirror.defineExtension('querySuggestions', function () {
+    this.on('keyup', async (editor, event) => {
+        if (event.code === 'Space') {
+            console.log('CodeMirror Query Suggestions Extension');
+        }
+    });
+});

--- a/querybook/webapp/lib/codemirror/codemirror-copilot.ts
+++ b/querybook/webapp/lib/codemirror/codemirror-copilot.ts
@@ -1,6 +1,6 @@
 import CodeMirror from 'codemirror';
 
-CodeMirror.defineExtension('querySuggestions', function () {
+CodeMirror.defineExtension('copilotSuggestions', function () {
     this.on('keyup', async (editor, event) => {
         if (event.code === 'Space') {
             console.log('CodeMirror Query Suggestions Extension');

--- a/querybook/webapp/lib/codemirror/codemirror-copilot.ts
+++ b/querybook/webapp/lib/codemirror/codemirror-copilot.ts
@@ -1,6 +1,6 @@
 import CodeMirror from 'codemirror';
 
-CodeMirror.defineExtension('copilotSuggestions', function () {
+CodeMirror.defineExtension('queryAISuggestions', function () {
     this.on('keyup', async (editor, event) => {
         if (event.code === 'Space') {
             console.log('CodeMirror Query Suggestions Extension');

--- a/querybook/webapp/lib/codemirror/index.ts
+++ b/querybook/webapp/lib/codemirror/index.ts
@@ -25,7 +25,7 @@ import 'codemirror/theme/duotone-light.css';
 import 'codemirror/theme/material-palenight.css';
 import 'codemirror/theme/monokai.css';
 import 'codemirror/theme/solarized.css';
-// Query Suggestions
+// AI Query Suggestions
 import 'lib/codemirror/codemirror-copilot';
 // This should apply the hover option to codemirror
 import 'lib/codemirror/codemirror-hover';
@@ -35,7 +35,7 @@ import './editor_styles.scss';
 
 declare module 'codemirror' {
     interface Editor {
-        querySuggestions(): void;
+        copilotSuggestions(): void;
     }
     // This is copied from runmode.d.ts. Not sure how to import it :(
     function runMode(

--- a/querybook/webapp/lib/codemirror/index.ts
+++ b/querybook/webapp/lib/codemirror/index.ts
@@ -25,7 +25,7 @@ import 'codemirror/theme/duotone-light.css';
 import 'codemirror/theme/material-palenight.css';
 import 'codemirror/theme/monokai.css';
 import 'codemirror/theme/solarized.css';
-// AI Query Suggestions
+// Query AI Suggestions
 import 'lib/codemirror/codemirror-copilot';
 // This should apply the hover option to codemirror
 import 'lib/codemirror/codemirror-hover';

--- a/querybook/webapp/lib/codemirror/index.ts
+++ b/querybook/webapp/lib/codemirror/index.ts
@@ -48,10 +48,6 @@ declare module 'codemirror' {
     function normalizeKeyMap(
         keyMap: Record<string, string | (() => any)>
     ): Record<string, string | (() => any)>;
-
-    interface Editor {
-        querySuggestions(): void;
-    }
 }
 
 attachCustomCommand(CodeMirror.commands);

--- a/querybook/webapp/lib/codemirror/index.ts
+++ b/querybook/webapp/lib/codemirror/index.ts
@@ -35,7 +35,7 @@ import './editor_styles.scss';
 
 declare module 'codemirror' {
     interface Editor {
-        copilotSuggestions(): void;
+        queryAISuggestions(): void;
     }
     // This is copied from runmode.d.ts. Not sure how to import it :(
     function runMode(

--- a/querybook/webapp/lib/codemirror/index.ts
+++ b/querybook/webapp/lib/codemirror/index.ts
@@ -18,14 +18,15 @@ import 'codemirror/addon/runmode/runmode';
 // Search highlighting
 import 'codemirror/addon/search/match-highlighter.js';
 import 'codemirror/lib/codemirror.css';
+import 'codemirror/mode/jinja2/jinja2';
 // From codemirror non-react package:
 import 'codemirror/mode/sql/sql';
-import 'codemirror/mode/jinja2/jinja2';
-
 import 'codemirror/theme/duotone-light.css';
 import 'codemirror/theme/material-palenight.css';
 import 'codemirror/theme/monokai.css';
 import 'codemirror/theme/solarized.css';
+// Query Suggestions
+import 'lib/codemirror/codemirror-copilot';
 // This should apply the hover option to codemirror
 import 'lib/codemirror/codemirror-hover';
 
@@ -33,6 +34,9 @@ import 'lib/codemirror/codemirror-hover';
 import './editor_styles.scss';
 
 declare module 'codemirror' {
+    interface Editor {
+        querySuggestions(): void;
+    }
     // This is copied from runmode.d.ts. Not sure how to import it :(
     function runMode(
         text: string,
@@ -44,6 +48,10 @@ declare module 'codemirror' {
     function normalizeKeyMap(
         keyMap: Record<string, string | (() => any)>
     ): Record<string, string | (() => any)>;
+
+    interface Editor {
+        querySuggestions(): void;
+    }
 }
 
 attachCustomCommand(CodeMirror.commands);


### PR DESCRIPTION
## Context
- Hide query suggestion feature toggle behind ‘User Settings’ value to allow users to control enablement
- Next PR will handle creating widget to display suggestions in the code editor when typing

## Test Plan
![image](https://github.com/user-attachments/assets/1071bb26-10af-45ae-b242-7f15de471494)
