### PR TITLE
fix: template query hangs with big payload

### DIFF
--- a/querybook/server/lib/query_analysis/templating.py
+++ b/querybook/server/lib/query_analysis/templating.py
@@ -49,19 +49,19 @@ def _escape_sql_comments(query: str):
     query_len = len(query)
     while pos < query_len:
         ch = query[pos]
-        # If inside a quoted string, just copy it verbatim.
-        if ch in ("'", '"'):
-            quote_char = ch
+        # If inside a quoted string, just copy it verbatim. ANSI SQL only allows single quotes.
+        if ch == "'":
             start = pos
             pos += 1
             while pos < query_len:
-                if query[pos] == "\\":
-                    pos += 2
-                    continue
-                if query[pos] == quote_char:
+                if query[pos] == "'":
+                    # ANSI SQL uses two single quotes to escape a single quote,
+                    # which can be just treated as two consecutive literals and we dont need to handle it separately.
                     pos += 1
                     break
+
                 pos += 1
+
             result.append(query[start:pos])
             continue
 

--- a/querybook/server/lib/query_analysis/templating.py
+++ b/querybook/server/lib/query_analysis/templating.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 import json
-import re
 from typing import Callable, Dict, Set
 
 from jinja2.exceptions import TemplateSyntaxError

--- a/querybook/tests/test_lib/test_query_analysis/test_templating.py
+++ b/querybook/tests/test_lib/test_query_analysis/test_templating.py
@@ -367,7 +367,8 @@ limit 100"""
 
     def test_big_payload(self):
         query = " /*" * 32000
-        self.assertEqual(_escape_sql_comments(query), query)
+        expected = ' {{ "' + query.strip() + '" }}'
+        self.assertEqual(_escape_sql_comments(query), expected)
 
 
 class LatestPartitionTestCase(TemplatingTestCase):

--- a/querybook/tests/test_lib/test_query_analysis/test_templating.py
+++ b/querybook/tests/test_lib/test_query_analysis/test_templating.py
@@ -365,6 +365,18 @@ order by c DESC
 limit 100"""
         self.assertEqual(_escape_sql_comments(query), query)
 
+    def test_string_literals(self):
+        query = "select '/*' -- test"
+        self.assertEqual(_escape_sql_comments(query), """select '/*' {{ "-- test" }}""")
+
+    def test_unclosed_comments(self):
+        # The rest of unclosed /* will be treated as comment
+        query = "select 1 \n/* \ntest\n"
+        self.assertEqual(
+            _escape_sql_comments(query),
+            'select 1 \n{{ "/* \\ntest\\n" }}',
+        )
+
     def test_big_payload(self):
         query = " /*" * 32000
         expected = ' {{ "' + query.strip() + '" }}'

--- a/querybook/tests/test_lib/test_query_analysis/test_templating.py
+++ b/querybook/tests/test_lib/test_query_analysis/test_templating.py
@@ -369,6 +369,10 @@ limit 100"""
         query = "select '/*' -- test"
         self.assertEqual(_escape_sql_comments(query), """select '/*' {{ "-- test" }}""")
 
+    def test_escape_quote_in_string_literals(self):
+        query = "SELECT 'It''s an /* example */ string' FROM dual"
+        self.assertEqual(_escape_sql_comments(query), query)
+
     def test_unclosed_comments(self):
         # The rest of unclosed /* will be treated as comment
         query = "select 1 \n/* \ntest\n"

--- a/querybook/tests/test_lib/test_query_analysis/test_templating.py
+++ b/querybook/tests/test_lib/test_query_analysis/test_templating.py
@@ -365,6 +365,10 @@ order by c DESC
 limit 100"""
         self.assertEqual(_escape_sql_comments(query), query)
 
+    def test_big_payload(self):
+        query = " /*" * 32000
+        self.assertEqual(_escape_sql_comments(query), query)
+
 
 class LatestPartitionTestCase(TemplatingTestCase):
     def setUp(self):


### PR DESCRIPTION
**Summary**
This PR addresses a vulnerability in the /ds/query_execution/templated_query/ endpoint of Querybook, where a Regular Expression used to escape SQL comments is vulnerable to ReDoS attacks.

**Impact**
The flaw allows an attacker to send malicious queries that can hang the server and consume excessive CPU resources, impacting availability.

**Reproduction Steps**
Attacker logs in and sends a crafted POST request to the endpoint.
The server hangs and CPU usage spikes to nearly 100%.
See the new test case as an example

**Root Cause**
The issue stems from the use of re.sub with a vulnerable regex pattern in the _escape_sql_comments function.

**Proposed Fix**
Replace the regex-based substitution with a non-regex alternative.