### PR TITLE
fix: publish doc title as tab title

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.41.5",
+    "version": "3.41.6",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/webapp/components/DataDoc/DataDoc.tsx
+++ b/querybook/webapp/components/DataDoc/DataDoc.tsx
@@ -109,8 +109,6 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
     public matchDatadocPath() {
         return !!matchPath(location.pathname, {
             path: '/:env/datadoc/:docId/',
-            exact: true,
-            strict: false,
         });
     }
 


### PR DESCRIPTION
It's supposed to use `exact: false` for matching the doc path as it may have the title in the pathname