### PR TITLE
feat: add cache control for static assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "querybook",
-    "version": "3.42.0",
+    "version": "3.42.1",
     "description": "A Big Data Webapp",
     "private": true,
     "scripts": {

--- a/querybook/config/querybook_default_config.yaml
+++ b/querybook/config/querybook_default_config.yaml
@@ -113,3 +113,10 @@ GITHUB_CLIENT_SECRET: ~
 GITHUB_REPO_NAME: ~
 GITHUB_BRANCH: 'main'
 GITHUB_CRYPTO_SECRET: ''
+
+# --------------- Cache Control ---------------
+# Cache control settings for HTTP responses on static assets
+# Maximum age in seconds for static assets (CSS, JS, images, fonts)
+CACHE_CONTROL_MAX_AGE: 604800  # 7 days
+# Stale-while-revalidate duration in seconds for static assets
+CACHE_CONTROL_STALE_WHILE_REVALIDATE: 86400  # 1 day

--- a/querybook/server/app/flask_app.py
+++ b/querybook/server/app/flask_app.py
@@ -173,8 +173,12 @@ def make_blue_print(app, limiter):
     def add_static_cache(response):
         if response.status_code == 200:
             max_age = QuerybookSettings.CACHE_CONTROL_MAX_AGE
-            stale_while_revalidate = QuerybookSettings.CACHE_CONTROL_STALE_WHILE_REVALIDATE
-            response.headers["Cache-Control"] = f"public, max-age={max_age}, stale-while-revalidate={stale_while_revalidate}"
+            stale_while_revalidate = (
+                QuerybookSettings.CACHE_CONTROL_STALE_WHILE_REVALIDATE
+            )
+            response.headers["Cache-Control"] = (
+                f"public, max-age={max_age}, stale-while-revalidate={stale_while_revalidate}"
+            )
         return response
 
     app.register_blueprint(blueprint)

--- a/querybook/server/app/flask_app.py
+++ b/querybook/server/app/flask_app.py
@@ -172,8 +172,9 @@ def make_blue_print(app, limiter):
     @blueprint.after_request
     def add_static_cache(response):
         if response.status_code == 200:
-            # Use browser's default heuristic for cache control and stale-while-revalidate for 1 day
-            response.headers["Cache-Control"] = "public, stale-while-revalidate=86400"
+            max_age = QuerybookSettings.CACHE_CONTROL_MAX_AGE
+            stale_while_revalidate = QuerybookSettings.CACHE_CONTROL_STALE_WHILE_REVALIDATE
+            response.headers["Cache-Control"] = f"public, max-age={max_age}, stale-while-revalidate={stale_while_revalidate}"
         return response
 
     app.register_blueprint(blueprint)

--- a/querybook/server/app/flask_app.py
+++ b/querybook/server/app/flask_app.py
@@ -167,6 +167,15 @@ def make_blue_print(app, limiter):
         static_folder=WEBAPP_DIR_PATH,
         static_url_path=BUILD_PATH,
     )
+
+    # Add cache control to the blueprint
+    @blueprint.after_request
+    def add_static_cache(response):
+        if response.status_code == 200:
+            # Use browser's default heuristic for cache control and stale-while-revalidate for 1 day
+            response.headers["Cache-Control"] = "public, stale-while-revalidate=86400"
+        return response
+
     app.register_blueprint(blueprint)
     limiter.exempt(blueprint)
     return blueprint

--- a/querybook/server/env.py
+++ b/querybook/server/env.py
@@ -165,3 +165,7 @@ class QuerybookSettings(object):
     GITHUB_REPO_NAME = get_env_config("GITHUB_REPO_NAME")
     GITHUB_BRANCH = get_env_config("GITHUB_BRANCH")
     GITHUB_CRYPTO_SECRET = get_env_config("GITHUB_CRYPTO_SECRET")
+
+    # Cache Control
+    CACHE_CONTROL_MAX_AGE = int(get_env_config("CACHE_CONTROL_MAX_AGE") or "604800")  # 7 days
+    CACHE_CONTROL_STALE_WHILE_REVALIDATE = int(get_env_config("CACHE_CONTROL_STALE_WHILE_REVALIDATE") or "86400")  # 1 day

--- a/querybook/server/env.py
+++ b/querybook/server/env.py
@@ -167,5 +167,9 @@ class QuerybookSettings(object):
     GITHUB_CRYPTO_SECRET = get_env_config("GITHUB_CRYPTO_SECRET")
 
     # Cache Control
-    CACHE_CONTROL_MAX_AGE = int(get_env_config("CACHE_CONTROL_MAX_AGE") or "604800")  # 7 days
-    CACHE_CONTROL_STALE_WHILE_REVALIDATE = int(get_env_config("CACHE_CONTROL_STALE_WHILE_REVALIDATE") or "86400")  # 1 day
+    CACHE_CONTROL_MAX_AGE = int(
+        get_env_config("CACHE_CONTROL_MAX_AGE") or "604800"
+    )  # 7 days
+    CACHE_CONTROL_STALE_WHILE_REVALIDATE = int(
+        get_env_config("CACHE_CONTROL_STALE_WHILE_REVALIDATE") or "86400"
+    )  # 1 day


### PR DESCRIPTION
Adds HTTP cache control for static assets (CSS, JS, images, fonts) to improve page load performance.

- Sets Cache-Control: public, max-age=604800, stale-while-revalidate=86400 on static files
- 7-days max-age and 1-day stale-while-revalidate for fast loading