### PR TITLE
fix: space between the cell and control buttons in readonly doc

### DIFF
--- a/querybook/webapp/components/DataDoc/DataDoc.scss
+++ b/querybook/webapp/components/DataDoc/DataDoc.scss
@@ -117,6 +117,7 @@
                             display: none;
                         }
 
+                        height: 32px;
                         top: -17px;
                         position: relative;
                         text-align: center;


### PR DESCRIPTION
There needs to have space between the control buttons (comment button) and the above cell. 
The reason is there are no cell creation button to take the space, this fix is to add the height always.
Before
![image](https://github.com/user-attachments/assets/791cb174-d62a-4efa-8246-66b7982804da)

After
![image](https://github.com/user-attachments/assets/64538ef4-6078-453c-8d2e-c573181eb03d)

