### PR TITLE
feat: Added excel export

### DIFF
--- a/plugins/exporter_plugin/__init__.py
+++ b/plugins/exporter_plugin/__init__.py
@@ -1,3 +1,7 @@
-ALL_PLUGIN_EXPORTERS = [
+from lib.export.exporters.python_exporter import PythonExporter
+from lib.export.exporters.r_exporter import RExporter
 
+ALL_PLUGIN_EXPORTERS = [
+    PythonExporter(),
+    RExporter()
 ]

--- a/querybook/webapp/components/StatementExecutionBar/ResultExportDropdown.tsx
+++ b/querybook/webapp/components/StatementExecutionBar/ResultExportDropdown.tsx
@@ -118,6 +118,17 @@ export const ResultExportDropdown: React.FunctionComponent<IProps> = ({
         }
     }, [statementId]);
 
+    const onDownloadXlsxClick = React.useCallback(() => {
+        trackExportButtonClick('Download XLSX');
+
+        const url = getStatementExecutionResultDownloadUrl(statementId, "xlsx");
+        if (url) {
+            Utils.download(url, `${statementId}.xlsx`);
+        } else {
+            toast.error('No valid url!');
+        }
+    }, [statementId]);
+
     const onExportTSVClick = React.useCallback(async () => {
         trackExportButtonClick('Copy to Clipboard');
 
@@ -198,6 +209,11 @@ export const ResultExportDropdown: React.FunctionComponent<IProps> = ({
             {
                 name: 'Download Full Result (as CSV)',
                 onClick: onDownloadClick,
+                icon: 'Download',
+            },
+            {
+                name: 'Download Full Result (as xlsx)',
+                onClick: onDownloadXlsxClick,
                 icon: 'Download',
             },
             {

--- a/querybook/webapp/lib/query-execution.ts
+++ b/querybook/webapp/lib/query-execution.ts
@@ -1,3 +1,3 @@
-export function getStatementExecutionResultDownloadUrl(id: number) {
-    return `${location.protocol}//${location.host}/ds/statement_execution/${id}/result/download/`;
+export function getStatementExecutionResultDownloadUrl(id: number, type: "csv" | "xlsx" = "csv"): string {
+    return `${location.protocol}//${location.host}/ds/statement_execution/${id}/result/download/?type=${type}`;
 }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -43,6 +43,7 @@ pandas==1.3.5
 typing-extensions==4.9.0
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 numpy>=1.22.2,<2.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
+xlsxwriter==3.2.2
 
 # Query engine - PostgreSQL
 psycopg2==2.9.5


### PR DESCRIPTION
This pull request introduces an Excel export feature for Querybook. I developed this functionality for Hundt Consult GmbH, with the goal of enhancing usability for non-technical users who rely heavily on Excel.

The motivation for this feature was to make it easier for non-technical users to review and share query results directly in a familiar format. It also must be robust for text fields, that use line breaks and commas within texts, that break csv files. This ensurs that the exported files maintain integrity and readability.

I'm very happy to contribute this feature back to the project and am excited to receive feedback from the community. Any suggestions or improvements are highly welcome.

Thank you for your time and consideration!