### PR TITLE
fix: comment permission

### DIFF
--- a/querybook/server/datasources/comment.py
+++ b/querybook/server/datasources/comment.py
@@ -5,6 +5,8 @@ from app.auth.permission import verify_data_table_permission
 from logic.comment_permission import (
     assert_can_edit_and_delete,
     assert_can_read_datadoc,
+    assert_can_read_comment,
+    assert_can_delete_reaction,
 )
 
 
@@ -13,6 +15,7 @@ from logic.comment_permission import (
     methods=["GET"],
 )
 def get_comments_by_cell_id(data_cell_id: int):
+    assert_can_read_datadoc(data_cell_id=data_cell_id)
     return logic.get_comments_by_data_cell_id(data_cell_id=data_cell_id)
 
 
@@ -53,6 +56,7 @@ def add_comment_to_table(data_table_id: int, text):
     methods=["GET"],
 )
 def get_thread_comments(parent_comment_id: int):
+    assert_can_read_comment(comment_id=parent_comment_id)
     return logic.get_thread_comments(parent_comment_id=parent_comment_id)
 
 
@@ -61,6 +65,7 @@ def get_thread_comments(parent_comment_id: int):
     methods=["POST"],
 )
 def add_thread_comment(parent_comment_id: int, text):
+    assert_can_read_comment(comment_id=parent_comment_id)
     return logic.add_thread_comment(
         parent_comment_id=parent_comment_id, uid=current_user.id, text=text
     )
@@ -88,6 +93,7 @@ def soft_delete_comment(comment_id: int):
     methods=["POST"],
 )
 def add_reaction(comment_id: int, reaction: str):
+    assert_can_read_comment(comment_id=comment_id)
     return logic.add_reaction(
         comment_id=comment_id,
         reaction=reaction,
@@ -100,4 +106,5 @@ def add_reaction(comment_id: int, reaction: str):
     methods=["DELETE"],
 )
 def remove_reaction(reaction_id: int):
+    assert_can_delete_reaction(reaction_id=reaction_id)
     return logic.remove_reaction(reaction_id=reaction_id)

--- a/querybook/server/logic/comment_permission.py
+++ b/querybook/server/logic/comment_permission.py
@@ -9,10 +9,7 @@ from const.datasources import (
 from logic import comment as logic
 from logic.datadoc_permission import assert_can_read
 from models.datadoc import DataDocDataCell
-
-
-class CommentDoesNotExist(Exception):
-    pass
+from models.comment import DataCellComment, CommentReaction
 
 
 @with_session
@@ -26,15 +23,45 @@ def assert_can_read_datadoc(data_cell_id, session=None):
 
 
 @with_session
+def assert_can_read_comment(comment_id, session=None):
+    """Check if the current user can read a comment by checking if it belongs to a datadoc."""
+    comment = logic.get_comment_by_id(comment_id=comment_id, session=session)
+    api_assert(comment is not None, "COMMENT_DNE", RESOURCE_NOT_FOUND_STATUS_CODE)
+
+    # Check if this comment belongs to a datadoc
+    data_cell_comment = (
+        session.query(DataCellComment)
+        .filter(DataCellComment.comment_id == comment_id)
+        .first()
+    )
+
+    if data_cell_comment:
+        # This comment belongs to a datadoc - reuse existing permission check
+        assert_can_read_datadoc(data_cell_comment.data_cell_id, session=session)
+
+    # If it doesn't belong to a datadoc, it's a table comment - no permission check needed
+
+
+@with_session
+def assert_can_delete_reaction(reaction_id, session=None):
+    """Check if the current user can delete a reaction (must be the reaction owner)."""
+    reaction = session.query(CommentReaction).get(reaction_id)
+    api_assert(reaction is not None, "REACTION_DNE", RESOURCE_NOT_FOUND_STATUS_CODE)
+
+    # Check if user is the owner of this reaction
+    api_assert(
+        reaction.created_by == current_user.id,
+        "NOT_REACTION_OWNER",
+        UNAUTHORIZED_STATUS_CODE,
+    )
+
+
+@with_session
 def assert_can_edit_and_delete(comment_id, session=None):
-    try:
-        comment = logic.get_comment_by_id(comment_id=comment_id, session=session)
-        if comment is None:
-            raise CommentDoesNotExist
-        api_assert(
-            comment.created_by == current_user.id,
-            "NOT_COMMENT_AUTHOR",
-            UNAUTHORIZED_STATUS_CODE,
-        )
-    except CommentDoesNotExist:
-        api_assert(False, "COMMENT_DNE", RESOURCE_NOT_FOUND_STATUS_CODE)
+    comment = logic.get_comment_by_id(comment_id=comment_id, session=session)
+    api_assert(comment is not None, "COMMENT_DNE", RESOURCE_NOT_FOUND_STATUS_CODE)
+    api_assert(
+        comment.created_by == current_user.id,
+        "NOT_COMMENT_AUTHOR",
+        UNAUTHORIZED_STATUS_CODE,
+    )


### PR DESCRIPTION
**Issue**
Unauthorized users could access comments on private documents via direct API calls.

**Fix**
Added proper authorization checks to comment endpoints:
 - Comments on datadocs require datadoc read permission
 - Reaction deletion requires ownership
 - Table comments remain unrestricted
