### PR TITLE
feat: add a task queue and support cancelling

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "@uiw/react-json-view": "^2.0.0-alpha.30",
         "@welldone-software/why-did-you-render": "^6.1.1",
         "axios": "^1.2.2",
+        "balloon-css": "^1.2.0",
         "bignumber.js": "^9.0.1",
         "chart.js": "^3.9.1",
         "chartjs-adapter-moment": "^1.0.0",

--- a/querybook/server/app/flask_app.py
+++ b/querybook/server/app/flask_app.py
@@ -60,6 +60,11 @@ def make_flask_app():
     @app.after_request
     def add_csp_header(response):
         response.headers["Content-Security-Policy"] = csp_header_value
+
+        # To enable SharedArrayBuffer for interrupting Pyodide in a Web Worker from the main thread
+        response.headers["Cross-Origin-Opener-Policy"] = "same-origin"
+        response.headers["Cross-Origin-Embedder-Policy"] = "require-corp"
+
         return response
 
     return app

--- a/querybook/webapp/index.html
+++ b/querybook/webapp/index.html
@@ -4,10 +4,6 @@
         <meta charset="UTF-8" />
         <title><%= htmlWebpackPlugin.options.title %></title>
         <link
-            rel="stylesheet"
-            href="https://unpkg.com/balloon-css/balloon.min.css"
-        />
-        <link
             rel="shortcut icon"
             type="image/x-icon"
             href="/static/favicon/querybook.svg"

--- a/querybook/webapp/index.scss
+++ b/querybook/webapp/index.scss
@@ -21,3 +21,4 @@
 }
 
 @import './stylesheets/_html.scss';
+@import '~balloon-css/src/balloon';

--- a/querybook/webapp/lib/python/patch.ts
+++ b/querybook/webapp/lib/python/patch.ts
@@ -157,7 +157,7 @@ async function patchNamespaceHelper(pyodide: PyodideInterface) {
                   "name": name,
                   "type": type_name
               })
