### PR TITLE
chore: make the survey duration configurable

### DIFF
--- a/docs_website/docs/integrations/add_surveys.mdx
+++ b/docs_website/docs/integrations/add_surveys.mdx
@@ -20,6 +20,7 @@ Below is an example of a setting that enables all surveys:
 survey:
     global_response_cooldown: 2592000 # 30 days
     global_trigger_cooldown: 600 # 10 minutes
+    global_trigger_duration: 60 # 1 minute
     global_max_per_week: 6
     global_max_per_day: 3
 
@@ -40,5 +41,6 @@ There are 4 variables that you can configure either for eaceh individual surface
 
 -   **response_cooldown**: Time (in seconds) the system waits before showing the same survey to a user who has already responded.
 -   **trigger_cooldown**: Waiting period before the same survey is shown to the same user.
+-   **trigger_duration**: The duration (in seconds) for which the survey is displayed before being dismissed.
 -   **max_per_week**: Maximum number of surveys shown to a user per week (per surface type).
 -   **max_per_day**: Daily limit for the number of surveys shown to a user (per surface type).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.34.1",
+    "version": "3.34.2",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/config/querybook_public_config.yaml
+++ b/querybook/config/querybook_public_config.yaml
@@ -18,6 +18,7 @@ ai_assistant:
 survey:
     global_response_cooldown: 2592000 # 30 days
     global_trigger_cooldown: 600 # 10 minutes
+    global_trigger_duration: 60 # 1 minute
     global_max_per_week: 6
     global_max_per_day: 3
 

--- a/querybook/webapp/config.d.ts
+++ b/querybook/webapp/config.d.ts
@@ -106,6 +106,7 @@ declare module 'config/querybook_public_config.yaml' {
         survey?: {
             global_response_cooldown?: number;
             global_trigger_cooldown?: number;
+            global_trigger_duration?: number;
             global_max_per_week?: number;
             global_max_per_day?: number;
 
@@ -113,6 +114,7 @@ declare module 'config/querybook_public_config.yaml' {
                 surface: string;
                 response_cooldown?: number;
                 trigger_cooldown?: number;
+                trigger_duration?: number;
                 max_per_week?: number;
                 max_per_day?: number;
             }>;

--- a/querybook/webapp/hooks/ui/useSurveyTrigger.tsx
+++ b/querybook/webapp/hooks/ui/useSurveyTrigger.tsx
@@ -8,6 +8,7 @@ import {
     shouldTriggerSurvey,
 } from 'lib/survey/triggerLogic';
 import { useDebouncedFn } from 'hooks/useDebouncedFn';
+import { SURVEY_CONFIG } from 'lib/survey/config';
 
 export async function triggerSurvey(
     surface: SurveySurfaceType,
@@ -28,7 +29,7 @@ export async function triggerSurvey(
             />
         ),
         {
-            duration: 1 * 60 * 1000, // 1 minute
+            duration: SURVEY_CONFIG[surface].triggerDuration * 1000,
         }
     );
 

--- a/querybook/webapp/lib/survey/config.ts
+++ b/querybook/webapp/lib/survey/config.ts
@@ -15,6 +15,10 @@ surveyConfig?.surfaces?.forEach((surface) => {
             surface.trigger_cooldown ??
             surveyConfig.global_trigger_cooldown ??
             600, // 10 minutes
+        triggerDuration:
+            surface.trigger_duration ??
+            surveyConfig.global_trigger_duration ??
+            60, // 1 minute
         maxPerWeek:
             surface.max_per_week ?? surveyConfig.global_max_per_week ?? 3,
         maxPerDay: surface.max_per_day ?? surveyConfig.global_max_per_day ?? 1,

--- a/querybook/webapp/lib/survey/types.ts
+++ b/querybook/webapp/lib/survey/types.ts
@@ -2,6 +2,7 @@ export interface ISurveyConfig {
     surface: string;
     responseCooldown: number;
     triggerCooldown: number;
+    triggerDuration: number;
     maxPerWeek: number;
     maxPerDay: number;
 }


### PR DESCRIPTION
Add a config of `trigger_duration` and `global_trigger_duration` to control the survey toast duration