### PR TITLE
Add id to data doc cell wrapper

### DIFF
--- a/querybook/webapp/components/AIAssistant/AIAgentButton.tsx
+++ b/querybook/webapp/components/AIAssistant/AIAgentButton.tsx
@@ -5,12 +5,12 @@ interface AIAgentButtonProps {
     renderer: (cellId: number) => React.ReactNode;
 }
 
-const AIAgentButton = ({ cellId, renderer }: AIAgentButtonProps) => {
+const AIAgentButton: React.FC<AIAgentButtonProps> = ({ cellId, renderer }) => {
     if (!renderer) {
         return null;
     }
 
-    return renderer(cellId);
+    return <>{renderer(cellId)}</>;
 };
 
 export default AIAgentButton;


### PR DESCRIPTION
Add id to data doc cell wrapper to provide a way to reference the data doc cell in other features.

Minor change:
- Also remove the additional <></> wrapper around the AIAgentButton