### PR TITLE
fix: scroll the current search result into view

### DIFF
--- a/querybook/webapp/hooks/queryEditor/extensions/useSearchExtension.ts
+++ b/querybook/webapp/hooks/queryEditor/extensions/useSearchExtension.ts
@@ -75,6 +75,7 @@ export const useSearchExtension = ({
             if (shouldHighlight) {
                 editorView?.dispatch({
                     selection: EditorSelection.single(item.from, item.to),
+                    effects: EditorView.scrollIntoView(item.from),
                 });
             } else {
                 editorView?.dispatch({


### PR DESCRIPTION
forgot to scroll the current search result into the view when doing the search(cmd+f) and press prev/next