-          except:
+          except Exception:
               # Handle cases where eval might fail
               result.append({
                   "name": name,

--- a/querybook/webapp/lib/python/python-provider.tsx
+++ b/querybook/webapp/lib/python/python-provider.tsx
@@ -21,7 +21,12 @@ export interface PythonContextType {
     runPython: (
         code: string,
         namespaceId?: number,
-        progressCallback?: (status: PythonExecutionStatus, data?: any) => void,
+        progressCallback?: (
+            status: PythonExecutionStatus,
+            data?: {
+                executionCount?: number;
+            }
+        ) => void,
         stdoutCallback?: (text: string) => void,
         stderrCallback?: (text: string) => void
     ) => Promise<void>;
@@ -119,7 +124,9 @@ function PythonProvider({ children }: PythonProviderProps) {
             namespaceId?: number,
             progressCallback?: (
                 status: PythonExecutionStatus,
-                data?: any
+                data?: {
+                    executionCount?: number;
+                }
             ) => void,
             stdoutCallback?: (text: string) => void,
             stderrCallback?: (text: string) => void

--- a/querybook/webapp/lib/python/python-worker.ts
+++ b/querybook/webapp/lib/python/python-worker.ts
@@ -149,7 +149,7 @@ class PyodideKernel implements PythonKernel {
 
             // Execute the code
             const result = await this.pyodide.runPythonAsync(code, {
-                locals: namespace,
+                globals: namespace,
             });
 
             // Print result if not undefined

--- a/querybook/webapp/lib/python/python-worker.ts
+++ b/querybook/webapp/lib/python/python-worker.ts
@@ -149,6 +149,7 @@ class PyodideKernel implements PythonKernel {
 
             // Execute the code
             const result = await this.pyodide.runPythonAsync(code, {
+                // globals vs locals: https://github.com/pyodide/pyodide/issues/4673
                 globals: namespace,
             });
 

--- a/querybook/webapp/lib/python/python-worker.ts
+++ b/querybook/webapp/lib/python/python-worker.ts
@@ -1,19 +1,20 @@
+import { Task, TaskQueue } from './task-queue';
 import { expose } from 'comlink';
 import { loadPyodide, PyodideInterface, version } from 'pyodide';
 
 import type { PyProxy } from 'pyodide/ffi';
 
 import { patchPyodide } from './patch';
-import { PythonKernel } from './types';
+import {
+    InterruptBufferStatus,
+    PythonExecutionStatus,
+    PythonKernel,
+    PythonNamespaceInfo,
+} from './types';
 
 // Constants
 const INDEX_URL = `https://cdn.jsdelivr.net/pyodide/v${version}/full/`;
 const DEFAULT_PACKAGES = ['micropip', 'numpy', 'pandas', 'matplotlib'];
-
-enum InterruptBufferStatus {
-    RESET = 0, // Reset
-    SIGINT = 2, // Interrupt the execution
-}
 
 /**
  * PyodideKernel - Handles Pyodide initialization and execution
@@ -21,12 +22,13 @@ enum InterruptBufferStatus {
  */
 class PyodideKernel implements PythonKernel {
     public version = version;
+    public interruptBuffer: Uint8Array | null = null;
 
     private loadPyodidePromise: Promise<void> | null = null;
     private namespaces: Record<number, PyProxy> = {};
     private executionCountByNS: Record<number, number> = {};
     private pyodide: PyodideInterface | null = null;
-    private interruptBuffer: Uint8Array | null = null;
+    private taskQueue = new TaskQueue();
 
     /**
      * Initialize pyodide with specified packages
@@ -43,65 +45,34 @@ class PyodideKernel implements PythonKernel {
     }
 
     /**
-     * Run Python code in the specified namespace
-     *
-     * @returns The result of the execution, if any
+     * Run Python code using a task queue to ensure sequential execution
      */
     public async runPython(
         code: string,
         namespaceId?: number,
-        stdoutCallback?: ((text: string) => void) | null,
-        stderrCallback?: ((text: string) => void) | null
+        progressCallback?: (status: PythonExecutionStatus, data?: any) => void,
+        stdoutCallback?: (text: string) => void,
+        stderrCallback?: (text: string) => void
     ): Promise<void> {
         this._ensurePyodide();
 
-        // Reset interrupt buffer and set status
-        this.interruptBuffer[0] = InterruptBufferStatus.RESET;
-
-        if (namespaceId !== undefined) {
-            this.executionCountByNS[namespaceId] =
-                this.getExecutionCount(namespaceId) + 1;
-        }
-
-        // Load any required packages from imports
-        await this.pyodide.loadPackagesFromImports(code);
-
-        // Set I/O handlers
-        this.pyodide.setStdout(
-            stdoutCallback ? { batched: stdoutCallback } : undefined
-        );
-        this.pyodide.setStderr(
-            stderrCallback ? { batched: stderrCallback } : undefined
-        );
-
-        // Get namespace for execution
-        const namespace = this._getNamespace(namespaceId);
-
-        // Execute the code
-        const result = await this.pyodide.runPythonAsync(code, {
-            locals: namespace,
+        return new Promise((resolve, reject) => {
+            const task: Task = {
+                run: async () => {
+                    // Call the actual runPython method.
+                    await this._runPython(
+                        code,
+                        namespaceId,
+                        progressCallback,
+                        stdoutCallback,
+                        stderrCallback
+                    );
+                },
+                resolve,
+                reject,
+            };
+            this.taskQueue.push(task);
         });
-
-        // Print result if not undefined
-        if (result !== undefined) {
-            this.pyodide.globals.get('_custom_print')(result);
-        }
-    }
-
-    /**
-     * Cancel the current Python execution
-     */
-    public cancelRun(): void {
-        if (this.interruptBuffer) {
-            this.interruptBuffer[0] = InterruptBufferStatus.SIGINT;
-        }
-    }
-
-    /**
-     * Get the execution count for a namespace
-     */
-    public getExecutionCount(namespaceId: number): number {
-        return this.executionCountByNS[namespaceId] || 0;
     }
 
     /**
@@ -122,16 +93,86 @@ class PyodideKernel implements PythonKernel {
     }
 
     /**
-     * Get variables in the specified namespace
+     * Get the namespace information for a given namespace
      */
-    public getNamespaceVariables(namespaceId: number): string[] {
+    public async getNamespaceInfo(namespaceId: number): Promise<string> {
         this._ensurePyodide();
 
         const namespace = this._getNamespace(namespaceId);
-        return Object.keys(namespace.toJs()).filter(
-            (key) => key !== '__builtins__'
-        );
+        const identifiers = await this.pyodide.globals.get(
+            '_get_namespace_identifiers'
+        )(namespace);
+        const executionCount = this.executionCountByNS[namespaceId];
+
+        const info: PythonNamespaceInfo = {
+            identifiers: identifiers.toJs(),
+            executionCount,
+        };
+        // return names.toJs();
+        return JSON.stringify(info);
     }
+
+    /**
+     * Run Python code in the specified namespace
+     */
+    private async _runPython(
+        code: string,
+        namespaceId?: number,
+        progressCallback?: (status: PythonExecutionStatus, data?: any) => void,
+        stdoutCallback?: (code: string) => void,
+        stderrCallback?: (code: string) => void
+    ): Promise<void> {
+        progressCallback?.(PythonExecutionStatus.RUNNING);
+        // Reset interrupt buffer and set status
+        this.interruptBuffer[0] = InterruptBufferStatus.RESET;
+
+        if (namespaceId !== undefined) {
+            this.executionCountByNS[namespaceId] ??= 0;
+            this.executionCountByNS[namespaceId]++;
+        }
+        const executionCount = this.executionCountByNS[namespaceId];
+
+        try {
+            // Load any required packages from imports
+            await this.pyodide.loadPackagesFromImports(code);
+
+            // Set I/O handlers
+            this.pyodide.setStdout(
+                stdoutCallback ? { batched: stdoutCallback } : undefined
+            );
+            this.pyodide.setStderr(
+                stderrCallback ? { batched: stderrCallback } : undefined
+            );
+
+            // Get namespace for execution
+            const namespace = this._getNamespace(namespaceId);
+
+            // Execute the code
+            const result = await this.pyodide.runPythonAsync(code, {
+                locals: namespace,
+            });
+
+            // Print result if not undefined
+            if (result !== undefined) {
+                this.pyodide.globals.get('_custom_print')(result);
+            }
+            progressCallback?.(PythonExecutionStatus.SUCCESS, {
+                executionCount,
+            });
+        } catch (error) {
+            if (error.message?.includes('KeyboardInterrupt')) {
+                progressCallback?.(PythonExecutionStatus.CANCEL, {
+                    executionCount,
+                });
+            } else {
+                progressCallback?.(PythonExecutionStatus.ERROR, {
+                    executionCount,
+                });
+            }
+            stderrCallback?.(`${error.message || String(error)}`);
+        }
+    }
+
     /**
      * Ensure that pyodide is initialized
      */
@@ -155,7 +196,7 @@ class PyodideKernel implements PythonKernel {
         });
 
         // Set up interrupt buffer
-        this.interruptBuffer = new Uint8Array(new ArrayBuffer(1));
+        this.interruptBuffer = new Uint8Array(new SharedArrayBuffer(1));
         this.pyodide.setInterruptBuffer(this.interruptBuffer);
 
         // Load additional packages if specified

--- a/querybook/webapp/lib/python/python-worker.ts
+++ b/querybook/webapp/lib/python/python-worker.ts
@@ -50,7 +50,12 @@ class PyodideKernel implements PythonKernel {
     public async runPython(
         code: string,
         namespaceId?: number,
-        progressCallback?: (status: PythonExecutionStatus, data?: any) => void,
+        progressCallback?: (
+            status: PythonExecutionStatus,
+            data?: {
+                executionCount?: number;
+            }
+        ) => void,
         stdoutCallback?: (text: string) => void,
         stderrCallback?: (text: string) => void
     ): Promise<void> {
@@ -118,7 +123,12 @@ class PyodideKernel implements PythonKernel {
     private async _runPython(
         code: string,
         namespaceId?: number,
-        progressCallback?: (status: PythonExecutionStatus, data?: any) => void,
+        progressCallback?: (
+            status: PythonExecutionStatus,
+            data?: {
+                executionCount?: number;
+            }
+        ) => void,
         stdoutCallback?: (code: string) => void,
         stderrCallback?: (code: string) => void
     ): Promise<void> {

--- a/querybook/webapp/lib/python/task-queue.ts
+++ b/querybook/webapp/lib/python/task-queue.ts
@@ -1,0 +1,42 @@
+export interface Task {
+    run: () => Promise<void>;
+    resolve: () => void;
+    reject: (error: any) => void;
+}
+
+/**
+ * A simple task queue that runs tasks in sequence.
+ */
+export class TaskQueue {
+    private queue: Task[] = [];
+    private isRunning: boolean = false;
+
+    // Add a task to the queue and immediately attempt to run the next task
+    public push(task: Task) {
+        this.queue.push(task);
+        this.runNext();
+    }
+
+    private async runNext() {
+        // If a task is already running or queue is empty, do nothing.
+        if (this.isRunning || this.queue.length === 0) {
+            return;
+        }
+
+        // Pull the next task from the queue.
+        const task = this.queue.shift();
+        if (!task) return;
+
+        this.isRunning = true;
+        try {
+            await task.run();
+            task.resolve();
+        } catch (error) {
+            task.reject(error);
+        } finally {
+            this.isRunning = false;
+            // Process the next task in queue.
+            this.runNext();
+        }
+    }
+}

--- a/querybook/webapp/lib/python/task-queue.ts
+++ b/querybook/webapp/lib/python/task-queue.ts
@@ -31,14 +31,14 @@ export class TaskQueue {
         try {
             await task.run();
             task.resolve();
-            // Process the next task in queue.
-            this.runNext();
         } catch (error) {
             task.reject(error);
             // empty the queue on error to keep the behavior consistent with Jupyter notebook
             this.queue = [];
         } finally {
             this.isRunning = false;
+            // Process the next task in queue.
+            this.runNext();
         }
     }
 }

--- a/querybook/webapp/lib/python/task-queue.ts
+++ b/querybook/webapp/lib/python/task-queue.ts
@@ -33,6 +33,8 @@ export class TaskQueue {
             task.resolve();
         } catch (error) {
             task.reject(error);
+            // empty the queue on error to keep the behavior consistent with Jupyter notebook
+            this.queue = [];
         } finally {
             this.isRunning = false;
             // Process the next task in queue.

--- a/querybook/webapp/lib/python/task-queue.ts
+++ b/querybook/webapp/lib/python/task-queue.ts
@@ -31,14 +31,14 @@ export class TaskQueue {
         try {
             await task.run();
             task.resolve();
+            // Process the next task in queue.
+            this.runNext();
         } catch (error) {
             task.reject(error);
             // empty the queue on error to keep the behavior consistent with Jupyter notebook
             this.queue = [];
         } finally {
             this.isRunning = false;
-            // Process the next task in queue.
-            this.runNext();
         }
     }
 }

--- a/querybook/webapp/lib/python/types.ts
+++ b/querybook/webapp/lib/python/types.ts
@@ -12,7 +12,7 @@ export enum PythonKernelStatus {
     // Kernel is currently executing code.
     BUSY = 'busy',
 
-    // Kernel has encountered an error.
+    // Kernel has encountered an error when initializing.
     FAILED = 'failed',
 }
 
@@ -69,6 +69,7 @@ export interface PythonKernel {
      *
      * @param code - The Python code to execute.
      * @param namespaceId - An optional ID of the namespace to execute the code in.
+     * @param progressCallback - An optional callback to handle execution status updates.
      * @param stdoutCallback - An optional callback to handle standard output from the execution.
      * @param stderrCallback - An optional callback to handle standard error output from the execution.
      * @returns A promise that resolves when the execution is complete.
@@ -76,14 +77,15 @@ export interface PythonKernel {
     runPython: (
         code: string,
         namespaceId?: number,
-        stdoutCallback?: (text: string) => void,
-        stderrCallback?: (text: string) => void
+        progressCallback?: (
+            status: PythonExecutionStatus,
+            data?: {
+                executionCount?: number;
+            }
+        ) => void,
+        stdoutCallback?: (code: string) => void,
+        stderrCallback?: (code: string) => void
     ) => Promise<void>;
-
-    /**
-     * Cancels the currently running code execution.
-     */
-    cancelRun: () => void;
 
     /**
      * Creates a DataFrame in the specified namespace.
@@ -100,20 +102,17 @@ export interface PythonKernel {
     ) => Promise<void>;
 
     /**
-     * Retrieves the execution count for the specified namespace.
+     * Retrieves information about the specified namespace, including the execution count and identifiers.
      *
      * @param namespaceId - The ID of the namespace.
-     * @returns The execution count for the specified namespace.
+     * @returns JSON string containing the namespace information (PythonNamespaceInfo).
      */
-    getExecutionCount: (namespaceId: number) => number;
+    getNamespaceInfo: (namespaceId: number) => Promise<string>;
 
     /**
-     * Returns a list of variable names in the specified namespace.
-     *
-     * @param namespaceId - The ID of the namespace.
-     * @returns An array of variable names in the specified namespace.
+     * The shared interrupt buffer used to cancel the current execution
      */
-    getNamespaceVariables: (namespaceId: number) => string[];
+    interruptBuffer: Uint8Array | null;
 
     /**
      * The version of the Python kernel.

--- a/querybook/webapp/lib/python/types.ts
+++ b/querybook/webapp/lib/python/types.ts
@@ -83,8 +83,8 @@ export interface PythonKernel {
                 executionCount?: number;
             }
         ) => void,
-        stdoutCallback?: (code: string) => void,
-        stderrCallback?: (code: string) => void
+        stdoutCallback?: (text: string) => void,
+        stderrCallback?: (text: string) => void
     ) => Promise<void>;
 
     /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,6 +53,11 @@ function getDevServerSettings(env) {
                 changeOrigin: true,
             },
         },
+        // To enable SharedArrayBuffer for interrupting Pyodide in a Web Worker from the main thread
+        headers: {
+            "Cross-Origin-Opener-Policy": "same-origin",
+            "Cross-Origin-Embedder-Policy": "require-corp",
+        },
         publicPath: '/build/',
         onListening: (server) => {
             let firstTimeBuildComplete = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7599,6 +7599,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+balloon-css@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/balloon-css/-/balloon-css-1.2.0.tgz#53d3fb4051264a278a58713bed6865845dbcaf4b"
+  integrity sha512-urXwkHgwp6GsXVF+it01485Z2Cj4pnW02ICnM0TemOlkKmCNnDLmyy+ZZiRXBpwldUXO+aRNr7Hdia4CBvXJ5A==
+
 base16@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz"


### PR DESCRIPTION
* add a simple queue to run the tasks in sequence. User can kick off multiple runs, and they will become pending and pushed to the queue
* add cancellation support by using shared array buffer, which requires [cross-origin isolated](https://developer.mozilla.org/en-US/docs/Web/API/Window/crossOriginIsolated) enabled.
* add a `progressCallback` to better track the execution status and execution count.
* add another helper function to get identifiers of a namespace to support auto completion.