### PR TITLE
fix: codemirror got stuck when the query validation error is out of r…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.40.0",
+    "version": "3.40.1",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/hooks/queryEditor/useLint.tsx
+++ b/querybook/webapp/hooks/queryEditor/useLint.tsx
@@ -75,14 +75,19 @@ const queryValidationErrorsToDiagnostics = (
             suggestion,
         } = validationError;
 
-        const startPos = posToOffset(editorView, { line, ch });
-        const endPos =
+        let startPos = posToOffset(editorView, { line, ch });
+        let endPos =
             endLine !== null && endCh !== null
                 ? posToOffset(editorView, {
                       line: endLine,
                       ch: endCh + 1,
                   })
                 : startPos + 1;
+
+        // To prevent the range from going out of the document
+        const maxOffset = editorView.state.doc.length;
+        startPos = Math.min(startPos, maxOffset);
+        endPos = Math.min(endPos, maxOffset);
 
         return {
             from: startPos,


### PR DESCRIPTION
when the lint diagnostic is out of range, the code mirror editor will becomes uneditable, with error like below
```
Position 380 is out of range for changeset of length 372
```

Here to make user it will not exceed the doc length.