### PR TITLE
fix: disable cancel python run

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.41.4",
+    "version": "3.41.5",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/server/app/flask_app.py
+++ b/querybook/server/app/flask_app.py
@@ -60,11 +60,6 @@ def make_flask_app():
     @app.after_request
     def add_csp_header(response):
         response.headers["Content-Security-Policy"] = csp_header_value
-
-        # To enable SharedArrayBuffer for interrupting Pyodide in a Web Worker from the main thread
-        response.headers["Cross-Origin-Opener-Policy"] = "same-origin"
-        response.headers["Cross-Origin-Embedder-Policy"] = "require-corp"
-
         return response
 
     return app

--- a/querybook/webapp/components/DataDocPythonCell/DataDocPythonCell.tsx
+++ b/querybook/webapp/components/DataDocPythonCell/DataDocPythonCell.tsx
@@ -1,18 +1,10 @@
-import { ReactCodeMirrorRef } from '@uiw/react-codemirror';
-import JsonView from '@uiw/react-json-view';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { PythonEditor } from 'components/PythonEditor/PythonEditor';
-import { StatementResultTable } from 'components/StatementResultTable/StatementResultTable';
-import {
-    DataCellUpdateFields,
-    IDataCellMeta,
-    IDataPythonCellMeta,
-} from 'const/datadoc';
+import { DataCellUpdateFields, IDataPythonCellMeta } from 'const/datadoc';
 import { PythonExecutionStatus, PythonKernelStatus } from 'lib/python/types';
 import usePython from 'lib/python/usePython';
 import { KeyMap } from 'lib/utils/keyboard';
-import { PythonCellResource } from 'resource/pythonCell';
 import { AsyncButton } from 'ui/AsyncButton/AsyncButton';
 import { Icon } from 'ui/Icon/Icon';
 import { ResizableTextArea } from 'ui/ResizableTextArea/ResizableTextArea';
@@ -44,7 +36,6 @@ export const DataDocPythonCell = ({
     const {
         kernelStatus,
         runPython,
-        cancelRun,
         stdout,
         stderr,
         executionStatus,
@@ -118,7 +109,7 @@ export const DataDocPythonCell = ({
                     )}
                 </AccentText>
                 <div className="python-cell-controls">
-                    {isEditable && !isRunning && (
+                    {isEditable && (
                         <AsyncButton
                             className="run-button"
                             onClick={runPythonCode}
@@ -128,13 +119,6 @@ export const DataDocPythonCell = ({
                                 kernelStatus !== PythonKernelStatus.BUSY
                             }
                             color={'accent'}
-                        />
-                    )}
-                    {isEditable && isRunning && (
-                        <AsyncButton
-                            className="run-button"
-                            onClick={cancelRun}
-                            title="Canel"
                         />
                     )}
                 </div>

--- a/querybook/webapp/components/PythonKernelButton/guide.md
+++ b/querybook/webapp/components/PythonKernelButton/guide.md
@@ -48,6 +48,10 @@ By default, Python output is rendered as plain text, similar to a standard Pytho
 -   **JSON**: Rendered as a visualized JSON view.
 -   **Plot images from matplotlib**: Rendered as PNG static images.
 
+## Canceling a Running Python Cell
+
+Canceling or interrupting a running Python cell is **not supported** due to browser security restrictions. If you need to terminate a long-running or stuck Python cell, you can simply reload the page to restart the Python kernel, which will also clear all current Python cell states.
+
 ## Scheduled DataDocs
 
 Since Python cells execute entirely on the client side within the browser, they will be skipped in Scheduled DataDoc runs. Only Query cells are supported for scheduling.

--- a/querybook/webapp/lib/python/python-provider.tsx
+++ b/querybook/webapp/lib/python/python-provider.tsx
@@ -197,6 +197,10 @@ function PythonProvider({ children }: PythonProviderProps) {
      * Interrupting a running code execution is achieved using a shared buffer.
      * This operation must be performed on the main thread.
      * For more details, refer to https://pyodide.org/en/stable/usage/keyboard-interrupts.html
+     *
+     * The SharedArrayBuffer requires isolated cross-origin access,
+     * which will block cross-origin resources from being loaded.
+     * So we haven't really enabled the required CSP headers for this feature yet.
      */
     const cancelRun = useCallback(() => {
         if (sharedInterruptBuffer.current) {

--- a/querybook/webapp/lib/python/usePython.ts
+++ b/querybook/webapp/lib/python/usePython.ts
@@ -21,7 +21,6 @@ interface UsePythonProps {
 interface UsePythonReturn {
     kernelStatus: PythonKernelStatus;
     runPython: (code: string) => Promise<void>;
-    cancelRun: () => Promise<void>;
     createDataFrame: (
         dfName: string,
         statementExecutionId: number,
@@ -175,7 +174,6 @@ export default function usePython({
     return {
         kernelStatus,
         runPython: runPythonCode,
-        cancelRun: cancelRunPython,
         createDataFrame,
         stdout,
         stderr,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,11 +54,6 @@ function getDevServerSettings(env) {
                 changeOrigin: true,
             },
         },
-        // To enable SharedArrayBuffer for interrupting Pyodide in a Web Worker from the main thread
-        headers: {
-            "Cross-Origin-Opener-Policy": "same-origin",
-            "Cross-Origin-Embedder-Policy": "require-corp",
-        },
         publicPath: '/build/',
         onListening: (server) => {
             let firstTimeBuildComplete = true;


### PR DESCRIPTION
To cancel the Python run in a webworker, it needs to use [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements), which requires [cross-origin isolated](https://developer.mozilla.org/en-US/docs/Web/API/Window/crossOriginIsolated). But by enabling the required CSP headers, it will also block loading cross origin resources, e.g. to render some image from other sites.  So disabling this feature and update the user guide to reload the page for kernel restart if really needed.