### PR TITLE
fix: Update task type to use str instead of enum

### DIFF
--- a/querybook/server/tasks/all_tasks.py
+++ b/querybook/server/tasks/all_tasks.py
@@ -61,4 +61,4 @@ def configure_workers(sender=None, conf=None, **kwargs):
 @task_failure.connect
 def handle_task_failure(sender, signal, *args, **kwargs):
     task_type = get_schedule_task_type(sender.name)
-    stats_logger.incr(TASK_FAILURES, tags={"task_type": task_type})
+    stats_logger.incr(TASK_FAILURES, tags={"task_type": task_type.value})

--- a/querybook/server/tasks/disable_scheduled_docs.py
+++ b/querybook/server/tasks/disable_scheduled_docs.py
@@ -65,7 +65,7 @@ def get_scheduled_datadoc_tasks(session=None):
         .filter(
             TaskSchedule.enabled.is_(True),
             TaskSchedule.name.like(DATADOC_SCHEDULE_PREFIX + "%"),
-            TaskSchedule.task_type == ScheduleTaskType.USER,
+            TaskSchedule.task_type == ScheduleTaskType.USER.value,
         )
         .all()
     )


### PR DESCRIPTION
Because task type are enums but the column values are strings, the code fails to get the actual tasks. 