### PR TITLE
chore: update gihub action version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
                   echo MINOR_VERSION=$MINOR_VERSION >> $GITHUB_ENV
                   echo MAJOR_VERSION=$MAJOR_VERSION >> $GITHUB_ENV
             - name: Publish to Registry
-              uses: elgohr/Publish-Docker-Github-Action@master
+              uses: elgohr/Publish-Docker-Github-Action@v4
               env:
                   EXTRA_PIP_INSTALLS: extra.txt
               with:


### PR DESCRIPTION
Publish to Registry is failing 
```
>> elgohr/Publish-Docker-Github-Action@master has been deprecated.
>> Please use elgohr/Publish-Docker-Github-Action@v4 for a blast in speed and security.
Error response from daemon: Get "https://registry-1.docker.io/v2/": unauthorized: your account must log in with a Personal Access Token (PAT) - learn more at docs.docker.com/go/access-tokens
```
https://github.com/pinterest/querybook/actions/runs/13864816536/job/38801477190