### PR TITLE
fix: CodeMirror2 styles not appearing in CodeHighlightWithMark

### DIFF
--- a/querybook/webapp/ui/CodeHighlight/CodeHighlightWithMark.tsx
+++ b/querybook/webapp/ui/CodeHighlight/CodeHighlightWithMark.tsx
@@ -3,6 +3,8 @@ import React, { useEffect, useMemo } from 'react';
 import { UnControlled as ReactCodeMirror } from 'react-codemirror2';
 import styled from 'styled-components';
 
+import 'lib/codemirror';
+
 import { IHighlightRange } from './types';
 
 const EmbeddedCodeMirrorContainer = styled.div`


### PR DESCRIPTION
The `Show Query` button in the ad hoc editor is broken after the upgrade to Codemirror 6, because it still uses Codemirror 5 and the styles are not loaded.

**Repro:**
1. Run any query in the ad hoc editor
2. Click the `Show Query` button.
3. If it works correctly, reload the page

This is fixed by updating the `CodeHighlightWithMark` component to import the `lib/codemirror` module which loads all the Codemirror 5 styles, themes, etc.

If you open a DataDoc then switch back to the ad hoc page, this feature does work correctly.  This is because the DataDocQueryCell loads the `CodeHighlight` component which loads the `lib/codemirror` module.

**Before**
![Screenshot 2025-02-03 at 15-57-48 Adhoc Query - Querybook](https://github.com/user-attachments/assets/2beb37cc-5378-4e6d-95a7-9d43e9f9344a)

**After**
![Screenshot 2025-02-03 at 15-58-46 Adhoc Query - Querybook](https://github.com/user-attachments/assets/0c574999-f42d-415a-8722-5efa30dfdf19)
