### PR TITLE
fix:  table sampling and editor bug

### DIFF
--- a/querybook/webapp/components/DataDocStatementExecution/StatementResult.tsx
+++ b/querybook/webapp/components/DataDocStatementExecution/StatementResult.tsx
@@ -298,17 +298,22 @@ const FetchInfo: React.FC<{
                 <span className="accent-warning-text ml4">
                     Results must be upscaled by {Math.round(100 / sampleRate)}x
                 </span>
-                . Learn more about accuracy and opt-out
+                .
                 {sampleUserGuideLink ? (
-                    <IconButton
-                        className="ml4"
-                        onClick={() => {
-                            window.open(sampleUserGuideLink, '_blank');
-                        }}
-                        icon="Info"
-                        size={16}
-                        noPadding
-                    />
+                    <>
+                        <span className="ml4">
+                            Learn more about accuracy and opt-out
+                        </span>
+                        <IconButton
+                            className="ml4"
+                            onClick={() => {
+                                window.open(sampleUserGuideLink, '_blank');
+                            }}
+                            icon="Info"
+                            size={16}
+                            noPadding
+                        />
+                    </>
                 ) : null}
             </div>
         );

--- a/querybook/webapp/components/DataDocStatementExecution/StatementResult.tsx
+++ b/querybook/webapp/components/DataDocStatementExecution/StatementResult.tsx
@@ -294,6 +294,11 @@ const FetchInfo: React.FC<{
                 <span className="accent-warning-text ml4">
                     Sampled {sampleRate}%
                 </span>
+                )
+                <span className="accent-warning-text ml4">
+                    Results must be upscaled by {Math.round(100 / sampleRate)}x
+                </span>
+                . Learn more about accuracy and opt-out
                 {sampleUserGuideLink ? (
                     <IconButton
                         className="ml4"
@@ -305,7 +310,6 @@ const FetchInfo: React.FC<{
                         noPadding
                     />
                 ) : null}
-                )
             </div>
         );
 

--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -462,6 +462,7 @@ export const QueryEditor: React.FC<
                     extensions={extensions}
                     basicSetup={basicSetup}
                     editable={!readOnly}
+                    readOnly={readOnly}
                     autoFocus={false}
                     onChange={onChangeHandler}
                     indentWithTab={false}

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
@@ -309,7 +309,7 @@ const TableSamplingSelector: React.FC<{
 
     React.useEffect(() => {
         // If it is a new cell without the sample rate selected, use the default sample rate from user settings
-        if (sampleRate === undefined) {
+        if (isNaN(sampleRate)) {
             setSampleRate(userDefaultTableSampleRate);
         }
     }, [sampleRate, setSampleRate, userDefaultTableSampleRate]);

--- a/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
+++ b/querybook/webapp/components/QueryRunButton/QueryRunButton.tsx
@@ -298,14 +298,19 @@ const TableSamplingSelector: React.FC<{
     onTableSamplingInfoClick: () => void;
 }> = ({ sampleRate, setSampleRate, tooltipPos, onTableSamplingInfoClick }) => {
     const sampleRateOptions = React.useMemo(getTableSamplingRateOptions, []);
-    const userDefaultTableSampleRate = useSelector(
-        (state: IStoreState) => state.user.computedSettings['table_sample_rate']
-    );
+    const userDefaultTableSampleRate = useSelector((state: IStoreState) => {
+        const sampleRateSetting = parseFloat(
+            state.user.computedSettings['table_sample_rate']
+        );
+        return isNaN(sampleRateSetting)
+            ? TABLE_SAMPLING_CONFIG.default_sample_rate
+            : sampleRateSetting;
+    });
 
     React.useEffect(() => {
         // If it is a new cell without the sample rate selected, use the default sample rate from user settings
         if (sampleRate === undefined) {
-            setSampleRate(parseFloat(userDefaultTableSampleRate));
+            setSampleRate(userDefaultTableSampleRate);
         }
     }, [sampleRate, setSampleRate, userDefaultTableSampleRate]);
 


### PR DESCRIPTION
fix bugs
 - the default sample rate in user settting could be empty, use the default sample rate from public config for that case
 - it can paste into the query editor when it's readonly.

also updated the sampling message