### PR TITLE
fix: pin Docker base image to python:3.10-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.10-bookworm
 
 ARG PRODUCTION=true
 ARG EXTRA_PIP_INSTALLS=""


### PR DESCRIPTION
**Issue**
Docker builds were failing with "npm: not found" error due to recent changes in the Python base image packaging.

**Fix**
Fix by pinning to python:3.10-bookworm to ensure consistent Node.js/npm availability.