### PR TITLE
fix: remove SharedArrayBuffer code

### DIFF
--- a/querybook/webapp/lib/python/python-provider.tsx
+++ b/querybook/webapp/lib/python/python-provider.tsx
@@ -32,11 +32,6 @@ export interface PythonContextType {
         stdoutCallback?: (text: string) => void,
         stderrCallback?: (text: string) => void
     ) => Promise<void>;
-    createDataFrame: (
-        dfName: string,
-        statementExecutionId: number,
-        namespaceId?: number
-    ) => Promise<void>;
     getNamespaceInfo: (namespaceId: number) => Promise<PythonNamespaceInfo>;
 }
 
@@ -212,7 +207,6 @@ function PythonProvider({ children }: PythonProviderProps) {
             value={{
                 kernelStatus: status,
                 runPython,
-                createDataFrame: kernelRef.current?.createDataFrame,
                 getNamespaceInfo,
             }}
         >

--- a/querybook/webapp/lib/python/python-worker.ts
+++ b/querybook/webapp/lib/python/python-worker.ts
@@ -6,7 +6,6 @@ import type { PyProxy } from 'pyodide/ffi';
 
 import { patchPyodide } from './patch';
 import {
-    InterruptBufferStatus,
     PythonExecutionStatus,
     PythonKernel,
     PythonNamespaceInfo,
@@ -29,7 +28,6 @@ self.envirionment = '';
  */
 class PyodideKernel implements PythonKernel {
     public version = version;
-    public interruptBuffer: Uint8Array | null = null;
 
     private loadPyodidePromise: Promise<void> | null = null;
     private namespaces: Record<number, PyProxy> = {};
@@ -144,8 +142,6 @@ class PyodideKernel implements PythonKernel {
         stderrCallback?: (code: string) => void
     ): Promise<void> {
         progressCallback?.(PythonExecutionStatus.RUNNING);
-        // Reset interrupt buffer and set status
-        this.interruptBuffer[0] = InterruptBufferStatus.RESET;
 
         if (namespaceId !== undefined) {
             this.executionCountByNS[namespaceId] ??= 0;
@@ -216,10 +212,6 @@ class PyodideKernel implements PythonKernel {
             indexURL: INDEX_URL,
             packages: DEFAULT_PACKAGES,
         });
-
-        // Set up interrupt buffer
-        this.interruptBuffer = new Uint8Array(new SharedArrayBuffer(1));
-        this.pyodide.setInterruptBuffer(this.interruptBuffer);
 
         // Load additional packages if specified
         if (additionalPackages.length > 0) {

--- a/querybook/webapp/lib/python/python-worker.ts
+++ b/querybook/webapp/lib/python/python-worker.ts
@@ -86,23 +86,6 @@ class PyodideKernel implements PythonKernel {
     }
 
     /**
-     * Create a DataFrame in the specified namespace
-     */
-    public async createDataFrame(
-        dfName: string,
-        statementExecutionId: number,
-        namespaceId: number
-    ): Promise<void> {
-        this._ensurePyodide();
-
-        const namespace = this._getNamespace(namespaceId);
-        const df = await this.pyodide.globals.get('get_df')(
-            statementExecutionId
-        );
-        namespace.set(dfName, df);
-    }
-
-    /**
      * Get the namespace information for a given namespace
      */
     public async getNamespaceInfo(namespaceId: number): Promise<string> {

--- a/querybook/webapp/lib/python/types.ts
+++ b/querybook/webapp/lib/python/types.ts
@@ -107,20 +107,6 @@ export interface PythonKernel {
     ) => Promise<void>;
 
     /**
-     * Creates a DataFrame in the specified namespace.
-     *
-     * @param dfName - The name of the DataFrame to create.
-     * @param statementExecutionId - The ID of the statement execution that created the DataFrame.
-     * @param namespaceId - The ID of the namespace where the DataFrame will be created.
-     * @returns A promise that resolves when the DataFrame is created.
-     */
-    createDataFrame: (
-        dfName: string,
-        statementExecutionId: number,
-        namespaceId: number
-    ) => Promise<void>;
-
-    /**
      * Retrieves information about the specified namespace, including the execution count and identifiers.
      *
      * @param namespaceId - The ID of the namespace.

--- a/querybook/webapp/lib/python/types.ts
+++ b/querybook/webapp/lib/python/types.ts
@@ -46,11 +46,6 @@ export interface PythonNamespaceInfo {
     identifiers: PythonIdentifierInfo[];
 }
 
-export enum InterruptBufferStatus {
-    RESET = 0, // Reset
-    SIGINT = 2, // Interrupt the execution
-}
-
 // Keep it consistent with the backend python type `lib.data_doc.data_cell.PythonOutputType`
 export type PythonOutputType =
     | {
@@ -74,11 +69,6 @@ export type PythonOutputType =
  * Interface representing a Python kernel for executing Python code and managing namespaces.
  */
 export interface PythonKernel {
-    /**
-     * The shared interrupt buffer used to cancel the current execution
-     */
-    interruptBuffer: Uint8Array | null;
-
     /**
      * The version of the Python kernel.
      */

--- a/querybook/webapp/lib/python/usePython.ts
+++ b/querybook/webapp/lib/python/usePython.ts
@@ -21,11 +21,6 @@ interface UsePythonProps {
 interface UsePythonReturn {
     kernelStatus: PythonKernelStatus;
     runPython: (code: string) => Promise<void>;
-    createDataFrame: (
-        dfName: string,
-        statementExecutionId: number,
-        namespaceId?: number
-    ) => Promise<void>;
     stdout: PythonOutputType[];
     stderr: string | null;
     executionStatus: PythonExecutionStatus;
@@ -45,7 +40,7 @@ export default function usePython({
         useState<PythonExecutionStatus>();
     const [executionCount, setExecutionCount] = useState<number>();
 
-    const { kernelStatus, runPython, createDataFrame, getNamespaceInfo } =
+    const { kernelStatus, runPython, getNamespaceInfo } =
         useContext(PythonContext);
 
     useEffect(() => {
@@ -153,7 +148,6 @@ export default function usePython({
     return {
         kernelStatus,
         runPython: runPythonCode,
-        createDataFrame,
         stdout,
         stderr,
         executionStatus,

--- a/querybook/webapp/lib/python/usePython.ts
+++ b/querybook/webapp/lib/python/usePython.ts
@@ -44,15 +44,9 @@ export default function usePython({
     const [executionStatus, setExecutionStatus] =
         useState<PythonExecutionStatus>();
     const [executionCount, setExecutionCount] = useState<number>();
-    const cancelPromiseResolveRef = useRef<() => void>(null);
 
-    const {
-        kernelStatus,
-        runPython,
-        cancelRun,
-        createDataFrame,
-        getNamespaceInfo,
-    } = useContext(PythonContext);
+    const { kernelStatus, runPython, createDataFrame, getNamespaceInfo } =
+        useContext(PythonContext);
 
     useEffect(() => {
         if (cellId) {
@@ -95,14 +89,6 @@ export default function usePython({
         ) => {
             setExecutionStatus(status);
             setExecutionCount(data?.executionCount);
-
-            if (
-                cancelPromiseResolveRef.current &&
-                status === PythonExecutionStatus.CANCEL
-            ) {
-                cancelPromiseResolveRef.current();
-                cancelPromiseResolveRef.current = null;
-            }
         },
         [setExecutionCount, setExecutionStatus]
     );
@@ -163,13 +149,6 @@ export default function usePython({
         },
         [setStdout, setStdout, runPython, docId, stdoutCallback, stderrCallback]
     );
-
-    const cancelRunPython = useCallback((): Promise<void> => {
-        return new Promise((resolve) => {
-            cancelRun();
-            cancelPromiseResolveRef.current = resolve;
-        });
-    }, [cancelRun]);
 
     return {
         kernelStatus,


### PR DESCRIPTION
Disabled the cancel Python run feature in the PR https://github.com/pinterest/querybook/pull/1569, but didn't realize that `SharedArrrayBuffer` will be undefined when cross-origin is not isolated. Here to completely remove the related code.

Also remove the unused function of `createDataFrame` as we switched to use the code way `get_df`  to create dataframe from query result.