### PR TITLE
Chore upgrade kombu, celery, and redis and set max tasks to 100

### DIFF
--- a/querybook/scripts/runservice
+++ b/querybook/scripts/runservice
@@ -30,7 +30,7 @@ case "$SERVICE_NAME" in
     COMMAND="uwsgi --ini uwsgi.ini"
     ;;
 "prod_worker")
-    COMMAND="celery -A tasks.all_tasks worker -E --without-heartbeat --without-gossip --without-mingle"
+    COMMAND="celery -A tasks.all_tasks worker -E --without-heartbeat --without-gossip --without-mingle --max-tasks-per-child=100"
     ;;
 "prod_scheduler")
     COMMAND="celery -A tasks.all_tasks beat -S scheduler.DatabaseScheduler"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ Flask-Compress==1.10.1
 Flask-Login==0.6.2
 Flask-Limiter==2.2.0
 python-memcached==1.59
-redis==4.3.6
+redis==5.3.1
 
 gevent==21.12.0
 greenlet==1.1.2
@@ -21,8 +21,8 @@ flask-socketio==5.3.3
 Jinja2==3.1.3  # From Flask
 
 # Celery
-celery==5.2.7
-kombu==5.3.1 # not a direct dependency (from celery), pinned by due to bug: https://github.com/celery/kombu/issues/1785
+celery==5.6.0
+kombu==5.6.1 # not a direct dependency (from celery), pinned by due to bug: https://github.com/celery/kombu/issues/1785
 
 
 # Ops


### PR DESCRIPTION
Hi,
a bit of context about these changes:
- For version upgrades, it was mainly to solve a recurring issue that was happening, which was celery workers getting stuck because of redis restarts. These version upgrades fixed most of our issues on the production cluster.
- For the max-tasks-per-child, we noticed that the CPU on workers was always at the maximum, and thanks to this [medium page](https://medium.com/squad-engineering/two-years-with-celery-in-production-bug-fix-edition-22238669601d), we found out that setting the number to 100 solved the issue. If you want to make it dynamic, I'm also down for that.

Probably fixes #1552