### PR TITLE
fix: change log auto popup bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.41.2",
+    "version": "3.41.3",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/components/ChangeLog/ChangeLog.tsx
+++ b/querybook/webapp/components/ChangeLog/ChangeLog.tsx
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -56,15 +57,23 @@ export const ChangeLog: React.FunctionComponent = () => {
             Promise.all([
                 localStore.get<ChangeLogValue>(CHANGE_LOG_KEY),
                 ChangeLogResource.getAll(),
-            ]).then(([localStorageDate, { data }]) => {
-                setChangeLogList(data);
+            ])
+                .then(([localStorageDate, { data }]) => {
+                    setChangeLogList(data);
 
-                const lastViewedDate = localStorageDate ?? '2000-01-01';
-                const content = data
-                    .filter((log) => log.date > lastViewedDate)
-                    .map((log) => log.content);
-                setChangeLogContent(content);
-            });
+                    const lastViewedDate = localStorageDate ?? '2000-01-01';
+                    const content = data
+                        .filter((log) => log.date > lastViewedDate)
+                        .map((log) => log.content);
+                    setChangeLogContent(content);
+                })
+                .finally(() => {
+                    // Update the local storage with the last viewed date
+                    localStore.set<ChangeLogValue>(
+                        CHANGE_LOG_KEY,
+                        moment().format('YYYY-MM-DD')
+                    );
+                });
         }
     }, [changeLogDate]);
 

--- a/querybook/webapp/components/EnvironmentAppRouter/modalRoute/ChangeLogRoute.tsx
+++ b/querybook/webapp/components/EnvironmentAppRouter/modalRoute/ChangeLogRoute.tsx
@@ -5,8 +5,6 @@ import { RouteComponentProps } from 'react-router-dom';
 import { ChangeLog } from 'components/ChangeLog/ChangeLog';
 import { useBrowserTitle } from 'hooks/useBrowserTitle';
 import { useModalRoute } from 'hooks/useModalRoute';
-import localStore from 'lib/local-store';
-import { CHANGE_LOG_KEY, ChangeLogValue } from 'lib/local-store/const';
 import history from 'lib/router-history';
 import { Modal } from 'ui/Modal/Modal';
 
@@ -16,16 +14,8 @@ const ChangeLogRoute: React.FunctionComponent<RouteComponentProps> = ({
     useBrowserTitle('Change Log');
     const isModal = useModalRoute(location);
 
-    const handleHide = () => {
-        localStore.set<ChangeLogValue>(
-            CHANGE_LOG_KEY,
-            moment().format('YYYY-MM-DD')
-        );
-        history.goBack();
-    };
-
     return isModal ? (
-        <Modal onHide={handleHide} title="Change Log">
+        <Modal onHide={history.goBack} title="Change Log">
             <ChangeLog />
         </Modal>
     ) : (

--- a/querybook/webapp/components/EnvironmentAppRouter/modalRoute/ChangeLogRoute.tsx
+++ b/querybook/webapp/components/EnvironmentAppRouter/modalRoute/ChangeLogRoute.tsx
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 


### PR DESCRIPTION
issue: when the `Show Full View` user setting is enabled, the local store `change_log_last_viewed` will not be written, thus it will keep popping up the change log view.

fix: move the `localStore.set` into the change log view instead of only triggering on the modal dismiss.