### PR TITLE
chore: rename useVectorSearch

### DIFF
--- a/querybook/webapp/components/Search/SearchOverview.tsx
+++ b/querybook/webapp/components/Search/SearchOverview.tsx
@@ -101,7 +101,7 @@ export const SearchOverview: React.FC<ISearchOverviewProps> = ({
         searchOrder,
         searchType,
         searchAuthorChoices,
-        useVectorSearch,
+        isNLPSearch,
 
         searchRequest,
         queryMetastores,
@@ -143,7 +143,7 @@ export const SearchOverview: React.FC<ISearchOverviewProps> = ({
         if (!isLoading && searchString.length > 0 && results.length > 0) {
             const elementType = SearchTypeToElementType[searchType];
             trackView(ComponentType.SEARCH_MODAL, elementType, {
-                nlp: useVectorSearch,
+                nlp: isNLPSearch,
                 search: searchString,
                 results: results.map((r) => r.id),
                 page: currentPage,
@@ -170,8 +170,8 @@ export const SearchOverview: React.FC<ISearchOverviewProps> = ({
     const updateSearchType = React.useCallback((type) => {
         dispatch(searchActions.updateSearchType(type));
     }, []);
-    const updateUseVectorSearch = React.useCallback((useVectorSearch) => {
-        dispatch(searchActions.updateUseVectorSearch(useVectorSearch));
+    const updateUseVectorSearch = React.useCallback((isNLPSearch) => {
+        dispatch(searchActions.updateUseVectorSearch(isNLPSearch));
     }, []);
     const moveToPage = React.useCallback((page) => {
         dispatch(searchActions.moveToPage(page));
@@ -282,7 +282,7 @@ export const SearchOverview: React.FC<ISearchOverviewProps> = ({
                 component: ComponentType.SEARCH_MODAL,
                 element: elementType,
                 aux: {
-                    nlp: useVectorSearch,
+                    nlp: isNLPSearch,
                     search: searchString,
                     results: results.map((r) => r.id),
                     page: currentPage,
@@ -325,7 +325,7 @@ export const SearchOverview: React.FC<ISearchOverviewProps> = ({
                             Natural Language Search
                         </AccentText>
                         <ToggleSwitch
-                            checked={useVectorSearch}
+                            checked={isNLPSearch}
                             onChange={(val) => updateUseVectorSearch(val)}
                         />
                     </div>

--- a/querybook/webapp/redux/search/action.ts
+++ b/querybook/webapp/redux/search/action.ts
@@ -113,7 +113,7 @@ export function performSearch(): ThunkResult<Promise<ISearchPreview[]>> {
                 searchState.searchRequest.cancel();
             }
 
-            const { currentPage, searchType, useVectorSearch } = searchState;
+            const { currentPage, searchType, isNLPSearch } = searchState;
 
             const searchParams = mapStateToSearch(searchState);
 
@@ -125,7 +125,7 @@ export function performSearch(): ThunkResult<Promise<ISearchPreview[]>> {
             }>;
             switch (searchType) {
                 case SearchType.Query:
-                    if (useVectorSearch) {
+                    if (isNLPSearch) {
                         searchRequest = SearchQueryResource.vectorSearch({
                             environment_id:
                                 state.environment.currentEnvironmentId,
@@ -150,7 +150,7 @@ export function performSearch(): ThunkResult<Promise<ISearchPreview[]>> {
                     const metastoreId =
                         state.dataTableSearch.metastoreId ||
                         queryMetastoresSelector(state)[0].id;
-                    if (useVectorSearch) {
+                    if (isNLPSearch) {
                         searchRequest = SearchTableResource.vectorSearch({
                             metastore_id: metastoreId,
                             keywords: searchString,
@@ -300,15 +300,13 @@ export function updateSearchType(searchType: SearchType): ThunkResult<void> {
     };
 }
 
-export function updateUseVectorSearch(
-    useVectorSearch: boolean
-): ThunkResult<void> {
+export function updateUseVectorSearch(isNLPSearch: boolean): ThunkResult<void> {
     return (dispatch, getState) => {
         dispatch(resetSearchResult());
         dispatch({
             type: '@@search/USE_VECTOR_SEARCH_UPDATE',
             payload: {
-                useVectorSearch,
+                isNLPSearch,
             },
         });
         mapStateToQueryParam(getState().search);

--- a/querybook/webapp/redux/search/reducer.ts
+++ b/querybook/webapp/redux/search/reducer.ts
@@ -23,7 +23,7 @@ const initialSearchParamState = {
     searchOrder: SearchOrder.Relevance,
     searchString: '',
     searchType: SearchType.Query,
-    useVectorSearch: false,
+    isNLPSearch: false,
 };
 
 const initialState: ISearchState = {
@@ -135,7 +135,7 @@ export default function search(
                 return;
             }
             case '@@search/USE_VECTOR_SEARCH_UPDATE': {
-                draft.useVectorSearch = action.payload.useVectorSearch;
+                draft.isNLPSearch = action.payload.isNLPSearch;
                 return;
             }
             case '@@search/SEARCH_GO_TO_PAGE': {

--- a/querybook/webapp/redux/search/types.ts
+++ b/querybook/webapp/redux/search/types.ts
@@ -93,7 +93,7 @@ export interface ISearchTypeUpdateAction extends Action {
 export interface IUseVectorSearchUpdateAction extends Action {
     type: '@@search/USE_VECTOR_SEARCH_UPDATE';
     payload: {
-        useVectorSearch: boolean;
+        isNLPSearch: boolean;
     };
 }
 
@@ -159,7 +159,7 @@ export interface ISearchState extends ISearchPaginationState {
     searchOrder: SearchOrder;
     searchType: SearchType;
     searchString: string;
-    useVectorSearch: boolean;
+    isNLPSearch: boolean;
 
     // visuals
     // displayOption: DisplayOption;


### PR DESCRIPTION
renaming `useVectorSearch` as it looks like a react hook name.