### PR TITLE
fix: auto fix runs the old query

### DIFF
--- a/querybook/webapp/components/AIAssistant/AutoFixButton.tsx
+++ b/querybook/webapp/components/AIAssistant/AutoFixButton.tsx
@@ -78,7 +78,7 @@ export const AutoFixButton = ({
                 }}
             />
             <Button
-                title={fixedQuery ? "Apply" : "Helpful"}
+                title={fixedQuery ? 'Apply' : 'Helpful'}
                 color="confirm"
                 onClick={() => {
                     if (fixedQuery) {

--- a/querybook/webapp/components/AIAssistant/AutoFixButton.tsx
+++ b/querybook/webapp/components/AIAssistant/AutoFixButton.tsx
@@ -70,27 +70,28 @@ export const AutoFixButton = ({
             />
         </div>
     ) : (
-        fixedQuery && (
-            <div className="right-align mb16">
-                <Button
-                    title="Reject"
-                    onClick={() => {
-                        setShowModal(false);
-                    }}
-                />
-                <Button
-                    title="Apply"
-                    color="confirm"
-                    onClick={() => {
+        <div className="right-align mb16">
+            <Button
+                title="Unhelpful"
+                onClick={() => {
+                    setShowModal(false);
+                }}
+            />
+            <Button
+                title={fixedQuery ? "Apply" : "Helpful"}
+                color="confirm"
+                onClick={() => {
+                    if (fixedQuery) {
                         onUpdateQuery?.(fixedQuery, false);
-                        trackClick({
-                            component: ComponentType.AI_ASSISTANT,
-                            element:
-                                ElementType.QUERY_ERROR_AUTO_FIX_APPLY_BUTTON,
-                        });
-                        setShowModal(false);
-                    }}
-                />
+                    }
+                    trackClick({
+                        component: ComponentType.AI_ASSISTANT,
+                        element: ElementType.QUERY_ERROR_AUTO_FIX_APPLY_BUTTON,
+                    });
+                    setShowModal(false);
+                }}
+            />
+            {fixedQuery && (
                 <Button
                     title="Apply and Run"
                     color="accent"
@@ -104,8 +105,8 @@ export const AutoFixButton = ({
                         setShowModal(false);
                     }}
                 />
-            </div>
-        )
+            )}
+        </div>
     );
     return (
         <>

--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -170,10 +170,11 @@ export const QueryEditor: React.FC<
                     );
                 }
 
-                return value;
+                // Return null when no selection so that callers can fallback to their own query text
+                return null;
             }
-            return value;
-        }, [editorRef.current?.view, value]);
+            return null;
+        }, [editorRef.current?.view]);
 
         useImperativeHandle(
             ref,


### PR DESCRIPTION
Fixes an issue where "Apply and Run" sometimes runs the old query due to getSelection() returning the full (potentially stale) query when nothing is selected. Now, getSelection() returns null if there’s no selection.

Also adds "Helpful" and "Unhelpful" buttons to the auto-fix modal when no fixed query is shown.