### PR TITLE
chore: update to use PAT for dockerhub login

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
               with:
                   name: querybook/querybook
                   username: ${{ secrets.DOCKER_USERNAME }}
-                  password: ${{ secrets.DOCKER_PASSWORD }}
+                  password: ${{ secrets.DOCKER_PAT }}
                   tags: 'latest,${{ env.PATCH_VERSION }},${{ env.MINOR_VERSION }},${{ env.MAJOR_VERSION }}'
                   cache: ${{ github.event_name != 'schedule' }}
                   buildargs: EXTRA_PIP_INSTALLS


### PR DESCRIPTION
Dockerhub now needs to use PAT for login
> Error response from daemon: Get "https://registry-1.docker.io/v2/": unauthorized: your account must log in with a Personal Access Token (PAT) - learn more at [docs.docker.com/go/access-tokens](http://docs.docker.com/go/access-tokens)