### PR TITLE
chore: Optimize SQL performance for tables with large number of columns

### DIFF
--- a/querybook/server/lib/ai_assistant/tools/table_schema.py
+++ b/querybook/server/lib/ai_assistant/tools/table_schema.py
@@ -1,23 +1,16 @@
 from typing import Callable
 
+
+from sqlalchemy import and_, or_
+from sqlalchemy.orm import joinedload, load_only
 from app.db import with_session
-from lib.vector_store import get_vector_store
 from logic import metastore as m_logic
-from models.metastore import DataTable, DataTableColumn
-
-
-def get_table_documentation(table: DataTable) -> str:
-    """Get table documentation.
-    Try to get it from database first. If not found, get it from the vector store.
-    """
-    if table.information.description:
-        return table.information.description
-
-    vs = get_vector_store()
-    if vs:
-        return vs.get_table_summary(table.id)
-
-    return ""
+from models.metastore import (
+    DataSchema,
+    DataTable,
+    DataTableColumn,
+)
+from models.tag import TagItem
 
 
 def _get_column(column: DataTableColumn) -> dict[str, str]:
@@ -64,7 +57,12 @@ def _get_table_schema(
     table_json = {}
 
     table_json["table_name"] = f"{table.data_schema.name}.{table.name}"
-    table_json["table_description"] = get_table_documentation(table)
+    table_json["table_description"] = table.information.description
+    table_json["latest_partitions"] = table.information.latest_partitions
+    table_json["column_info"] = table.information.column_info
+    table_json["tags"] = [
+        {"type": tag.tag.meta.get("type"), "name": tag.tag_name} for tag in table.tags
+    ]
 
     columns = []
     for column in table.columns:
@@ -106,6 +104,138 @@ def get_table_schemas_by_ids(
 
 
 @with_session
+def get_table_schemas_by_names(
+    metastore_id: int,
+    full_table_names: list[str],
+    should_skip_column: Callable[[DataTableColumn], bool] = None,
+    session=None,
+) -> list[dict]:
+    """Retrieve table schemas for specified tables in a metastore.
+
+    This function fetches table schemas for a list of fully qualified table names
+    (schema.table) from a specific metastore. It performs optimized database queries
+    to retrieve table information, columns, and tags in separate batches.
+
+    Args:
+        metastore_id: The ID of the metastore to query.
+        full_table_names: List of fully qualified table names in the format "schema.table".
+        should_skip_column: Optional function that determines if a column should be excluded
+            from the result. Takes a DataTableColumn as input and returns a boolean.
+        session: Optional database session. If not provided, a new session will be created.
+
+    Returns:
+        A list of dictionaries containing schema information for each requested table,
+        in the same order as the input list.
+
+    Note:
+        This function optimizes database access by loading table metadata, columns,
+        and tags in separate queries to minimize the amount of data transferred.
+    """
+    if not full_table_names:
+        return []
+
+    # Parse table names
+    parsed_tables = []
+    for full_table_name in full_table_names:
+        parts = full_table_name.split(".")
+        if len(parts) == 2:
+            parsed_tables.append((parts[0], parts[1]))
+
+    if not parsed_tables:
+        return []
+
+    # Create filters for each schema+table combination
+    conditions = []
+    for schema_name, table_name in parsed_tables:
+        conditions.append(
+            and_(DataSchema.name == schema_name, DataTable.name == table_name)
+        )
+
+    if not conditions:
+        return []
+
+    # STEP 1: Get just the basic table data with schema and information
+    tables = (
+        session.query(DataTable)
+        .join(DataSchema, DataTable.schema_id == DataSchema.id)
+        .filter(DataSchema.metastore_id == metastore_id)
+        .filter(or_(*conditions))
+        .options(
+            load_only("id", "name", "schema_id"),
+            joinedload(DataTable.data_schema).load_only("id", "name"),
+            joinedload(DataTable.information).load_only(
+                "description", "latest_partitions"
+            ),
+        )
+        .all()
+    )
+
+    # Build a lookup map of table IDs
+    table_ids = [table.id for table in tables]
+
+    if not table_ids:
+        return []
+
+    # STEP 2: Load columns in a separate query
+    column_data = (
+        session.query(DataTableColumn)
+        .filter(DataTableColumn.table_id.in_(table_ids))
+        .options(
+            load_only("id", "name", "type", "description", "table_id"),
+            # Eager load data elements
+            joinedload(DataTableColumn.data_elements).load_only("description", "name"),
+            # Eager load statistics
+            joinedload(DataTableColumn.statistics).load_only("key", "value"),
+        )
+        .all()
+    )
+
+    # Group columns by table_id
+    columns_by_table = {}
+    for col in column_data:
+        if col.table_id not in columns_by_table:
+            columns_by_table[col.table_id] = []
+        columns_by_table[col.table_id].append(col)
+
+    # STEP 3: Load tags in a separate query
+    tags_data = (
+        session.query(TagItem)
+        .filter(TagItem.table_id.in_(table_ids))
+        .options(
+            load_only("id", "tag_name", "table_id"),
+            joinedload(TagItem.tag).load_only("id", "meta"),
+        )
+        .all()
+    )
+
+    # Group tags by table_id
+    tags_by_table = {}
+    for tag in tags_data:
+        if tag.table_id not in tags_by_table:
+            tags_by_table[tag.table_id] = []
+        tags_by_table[tag.table_id].append(tag)
+
+    # Manually associate columns and tags with their tables
+    for table in tables:
+        table.columns = columns_by_table.get(table.id, [])
+        table.tags = tags_by_table.get(table.id, [])
+
+    # Build a map for quick lookup
+    table_map = {f"{table.data_schema.name}.{table.name}": table for table in tables}
+
+    # Create schemas in the same order as the input
+    result = []
+    for full_table_name in full_table_names:
+        table = table_map.get(full_table_name)
+        if table:
+            result.append(_get_table_schema(table, should_skip_column))
+        else:
+            result.append(None)
+
+    return result
+
+
+@with_session
 def get_table_schema_by_name(
     metastore_id: int,
     full_table_name: str,
@@ -113,37 +243,14 @@ def get_table_schema_by_name(
     session=None,
 ) -> dict:
     """Generate table schema prompt by full table name"""
-    full_table_name_parts = full_table_name.split(".")
-    if len(full_table_name_parts) != 2:
-        return None
-
-    table_schema, table_name = full_table_name_parts
-    table = m_logic.get_table_by_name(
-        schema_name=table_schema,
-        name=table_name,
+    table_schemas = get_table_schemas_by_names(
         metastore_id=metastore_id,
+        full_table_names=[full_table_name],
+        should_skip_column=should_skip_column,
         session=session,
     )
-    return _get_table_schema(table, should_skip_column)
 
-
-@with_session
-def get_table_schemas_by_names(
-    metastore_id: int,
-    full_table_names: list[str],
-    should_skip_column: Callable[[DataTableColumn], bool] = None,
-    session=None,
-) -> list[dict]:
-    """Generate table schemas prompt by table names"""
-    return [
-        get_table_schema_by_name(
-            metastore_id=metastore_id,
-            full_table_name=table_name,
-            should_skip_column=should_skip_column,
-            session=session,
-        )
-        for table_name in full_table_names
-    ]
+    return table_schemas[0] if table_schemas else {}
 
 
 def get_slimmed_table_schemas(table_schemas: list[dict]) -> list[dict]:

--- a/querybook/server/logic/tag.py
+++ b/querybook/server/logic/tag.py
@@ -30,6 +30,31 @@ def get_tags_by_column_id(column_id: int, session=None):
 
 
 @with_session
+def get_tags_by_column_ids(column_ids: int, session=None):
+    """Get all tags for multiple columns at once, organized by column_id"""
+    if not column_ids:
+        return {}
+
+    # Query all tags for the given column IDs in a single query
+    tag_results = (
+        session.query(Tag, TagItem.column_id)
+        .join(TagItem)
+        .filter(TagItem.column_id.in_(column_ids))
+        .order_by(Tag.count.desc())
+        .all()
+    )
+
+    # Organize results by column_id
+    tags_by_column = {}
+    for tag, column_id in tag_results:
+        if column_id not in tags_by_column:
+            tags_by_column[column_id] = []
+        tags_by_column[column_id].append(tag)
+
+    return tags_by_column
+
+
+@with_session
 def get_tags_by_keyword(keyword, limit=10, session=None):
     return (
         session.query(Tag)

--- a/querybook/server/models/metastore.py
+++ b/querybook/server/models/metastore.py
@@ -306,6 +306,7 @@ class DataTableColumn(TruncateString("name", "type", "comment"), Base):
         "DataTableColumnStatistics",
         uselist=True,
         viewonly=True,
+        lazy="joined",
     )
 
     def to_dict(self, include_table=False):
@@ -316,7 +317,7 @@ class DataTableColumn(TruncateString("name", "type", "comment"), Base):
             "comment": self.comment,
             "description": self.description,
             "table_id": self.table_id,
-            "stats": self.statistics,
+            "stats": [stat.to_dict() for stat in self.statistics],
         }
 
         if include_table:
@@ -454,3 +455,13 @@ class DataTableColumnStatistics(CRUDMixin, Base):
         ),
         foreign_keys=[column_id],
     )
+
+    def to_dict(self):
+        column_statistics = {
+            "id": self.id,
+            "column_id": self.column_id,
+            "key": self.key,
+            "value": self.value,
+            "uid": self.uid,
+        }
+        return column_statistics


### PR DESCRIPTION
This PR introduces performance optimizations for tables with many columns by reducing database load and query count:

### Key Changes:
- **Batch loading**: Implemented consolidated batch queries for columns, tags, and data element associations instead of individual queries
- **Optimized `get_table_schemas_by_names`**: Completely rewritten to:
  - Fetch tables, columns, and tags in separate efficient queries
  - Use SQLAlchemy's `load_only` and `joinedload` to minimize data transfer
  - Process results in memory rather than making many small queries
- **Optimized `get_detailed_columns_dict_by_table_id`**: Reimplemented to:
  - Retrieve all column data in a single query
  - Batch load tags and data element associations for all columns at once
  - Assemble column data in memory instead of making separate queries per column
- **Model improvements**:
  - Added `lazy="joined"` optimization for column statistics as `stats` will be retrieved by default
  - Added `to_dict()` method for DataTableColumnStatistics to support JSON serialization, which will make `flask.jsonify` more efficient.

### Performance Improvements:
- **Single table with 581 columns**:
  - `/ds/table/<table-id>/`: ~10s → <1s
  - `/ds/table/<table-id>/detailed_column/`: 5-6s → <1s
- **Multiple tables (10 tables including large table)**:
  - Schema retrieval: 9-10s → <2s