### PR TITLE
Make end_line, end_ch of table name suggestion variable

### DIFF
--- a/querybook/server/lib/query_analysis/validation/decorators/base_sqlglot_validation_decorator.py
+++ b/querybook/server/lib/query_analysis/validation/decorators/base_sqlglot_validation_decorator.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import List, Tuple
+from typing import List
 from sqlglot import Tokenizer
 from sqlglot.tokens import Token
 
@@ -11,6 +11,7 @@ from lib.query_analysis.validation.base_query_validator import (
 from lib.query_analysis.validation.decorators.base_validation_decorator import (
     BaseValidationDecorator,
 )
+from lib.query_analysis.validation.utils import get_query_coordinate_by_index
 
 
 class BaseSQLGlotValidationDecorator(BaseValidationDecorator):
@@ -32,16 +33,6 @@ class BaseSQLGlotValidationDecorator(BaseValidationDecorator):
     def _tokenize_query(self, query: str) -> List[Token]:
         return self.tokenizer.tokenize(query)
 
-    def _get_query_coordinate_by_index(self, query: str, index: int) -> Tuple[int, int]:
-        rows = query[: index + 1].splitlines(keepends=False)
-        return len(rows) - 1, len(rows[-1]) - 1
-
-    def _get_query_index_by_coordinate(
-        self, query: str, start_line: int, start_ch: int
-    ) -> int:
-        rows = query.splitlines(keepends=True)[:start_line]
-        return sum([len(row) for row in rows]) + start_ch
-
     def _get_query_validation_result(
         self,
         query: str,
@@ -53,8 +44,8 @@ class BaseSQLGlotValidationDecorator(BaseValidationDecorator):
     ):
         if message is None:
             message = self.message
-        start_line, start_ch = self._get_query_coordinate_by_index(query, start_index)
-        end_line, end_ch = self._get_query_coordinate_by_index(query, end_index)
+        start_line, start_ch = get_query_coordinate_by_index(query, start_index)
+        end_line, end_ch = get_query_coordinate_by_index(query, end_index)
 
         return QueryValidationResult(
             start_line,

--- a/querybook/server/lib/query_analysis/validation/utils.py
+++ b/querybook/server/lib/query_analysis/validation/utils.py
@@ -1,0 +1,11 @@
+from typing import Tuple
+
+
+def get_query_coordinate_by_index(query: str, index: int) -> Tuple[int, int]:
+    rows = query[: index + 1].splitlines(keepends=False)
+    return len(rows) - 1, len(rows[-1]) - 1
+
+
+def get_query_index_by_coordinate(query: str, start_line: int, start_ch: int) -> int:
+    rows = query.splitlines(keepends=True)[:start_line]
+    return sum([len(row) for row in rows]) + start_ch

--- a/querybook/tests/test_lib/test_query_analysis/test_validation/test_validators/test_presto_optimizing_validator.py
+++ b/querybook/tests/test_lib/test_query_analysis/test_validation/test_validators/test_presto_optimizing_validator.py
@@ -378,6 +378,7 @@ class PrestoTableNameSuggesterTestCase(BaseValidatorTestCase):
         )
         mock_get_metastore_id = patch_get_metastore_id.start()
         mock_get_metastore_id.return_value = 1
+        self.query = "SELECT * FROM world_happiness_15"
         self.addCleanup(patch_get_metastore_id.stop)
 
     def test_get_full_table_name_from_error(self):
@@ -417,7 +418,7 @@ class PrestoTableNameSuggesterTestCase(BaseValidatorTestCase):
         mock_table_suggestion.return_value = [
             {"schema": "main", "name": "world_happiness_rank_2015"}
         ], 1
-        self._validator._suggest_table_name_if_needed(validation_result, 0)
+        self._validator._suggest_table_name_if_needed(validation_result, 0, self.query)
         self.assertEquals(
             validation_result.suggestion, "main.world_happiness_rank_2015"
         )
@@ -430,13 +431,15 @@ class PrestoTableNameSuggesterTestCase(BaseValidatorTestCase):
             0,
             0,
             QueryValidationSeverity.WARNING,
-            "line 0:1: Table 'world_happiness_15' does not exist",
+            "line 0:14: Table 'world_happiness_15' does not exist",
         )
         mock_table_suggestion.return_value = [
             {"schema": "main", "name": "world_happiness_rank_2015"},
             {"schema": "main", "name": "world_happiness_rank_2016"},
         ], 2
-        self._validator._suggest_table_name_if_needed(validation_result, 0)
+        self._validator._suggest_table_name_if_needed(
+            validation_result, 0, "SELECT * FROM world_happiness_15"
+        )
         self.assertEquals(
             validation_result.suggestion, "main.world_happiness_rank_2015"
         )
@@ -449,10 +452,10 @@ class PrestoTableNameSuggesterTestCase(BaseValidatorTestCase):
             0,
             0,
             QueryValidationSeverity.WARNING,
-            "line 0:1: Table 'world_happiness_15' does not exist",
+            "line 0:14: Table 'world_happiness_15' does not exist",
         )
         mock_table_suggestion.return_value = [], 0
-        self._validator._suggest_table_name_if_needed(validation_result, 0)
+        self._validator._suggest_table_name_if_needed(validation_result, 0, self.query)
         self.assertEquals(validation_result.suggestion, None)
 
 


### PR DESCRIPTION
Rationale: If fuzzy_table_name used for searching the correct table name is different from the invalid table_name in the query, the method `get_replacement_end_line_ch` can be overridden to supply the correct end_line/end_ch based on the query