### PR TITLE
fix: add zope.interface to requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -46,3 +46,5 @@ numpy>=1.22.2,<2.0.0 # not directly required, pinned by Snyk to avoid a vulnerab
 
 # Query engine - PostgreSQL
 psycopg2==2.9.5
+zope.interface==6.0
+zope.event==5.0


### PR DESCRIPTION
This pull request fixes issue #1605 

The application was failing to start after upgrading to Python 10, with the error `pkg_resources.DistributionNotFound: The 'zope.event' distribution was not found and is required by the application`.

This was caused by a missing dependency, `zope.interface`, which is a dependency of `zope.event`. This pull request adds `zope.interface` to `requirements/base.txt` to ensure it is installed, which resolves the startup error.