### PR TITLE
feat: Auto-inject DataDoc variables into Python runtime context

### DIFF
--- a/querybook/webapp/components/DataDoc/DataDoc.tsx
+++ b/querybook/webapp/components/DataDoc/DataDoc.tsx
@@ -40,6 +40,7 @@ import {
     scrollToCell,
 } from 'lib/data-doc/data-doc-utils';
 import { replaceDataDoc, searchDataDocCells } from 'lib/data-doc/search';
+import { PythonContext } from 'lib/python/python-provider';
 import { sendConfirm, setBrowserTitle } from 'lib/querybookUI';
 import history from 'lib/router-history';
 import { copy, sanitizeUrlTitle } from 'lib/utils';
@@ -998,7 +999,68 @@ function mapDispatchToProps(dispatch: Dispatch) {
     };
 }
 
+// Function component that adds variable injection functionality
+const DataDocWithVariableInjection: React.FC<IProps> = (props) => {
+    const { injectVariables } = React.useContext(PythonContext);
+
+    // Helper function to convert variables to Python format
+    const convertVariablesToPythonFormat = React.useCallback(
+        (variables: IDataDocMeta['variables']): Record<string, any> => {
+            const pythonVariables: Record<string, any> = {};
+
+            if (variables) {
+                for (const variable of variables) {
+                    if (variable.name && variable.value !== undefined) {
+                        pythonVariables[variable.name] = variable.value;
+                    }
+                }
+            }
+
+            return pythonVariables;
+        },
+        []
+    );
+
+    // Function to inject DataDoc variables into Python runtime
+    const injectDataDocVariables = React.useCallback(async () => {
+        if (
+            props.dataDoc &&
+            props.dataDoc.meta &&
+            props.dataDoc.meta.variables
+        ) {
+            const pythonVariables = convertVariablesToPythonFormat(
+                props.dataDoc.meta.variables
+            );
+
+            if (Object.keys(pythonVariables).length > 0) {
+                try {
+                    await injectVariables(props.docId, pythonVariables);
+                } catch (error) {
+                    console.warn(
+                        'Failed to inject datadoc variables into Python runtime:',
+                        error
+                    );
+                }
+            }
+        }
+    }, [
+        props.dataDoc?.meta?.variables,
+        props.docId,
+        injectVariables,
+        convertVariablesToPythonFormat,
+    ]);
+
+    // Effect to inject variables when dataDoc or its variables change
+    React.useEffect(() => {
+        injectDataDocVariables();
+    }, [injectDataDocVariables]);
+
+    return <DataDocComponent {...props} />;
+};
+
+// Export the connected component - using minimal type assertion for React-Redux compatibility
 export const DataDoc = connect(
     mapStateToProps,
     mapDispatchToProps
-)(DataDocComponent);
+    // @ts-ignore: React-Redux connect has complex generic inference that doesn't work well with wrapped function components
+)(DataDocWithVariableInjection);

--- a/querybook/webapp/lib/python/python-provider.tsx
+++ b/querybook/webapp/lib/python/python-provider.tsx
@@ -33,6 +33,7 @@ export interface PythonContextType {
         stderrCallback?: (text: string) => void
     ) => Promise<void>;
     getNamespaceInfo: (namespaceId: number) => Promise<PythonNamespaceInfo>;
+    injectVariables: (namespaceId: number, variables: Record<string, any>) => Promise<void>;
 }
 
 const PythonContext = createContext<PythonContextType>(null);
@@ -206,12 +207,27 @@ function PythonProvider({ children }: PythonProviderProps) {
         [initKernel]
     );
 
+    const injectVariables = useCallback(
+        async (namespaceId: number, variables: Record<string, any>): Promise<void> => {
+            if (!kernelRef.current) {
+                await initKernel();
+                if (!kernelRef.current) {
+                    return;
+                }
+            }
+
+            await kernelRef.current.injectVariables(namespaceId, variables);
+        },
+        [initKernel]
+    );
+
     return (
         <PythonContext.Provider
             value={{
                 kernelStatus: status,
                 runPython,
                 getNamespaceInfo,
+                injectVariables,
             }}
         >
             {children}

--- a/querybook/webapp/lib/python/python-worker.ts
+++ b/querybook/webapp/lib/python/python-worker.ts
@@ -110,6 +110,23 @@ class PyodideKernel implements PythonKernel {
     }
 
     /**
+     * Inject variables into a Python namespace
+     */
+    public injectVariables(
+        namespaceId: number,
+        variables: Record<string, any>
+    ) {
+        this._ensurePyodide();
+
+        const namespace = this._getNamespace(namespaceId);
+
+        // Inject each variable into the namespace
+        for (const [name, value] of Object.entries(variables)) {
+            namespace.set(name, value);
+        }
+    }
+
+    /**
      * Run Python code in the specified namespace
      */
     private async _runPython(

--- a/querybook/webapp/lib/python/types.ts
+++ b/querybook/webapp/lib/python/types.ts
@@ -119,4 +119,11 @@ export interface PythonKernel {
      * @param env - The environment name to set for the kernel.
      */
     setEnvironment(env: string): void;
+
+    /**
+     * Injects variables into the specified namespace.
+     * @param namespaceId - The ID of the namespace to inject variables into.
+     * @param variables - A record of variable names and values to inject.
+     */
+    injectVariables(namespaceId: number, variables: Record<string, any>): void;
 }

--- a/querybook/webapp/lib/python/usePython.ts
+++ b/querybook/webapp/lib/python/usePython.ts
@@ -26,6 +26,7 @@ interface UsePythonReturn {
     executionStatus: PythonExecutionStatus;
     executionCount: number;
     getNamespaceInfo: (namespaceId: number) => Promise<PythonNamespaceInfo>;
+    injectVariables: (variables: Record<string, any>) => void;
 }
 
 export default function usePython({
@@ -40,7 +41,7 @@ export default function usePython({
         useState<PythonExecutionStatus>();
     const [executionCount, setExecutionCount] = useState<number>();
 
-    const { kernelStatus, runPython, getNamespaceInfo } =
+    const { kernelStatus, runPython, getNamespaceInfo, injectVariables } =
         useContext(PythonContext);
 
     useEffect(() => {
@@ -145,6 +146,15 @@ export default function usePython({
         [setStdout, setStdout, runPython, docId, stdoutCallback, stderrCallback]
     );
 
+    const injectVariablesForDoc = useCallback(
+        async (variables: Record<string, any>) => {
+            if (docId !== undefined) {
+                await injectVariables(docId, variables);
+            }
+        },
+        [docId, injectVariables]
+    );
+
     return {
         kernelStatus,
         runPython: runPythonCode,
@@ -153,5 +163,6 @@ export default function usePython({
         executionStatus,
         executionCount,
         getNamespaceInfo,
+        injectVariables: injectVariablesForDoc,
     };
 }


### PR DESCRIPTION
Automatically injects DataDoc variables into Python runtime when document loads or variables change, allowing Python cells to reference them directly.

- Added `injectVariables()` method to Python kernel and context
- Enhanced DataDoc component to monitor variable changes with `useEffect`
- Auto-converts DataDoc variables to Python-compatible format