### PR TITLE
fix: copy dataframe button & refactor sql generation logic

### DIFF
--- a/querybook/server/lib/ai_assistant/base_ai_assistant.py
+++ b/querybook/server/lib/ai_assistant/base_ai_assistant.py
@@ -228,7 +228,6 @@ class BaseAIAssistant(ABC):
             query_engine_id, session=session
         )
 
-
         self._generate_sql_query(
             query_engine=query_engine,
             tables=tables,

--- a/querybook/server/lib/ai_assistant/tools/table_schema.py
+++ b/querybook/server/lib/ai_assistant/tools/table_schema.py
@@ -57,13 +57,13 @@ def _get_column(column: DataTableColumn) -> ColumnInfo:
         "statistics": None,
     }
 
-    if column.description:
-        column_info["description"] = column.description
-    elif column.data_elements:
+    if column.data_elements:
         # use data element's description when column's description is empty
         # TODO: only handling the REF data element for now. Need to handle ARRAY, MAP and etc in the future.
         column_info["description"] = column.data_elements[0].description
         column_info["data_element"] = column.data_elements[0].name
+    elif column.description:
+        column_info["description"] = column.description
 
     if len(column.statistics):
         column_info["statistics"] = {

--- a/querybook/webapp/components/Search/SearchOverview.tsx
+++ b/querybook/webapp/components/Search/SearchOverview.tsx
@@ -143,6 +143,7 @@ export const SearchOverview: React.FC<ISearchOverviewProps> = ({
         if (!isLoading && searchString.length > 0 && results.length > 0) {
             const elementType = SearchTypeToElementType[searchType];
             trackView(ComponentType.SEARCH_MODAL, elementType, {
+                nlp: useVectorSearch,
                 search: searchString,
                 results: results.map((r) => r.id),
                 page: currentPage,
@@ -281,6 +282,7 @@ export const SearchOverview: React.FC<ISearchOverviewProps> = ({
                 component: ComponentType.SEARCH_MODAL,
                 element: elementType,
                 aux: {
+                    nlp: useVectorSearch,
                     search: searchString,
                     results: results.map((r) => r.id),
                     page: currentPage,

--- a/querybook/webapp/components/StatementExecutionBar/StatementExecutionBar.tsx
+++ b/querybook/webapp/components/StatementExecutionBar/StatementExecutionBar.tsx
@@ -98,7 +98,8 @@ export const StatementExecutionBar = React.memo<IProps>(
             />
         );
 
-        const copyAsDataFrameButton = (
+        const copyAsDataFrameButton = queryStatus ===
+            QueryExecutionStatus.DONE && (
             <TextButton
                 onClick={() => {
                     navigator.clipboard.writeText(


### PR DESCRIPTION
 -  only show dataframe button when query run succeeds
 - update to prefer data element's description over column description when getting table schema for ai assistant
 - make the whole logic of `generate_sql_query` to be overridable, so that custom assistant can get query engine to do query validation.
 - add tracking for the nlp search