### PR TITLE
fix: sample query generation

### DIFF
--- a/querybook/server/lib/query_analysis/samples.py
+++ b/querybook/server/lib/query_analysis/samples.py
@@ -123,7 +123,7 @@ def _format_partition_filter(
         column_name, column_val = column_filter.split("=")
         column_type = column_type_by_name.get(column_name, None)
         column_quote = ""
-        if column_type == QuerybookColumnType.String:
+        if column_type == QuerybookColumnType.String or column_type is None:
             column_quote = "'"
 
         partition_filters.append(


### PR DESCRIPTION
sometimes the partition column might be missing from the table schema. Treat it as string type when generating the sample query.  

e.g. if the partition is `"dt=2015-01-01"`
current: `where dt=2015-01-01`

fixed: `where dt='2015-01-01'`