### PR TITLE
Fix socketio error on datacell update

### DIFF
--- a/querybook/server/logic/datadoc_collab.py
+++ b/querybook/server/logic/datadoc_collab.py
@@ -11,6 +11,7 @@ from logic import datadoc as logic
 from logic import user as user_logic
 from logic.datadoc_permission import assert_can_read, assert_can_write
 from flask_login import current_user
+from lib.utils.serialize import serialize_value
 
 
 @with_session
@@ -95,7 +96,7 @@ def insert_data_cell(
     logic.insert_data_doc_cell(
         data_doc_id=doc_id, cell_id=data_cell.id, index=index, session=session
     )
-    data_cell_dict = data_cell.to_dict()
+    data_cell_dict = serialize_value(data_cell.to_dict())
     socketio.emit(
         "data_cell_inserted",
         (
@@ -235,7 +236,7 @@ def update_data_cell(cell_id, fields, sid="", session=None):
         session=session,
         **fields,
     )
-    data_cell_dict = data_cell.to_dict()
+    data_cell_dict = serialize_value(data_cell.to_dict())
     socketio.emit(
         "data_cell_updated",
         (sid, data_cell_dict),

--- a/querybook/server/models/datadoc.py
+++ b/querybook/server/models/datadoc.py
@@ -18,7 +18,6 @@ from lib.data_doc.meta import (
     validate_datadoc_meta,
 )
 from lib.data_doc.doc_types import DataDocMeta
-from lib.utils.serialize import with_formatted_date
 
 Base = db.Base
 
@@ -124,7 +123,6 @@ class DataCell(Base):
         order_by="QueryExecution.id.desc()",
     )
 
-    @with_formatted_date
     def to_dict(self, with_query_executions=False):
         item = {
             "id": self.id,


### PR DESCRIPTION
Fix socketio error "Object of type datetime is not JSON serializable" when datacell is updated by updating datetime fields in datacell dict to strings before emitting event