### PR TITLE
fix: kernel status is incorrect with mutlipel task running

### DIFF
--- a/querybook/webapp/components/PythonKernelButton/PythonKernelButton.tsx
+++ b/querybook/webapp/components/PythonKernelButton/PythonKernelButton.tsx
@@ -20,17 +20,17 @@ const BORDER_COLORS = {
 };
 
 export const PythonKernelButton = () => {
-    const { status } = useContext(PythonContext);
+    const { kernelStatus } = useContext(PythonContext);
     const [showModal, , toggleShowModal] = useToggleState(false);
 
     return (
         <>
             <div
-                aria-label={`Python kernel: ${status}`}
+                aria-label={`Python kernel: ${kernelStatus}`}
                 data-balloon-pos="left"
                 className="PythonKernelButton"
                 style={{
-                    borderColor: BORDER_COLORS[status],
+                    borderColor: BORDER_COLORS[kernelStatus],
                 }}
                 onClick={toggleShowModal}
             >

--- a/querybook/webapp/lib/python/python-provider.tsx
+++ b/querybook/webapp/lib/python/python-provider.tsx
@@ -20,7 +20,8 @@ import {
 } from './types';
 
 export interface PythonContextType {
-    status: PythonKernelStatus;
+    kernelStatus: PythonKernelStatus;
+    setKernelStatus: (status: PythonKernelStatus) => void;
     runPython: (
         code: string,
         namespaceId?: number,
@@ -148,9 +149,6 @@ function PythonProvider({ children }: PythonProviderProps) {
                 return;
             }
 
-            // Update status to reflect that we're about to run code
-            setStatus(PythonKernelStatus.BUSY);
-
             // Run the code with specific callbacks for this execution
             await kernelRef.current.runPython(
                 code,
@@ -159,7 +157,6 @@ function PythonProvider({ children }: PythonProviderProps) {
                 proxy(stdoutCallback),
                 proxy(stderrCallback)
             );
-            setStatus(PythonKernelStatus.IDLE);
         },
         [initKernel, setStatus]
     );
@@ -190,7 +187,8 @@ function PythonProvider({ children }: PythonProviderProps) {
     return (
         <PythonContext.Provider
             value={{
-                status,
+                kernelStatus: status,
+                setKernelStatus: setStatus,
                 runPython,
                 cancelRun,
                 createDataFrame: kernelRef.current?.createDataFrame,

--- a/querybook/webapp/lib/python/usePython.ts
+++ b/querybook/webapp/lib/python/usePython.ts
@@ -49,7 +49,6 @@ export default function usePython({
 
     const {
         kernelStatus,
-        setKernelStatus,
         runPython,
         cancelRun,
         createDataFrame,
@@ -98,12 +97,6 @@ export default function usePython({
             setExecutionStatus(status);
             setExecutionCount(data?.executionCount);
 
-            if (status === PythonExecutionStatus.RUNNING) {
-                setKernelStatus(PythonKernelStatus.BUSY);
-            } else {
-                setKernelStatus(PythonKernelStatus.IDLE);
-            }
-
             if (
                 cancelPromiseResolveRef.current &&
                 status === PythonExecutionStatus.CANCEL
@@ -112,7 +105,7 @@ export default function usePython({
                 cancelPromiseResolveRef.current = null;
             }
         },
-        [setExecutionCount, setExecutionStatus, setKernelStatus]
+        [setExecutionCount, setExecutionStatus]
     );
 
     const stdoutCallback = useCallback(


### PR DESCRIPTION
The issue: the kernel status will be cleared as idle when there is still pending tasks.

Fix: switch to derive the busy and idle status from the python execution status. 