### PR TITLE
fix: wrong data cells got deleted

### DIFF
--- a/querybook/webapp/components/DataDoc/DataDoc.tsx
+++ b/querybook/webapp/components/DataDoc/DataDoc.tsx
@@ -664,7 +664,7 @@ class DataDocComponent extends React.PureComponent<IProps, IState> {
         } else {
             return (
                 <DataDocCell
-                    key={cell.id}
+                    key={`${cell.id}-${index}`}
                     docId={dataDoc.id}
                     numberOfCells={dataDoc.dataDocCells.length}
                     templatedVariables={dataDoc.meta.variables}

--- a/querybook/webapp/components/DataDocCell/DataDocCell.tsx
+++ b/querybook/webapp/components/DataDocCell/DataDocCell.tsx
@@ -281,7 +281,7 @@ export const DataDocCell: React.FunctionComponent<IDataDocCellProps> =
                 <DataDocCellWrapper
                     cellKey={String(cell.id)}
                     placeholderHeight={getEstimatedCellHeight(cell)}
-                    key={cell.id}
+                    key={`${cell.id}-${index}`}
                 >
                     {innerCellContentDOM}
                 </DataDocCellWrapper>


### PR DESCRIPTION
**Problem**
When deleting multiple cells in sequence, the wrong cells were getting deleted. E.g. after deleting cells 30 and 31, trying to delete cell 32 would actually delete cell 34 instead.

**Cause**
React was reusing components with stale index props due to using only cell.id as the component key. When cells were deleted, remaining components kept their old position indices instead of updating to reflect their new positions in the array.

**Fix**
Updated React component keys to include both cell ID and position (key={cell.id}-${index}). This forces React to create fresh components with correct indices when cell positions change.