### PR TITLE
fix: some python cell bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.41.0",
+    "version": "3.41.1",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/components/DataDoc/DataDoc.tsx
+++ b/querybook/webapp/components/DataDoc/DataDoc.tsx
@@ -105,9 +105,22 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
     private searchAndReplaceRef = React.createRef<ISearchAndReplaceHandles>();
     private focusCellIndexAfterInsert: number = null;
 
+    @bind
+    public matchDatadocPath() {
+        return !!matchPath(location.pathname, {
+            path: '/:env/datadoc/:docId/',
+            exact: true,
+            strict: false,
+        });
+    }
+
     // Show data doc title in url and document title
     @decorate(memoizeOne)
     public publishDataDocTitle(title: string) {
+        if (!this.matchDatadocPath()) {
+            return;
+        }
+
         setBrowserTitle(title || 'Untitled DataDoc');
         if (title) {
             const pathParts = location.pathname.split('/');
@@ -189,18 +202,10 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
 
         cellId = cellId ?? (index != null ? dataDocCells?.[index]?.id : null);
 
-        if (cellId != null) {
-            const match = matchPath(location.pathname, {
-                path: '/:env/datadoc/:docId/',
-                exact: true,
-                strict: false,
-            });
-            if (match) {
-                // Only replace the url if we are in the datadoc page
-                executionId =
-                    executionId ?? this.state.cellIdToExecutionId[cellId];
-                history.replace(getShareUrl(cellId, executionId, true));
-            }
+        if (cellId != null && this.matchDatadocPath()) {
+            // Only replace the url if we are in the datadoc page
+            executionId = executionId ?? this.state.cellIdToExecutionId[cellId];
+            history.replace(getShareUrl(cellId, executionId, true));
         }
     }
 

--- a/querybook/webapp/components/DataDocPythonCell/DataDocPythonCell.tsx
+++ b/querybook/webapp/components/DataDocPythonCell/DataDocPythonCell.tsx
@@ -38,6 +38,7 @@ export const DataDocPythonCell = ({
     cellId,
     docId,
     context,
+    isEditable,
     onChange,
 }: IDataDocPythonCellProps) => {
     const {
@@ -102,18 +103,22 @@ export const DataDocPythonCell = ({
         <div className="DataDocPythonCell">
             <div className="python-cell-header">
                 <AccentText weight="bold" size="med">
-                    <div>
-                        <ResizableTextArea
-                            value={meta.title}
-                            onChange={updateTitle}
-                            transparent
-                            placeholder={defaultTitlePlaceholder}
-                            className="cell-title"
-                        />
-                    </div>
+                    {isEditable ? (
+                        <div>
+                            <ResizableTextArea
+                                value={meta.title}
+                                onChange={updateTitle}
+                                transparent
+                                placeholder={defaultTitlePlaceholder}
+                                className="cell-title"
+                            />
+                        </div>
+                    ) : (
+                        <span className="p8">{meta.title}</span>
+                    )}
                 </AccentText>
                 <div className="python-cell-controls">
-                    {!isRunning && (
+                    {isEditable && !isRunning && (
                         <AsyncButton
                             className="run-button"
                             onClick={runPythonCode}
@@ -125,7 +130,7 @@ export const DataDocPythonCell = ({
                             color={'accent'}
                         />
                     )}
-                    {isRunning && (
+                    {isEditable && isRunning && (
                         <AsyncButton
                             className="run-button"
                             onClick={cancelRun}
@@ -141,6 +146,7 @@ export const DataDocPythonCell = ({
                 value={context}
                 identifiers={identifiers}
                 keyBindings={keyBindings}
+                readonly={!isEditable}
                 onChange={(value) => {
                     onChange({
                         context: value,

--- a/querybook/webapp/components/DataDocPythonCell/PythonCellResultView.scss
+++ b/querybook/webapp/components/DataDocPythonCell/PythonCellResultView.scss
@@ -11,12 +11,12 @@
         background-color: var(--bg-lightest);
 
         .json-view {
-            max-height: 40vh;
+            max-height: 60vh;
             overflow: auto;
         }
 
         .image-view {
-            max-height: 40vh;
+            max-height: 60vh;
             overflow: auto;
         }
 

--- a/querybook/webapp/components/DataDocPythonCell/PythonCellResultView.scss
+++ b/querybook/webapp/components/DataDocPythonCell/PythonCellResultView.scss
@@ -16,8 +16,7 @@
         }
 
         .image-view {
-            max-height: 60vh;
-            overflow: auto;
+            width: 100%;
         }
 
         .text-view {

--- a/querybook/webapp/components/DataDocPythonCell/PythonCellResultView.tsx
+++ b/querybook/webapp/components/DataDocPythonCell/PythonCellResultView.tsx
@@ -51,7 +51,11 @@ export const PythonCellResultView = ({
                     />
                 );
             } else if (output['type'] === 'image') {
-                return <img src={output['data']} className="image-view" />;
+                return (
+                    <div className="image-view">
+                        <img src={output['data']} />
+                    </div>
+                );
             } else if (output['type'] === 'json') {
                 return (
                     <div className="json-view">

--- a/querybook/webapp/components/PythonKernelButton/guide.md
+++ b/querybook/webapp/components/PythonKernelButton/guide.md
@@ -22,7 +22,7 @@ To install other external pure Python packages with wheels, use `micropip`. For 
 
 ```py
 import micropip
-micropip.install('seaborn')
+await micropip.install('seaborn')
 ```
 
 For more details on package loading, refer to the [Pyodide documentation](https://pyodide.org/en/stable/usage/loading-packages.html#loading-packages).

--- a/querybook/webapp/components/PythonKernelButton/guide.md
+++ b/querybook/webapp/components/PythonKernelButton/guide.md
@@ -14,7 +14,7 @@ By default, only the Python standard library and the following packages are avai
 -   pandas
 -   matplotlib
 
-Note: Some modules have been removed from the standard library to reduce download size and may not work. You can view the list of removed modules [here](https://pyodide.org/en/stable/usage/wasm-constraints.html#removed-modules).
+**Note**: Some modules have been removed from the standard library to reduce download size and may not work. You can view the list of removed modules [here](https://pyodide.org/en/stable/usage/wasm-constraints.html#removed-modules).
 
 For other Pyodide [built-in packages](https://pyodide.org/en/stable/usage/packages-in-pyodide.html#packages-in-pyodide), you can import them directly, and they will load automatically when the code is executed.
 
@@ -35,6 +35,8 @@ To retrieve query results as a `DataFrame`, click the `Copy DataFrame` button lo
 df = await get_df(1, limit=10)
 df
 ```
+
+**Note**: All columns of the query result are string type. Please convert them to the appropriate types as needed.
 
 For more information about the `get_df` function, run `help(get_df)`.
 

--- a/querybook/webapp/lib/python/patch.ts
+++ b/querybook/webapp/lib/python/patch.ts
@@ -86,6 +86,7 @@ async function patchMatplotlib(pyodide: PyodideInterface) {
           # encode to a base64 str
           img = base64.b64encode(buf.read()).decode('utf-8')
           print(json.dumps({"type": "image", "data": "data:image/png;base64," + img}))
+          matplotlib.pyplot.clf()
 
       matplotlib.pyplot.show = show
 


### PR DESCRIPTION
fix few bugs

- Resolve issues where the Matplotlib figure isn’t cleared after displaying it, causing subsequent figures to include previous content.
- Modify the image output to maintain an automatic height with scroll functionality, ensuring it scales proportionally.
- update the doc of adding`await` to `micropip.install` to prevent some warnings.
- Fix the behavior of the changelog modal on the datadoc page so that it no longer appends the document title upon popping up.
- Make the python cell/title uneditable for readonly views