### PR TITLE
refactor: allow ai assistant plugin to override sql gen and fix

### DIFF
--- a/querybook/server/lib/ai_assistant/assistants/openai_assistant.py
+++ b/querybook/server/lib/ai_assistant/assistants/openai_assistant.py
@@ -17,8 +17,11 @@ OPENAI_MODEL_CONTEXT_WINDOW_SIZE = {
     # Current models
     "gpt-4o": 128000,
     "gpt-4o-mini": 128000,
+    "gpt-4.1": 1_047_576,
+    "gpt-4.1-mini": 1_047_576,
+    "gpt-4.1-nano": 1_047_576,
 }
-DEFAULT_MODEL_NAME = "gpt-4o-mini"
+DEFAULT_MODEL_NAME = "gpt-4.1-mini"
 
 
 class OpenAIAssistant(BaseAIAssistant):
@@ -45,7 +48,11 @@ class OpenAIAssistant(BaseAIAssistant):
 
     def _get_token_count(self, ai_command: str, prompt: str) -> int:
         model_name = self._get_llm_config(ai_command)["model_name"]
-        encoding = tiktoken.encoding_for_model(model_name)
+        if model_name.startswith("gpt-4.1"):
+            encoding = tiktoken.get_encoding("o200k_base")
+        else:
+            encoding = tiktoken.encoding_for_model(model_name)
+
         return len(encoding.encode(prompt))
 
     def _get_error_msg(self, error) -> str:

--- a/querybook/server/lib/ai_assistant/assistants/openai_assistant.py
+++ b/querybook/server/lib/ai_assistant/assistants/openai_assistant.py
@@ -48,6 +48,8 @@ class OpenAIAssistant(BaseAIAssistant):
 
     def _get_token_count(self, ai_command: str, prompt: str) -> int:
         model_name = self._get_llm_config(ai_command)["model_name"]
+        # tiktoken hasn't been upgraded to support gpt-4.1 models
+        # https://github.com/openai/tiktoken/issues/395
         if model_name.startswith("gpt-4.1"):
             encoding = tiktoken.get_encoding("o200k_base")
         else:

--- a/querybook/server/lib/ai_assistant/base_ai_assistant.py
+++ b/querybook/server/lib/ai_assistant/base_ai_assistant.py
@@ -264,11 +264,12 @@ class BaseAIAssistant(ABC):
 
     def _generate_sql_query(
         self,
+        *,
         language: str,
         question: str,
         table_schemas: list[str],
         original_query: str = None,
-        socket=None,
+        socket,
     ):
         """Override this method to implement your own SQL generation logic."""
         prompt = self._get_text_to_sql_prompt(
@@ -343,11 +344,12 @@ class BaseAIAssistant(ABC):
     @with_session
     def _query_auto_fix(
         self,
-        socket,
+        *,
         metastore_id: int,
         language: str,
         query: str,
         error: str,
+        socket,
         session=None,
     ):
         """Override this method to implement your own query auto fix logic."""

--- a/querybook/webapp/components/AIAssistant/AutoFixButton.tsx
+++ b/querybook/webapp/components/AIAssistant/AutoFixButton.tsx
@@ -7,6 +7,8 @@ import { useAISocket } from 'hooks/useAISocket';
 import useNonEmptyState from 'hooks/useNonEmptyState';
 import { trackClick } from 'lib/analytics';
 import { Button } from 'ui/Button/Button';
+import { Loading, LoadingIcon } from 'ui/Loading/Loading';
+import { Markdown } from 'ui/Markdown/Markdown';
 import { Message } from 'ui/Message/Message';
 import { Modal } from 'ui/Modal/Modal';
 import { AccentText } from 'ui/StyledText/StyledText';
@@ -31,6 +33,7 @@ const useSQLFix = () => {
         data: unformattedData,
         explanation,
         fix_suggestion: suggestion,
+        diagnosis,
         fixed_query: newFixedQuery,
     } = data;
 
@@ -41,7 +44,8 @@ const useSQLFix = () => {
     return {
         socket,
         fixed: Object.keys(data).length > 0, // If has data, then it has been fixed
-        explanation: explanation || unformattedData,
+        diagnosis: diagnosis || unformattedData,
+        explanation: explanation,
         suggestion,
         fixedQuery,
     };
@@ -53,7 +57,8 @@ export const AutoFixButton = ({
     onUpdateQuery,
 }: IProps) => {
     const [showModal, setShowModal] = useState<boolean>(false);
-    const { socket, fixed, explanation, suggestion, fixedQuery } = useSQLFix();
+    const { socket, fixed, diagnosis, explanation, suggestion, fixedQuery } =
+        useSQLFix();
 
     const bottomDOM = socket.loading ? (
         <div className="right-align mb16">
@@ -136,6 +141,13 @@ export const AutoFixButton = ({
                         message="Note: This AI-powered auto fix may not be 100% accurate. Please use your own judgement and verify the result."
                         type="warning"
                     />
+                    {socket.loading && (
+                        <div className="flex-row">
+                            <LoadingIcon />
+                            <div>Diagnosing...</div>
+                        </div>
+                    )}
+                    {diagnosis && <Markdown>{diagnosis}</Markdown>}
                     {explanation && (
                         <div>
                             <AccentText size="med" weight="bold">

--- a/requirements/ai/langchain.txt
+++ b/requirements/ai/langchain.txt
@@ -1,3 +1,3 @@
-langchain==0.1.20
-langchain-openai==0.1.6
-opensearch-py==2.3.0
+langchain==0.3.24
+langchain-openai==0.3.14
+opensearch-py==2.8.0


### PR DESCRIPTION
 - add two functions `_generate_sql_query` and `_query_auto_fix` in `base_ai_assistant` for plugin to override easlily
 - upgrade new langchain packages
 - add openai new models