### PR TITLE
fix: docker image build issue with requirements/extra.txt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ kombu==5.3.1 # not a direct dependency (from celery), pinned by due to bug: http
 pyyaml==6.0
 sqlalchemy==1.4.39
 pymysql==1.0.2
-requests==2.28.1
+requests>=2.32.0,<3.0.0
 elasticsearch==7.13.4
 
 # Query meta
@@ -39,7 +39,7 @@ beautifulsoup4==4.8.2
 markdown2
 
 # Utils
-pandas==1.3.5
+pandas==1.5.3
 typing-extensions==4.9.0
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 numpy>=1.22.2,<2.0.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements/engine/redshift.txt
+++ b/requirements/engine/redshift.txt
@@ -1,2 +1,2 @@
 sqlalchemy-redshift==0.8.9
-redshift_connector==2.0.907
+redshift_connector==2.1.3

--- a/requirements/engine/snowflake.txt
+++ b/requirements/engine/snowflake.txt
@@ -1,4 +1,4 @@
 # snake-connector-python version needs to specified since it is a transitive dependency of snowflake-sqlalchemy
 # https://github.com/pinterest/querybook/pull/669
-snowflake-connector-python==2.6.1
-snowflake-sqlalchemy==1.2.4
+snowflake-connector-python==2.7.2
+snowflake-sqlalchemy==1.4.6


### PR DESCRIPTION
Fix Python 3.10 compatibility and resolve dependency conflicts

- Update requests to >=2.32.0 to resolve version conflicts between opensearch-py and redshift-connector
- Upgrade pandas to 1.5.3 and snowflake package for Python 3.10 compatibility 
- Update redshift-connector to 2.1.3 to support higher requests versions
