### PR TITLE
feat: vim keybindings in query and python cells

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "@codemirror/lang-liquid": "^6.2.1",
         "@codemirror/lang-python": "^6.1.7",
         "@codemirror/lang-sql": "^6.8.0",
+        "@replit/codemirror-vim": "^6.3.0",
         "@types/diff": "^5.0.2",
         "@uiw/codemirror-extensions-events": "^4.23.6",
         "@uiw/codemirror-theme-monokai": "^4.23.6",

--- a/querybook/config/user_setting.yaml
+++ b/querybook/config/user_setting.yaml
@@ -101,3 +101,11 @@ sql_complete:
         - enabled
         - disabled
     helper: (Experimental) Enable it to receive inline AI-generated SQL completions as you type within the editor.
+
+vim_mode:
+    default: disabled
+    tab: editor
+    options:
+        - enabled
+        - disabled
+    helper: Enable vim keybindings for the code editor (normal/insert/visual modes).

--- a/querybook/webapp/components/CodeEditor/CodeEditor.scss
+++ b/querybook/webapp/components/CodeEditor/CodeEditor.scss
@@ -4,6 +4,34 @@
     position: relative;
     height: 100%;
 
+    .vim-mode-indicator {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        z-index: 10;
+        padding: 1px 6px;
+        font-size: var(--xxsmall-text-size);
+        font-family: monospace;
+        font-weight: var(--bold-font);
+        border-top-right-radius: var(--border-radius-sm);
+        pointer-events: none;
+
+        &.vim-mode-normal {
+            background-color: var(--color-accent-dark);
+            color: var(--bg);
+        }
+
+        &.vim-mode-insert {
+            background-color: var(--color-true);
+            color: var(--bg);
+        }
+
+        &.vim-mode-visual {
+            background-color: var(--color-warn);
+            color: var(--bg);
+        }
+    }
+
     &.fullScreen {
         @include full-screen(39);
     }

--- a/querybook/webapp/components/CodeEditor/CodeEditor.tsx
+++ b/querybook/webapp/components/CodeEditor/CodeEditor.tsx
@@ -165,7 +165,9 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, ICodeEditorProps>(
                 }}
             >
                 {vimMode && currentVimMode && (
-                    <div className={`vim-mode-indicator vim-mode-${currentVimMode}`}>
+                    <div
+                        className={`vim-mode-indicator vim-mode-${currentVimMode}`}
+                    >
                         -- {currentVimMode.toUpperCase()} --
                     </div>
                 )}

--- a/querybook/webapp/components/CodeEditor/CodeEditor.tsx
+++ b/querybook/webapp/components/CodeEditor/CodeEditor.tsx
@@ -24,6 +24,7 @@ import { useEventsExtension } from './useEventsExtension';
 import { useKeyMapExtension } from './useKeyMapExtension';
 import { useOptionsExtension } from './useOptionsExtension';
 import { useSearchExtension } from './useSearchExtension';
+import { useVimExtension } from './useVimExtension';
 
 import './CodeEditor.scss';
 
@@ -36,6 +37,7 @@ interface ICodeEditorProps {
     lineWrapping?: boolean;
     height?: 'auto' | 'full' | 'fixed';
     readonly?: boolean;
+    vimMode?: boolean;
     onChange: (value: string) => void;
     onFocus?: () => void;
     onBlur?: () => void;
@@ -53,6 +55,7 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, ICodeEditorProps>(
             lineWrapping = false,
             height = 'auto',
             readonly = false,
+            vimMode = false,
             onChange,
             onFocus,
             onBlur,
@@ -65,6 +68,9 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, ICodeEditorProps>(
 
         const { codeEditorTheme, options, fontSize } =
             useUserCodeEditorConfig();
+
+        const { vimExtension, vimMode: currentVimMode } =
+            useVimExtension(vimMode);
 
         const basicSetup = useMemo<BasicSetupOptions>(
             () => ({
@@ -127,6 +133,7 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, ICodeEditorProps>(
         );
         const finalExtensions = useMemo(
             () => [
+                ...vimExtension,
                 keyMapExtention,
                 eventsExtension,
                 optionsExtension,
@@ -141,6 +148,7 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, ICodeEditorProps>(
                 ...extensions,
             ],
             [
+                vimExtension,
                 keyMapExtention,
                 eventsExtension,
                 optionsExtension,
@@ -156,6 +164,11 @@ export const CodeEditor = forwardRef<ReactCodeMirrorRef, ICodeEditorProps>(
                     fontSize: fontSize ?? undefined,
                 }}
             >
+                {vimMode && currentVimMode && (
+                    <div className={`vim-mode-indicator vim-mode-${currentVimMode}`}>
+                        -- {currentVimMode.toUpperCase()} --
+                    </div>
+                )}
                 <CodeMirror
                     ref={editorRef}
                     theme={

--- a/querybook/webapp/components/CodeEditor/useVimExtension.ts
+++ b/querybook/webapp/components/CodeEditor/useVimExtension.ts
@@ -26,7 +26,10 @@ export function useVimExtension(enabled: boolean): {
         const modeListenerPlugin = ViewPlugin.fromClass(
             class {
                 private cm: any;
-                private handler: (e: { mode: string; subMode?: string }) => void;
+                private handler: (e: {
+                    mode: string;
+                    subMode?: string;
+                }) => void;
 
                 constructor(view: any) {
                     // getCM returns the cm5-compat object set up by the vim() extension

--- a/querybook/webapp/components/CodeEditor/useVimExtension.ts
+++ b/querybook/webapp/components/CodeEditor/useVimExtension.ts
@@ -31,7 +31,7 @@ export function useVimExtension(enabled: boolean): {
                     subMode?: string;
                 }) => void;
 
-                constructor(view: any) {
+                public constructor(view: any) {
                     // getCM returns the cm5-compat object set up by the vim() extension
                     this.cm = getCM(view);
                     if (this.cm) {
@@ -49,7 +49,7 @@ export function useVimExtension(enabled: boolean): {
                     }
                 }
 
-                destroy() {
+                public destroy() {
                     if (this.cm && this.handler) {
                         this.cm.off('vim-mode-change', this.handler);
                     }

--- a/querybook/webapp/components/CodeEditor/useVimExtension.ts
+++ b/querybook/webapp/components/CodeEditor/useVimExtension.ts
@@ -1,0 +1,61 @@
+import { getCM, vim } from '@replit/codemirror-vim';
+import { ViewPlugin } from '@codemirror/view';
+import { Extension } from '@uiw/react-codemirror';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+export type VimMode = 'normal' | 'insert' | 'visual' | null;
+
+export function useVimExtension(enabled: boolean): {
+    vimExtension: Extension[];
+    vimMode: VimMode;
+} {
+    const [vimMode, setVimMode] = useState<VimMode>(enabled ? 'normal' : null);
+    // Use a ref so the ViewPlugin closure always calls the latest setter
+    const setVimModeRef = useRef(setVimMode);
+    setVimModeRef.current = setVimMode;
+
+    useEffect(() => {
+        setVimMode(enabled ? 'normal' : null);
+    }, [enabled]);
+
+    const vimExtension = useMemo(() => {
+        if (!enabled) {
+            return [];
+        }
+
+        const modeListenerPlugin = ViewPlugin.fromClass(
+            class {
+                private cm: any;
+                private handler: (e: { mode: string; subMode?: string }) => void;
+
+                constructor(view: any) {
+                    // getCM returns the cm5-compat object set up by the vim() extension
+                    this.cm = getCM(view);
+                    if (this.cm) {
+                        this.handler = (e) => {
+                            const { mode } = e;
+                            if (mode === 'insert' || mode === 'replace') {
+                                setVimModeRef.current('insert');
+                            } else if (mode === 'visual') {
+                                setVimModeRef.current('visual');
+                            } else {
+                                setVimModeRef.current('normal');
+                            }
+                        };
+                        this.cm.on('vim-mode-change', this.handler);
+                    }
+                }
+
+                destroy() {
+                    if (this.cm && this.handler) {
+                        this.cm.off('vim-mode-change', this.handler);
+                    }
+                }
+            }
+        );
+
+        return [vim(), modeListenerPlugin];
+    }, [enabled]);
+
+    return { vimExtension, vimMode };
+}

--- a/querybook/webapp/components/DataDocPythonCell/DataDocPythonCell.tsx
+++ b/querybook/webapp/components/DataDocPythonCell/DataDocPythonCell.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo } from 'react';
 import { PythonEditor } from 'components/PythonEditor/PythonEditor';
 import { ComponentType, ElementType } from 'const/analytics';
 import { DataCellUpdateFields, IDataPythonCellMeta } from 'const/datadoc';
+import { useUserCodeEditorConfig } from 'hooks/redux/useUserCodeEditorConfig';
 import { trackClick } from 'lib/analytics';
 import { PythonExecutionStatus, PythonKernelStatus } from 'lib/python/types';
 import usePython from 'lib/python/usePython';
@@ -39,6 +40,8 @@ export const DataDocPythonCell = ({
     onFocus,
     onBlur,
 }: IDataDocPythonCellProps) => {
+    const { vimModeEnabled } = useUserCodeEditorConfig();
+
     const {
         kernelStatus,
         runPython,
@@ -167,6 +170,7 @@ export const DataDocPythonCell = ({
                 identifiers={identifiers}
                 keyBindings={keyBindings}
                 readonly={!isEditable}
+                vimMode={vimModeEnabled}
                 onChange={(value) => {
                     onChange({
                         context: value,

--- a/querybook/webapp/components/PythonEditor/PythonEditor.tsx
+++ b/querybook/webapp/components/PythonEditor/PythonEditor.tsx
@@ -23,6 +23,7 @@ interface IDataDocPythonCellProps {
     identifiers?: PythonIdentifierInfo[];
     keyBindings?: KeyBinding[];
     readonly?: boolean;
+    vimMode?: boolean;
     onChange: (value: string) => void;
     onFocus?: () => void;
     onBlur?: () => void;
@@ -36,6 +37,7 @@ export const PythonEditor = ({
     identifiers = [],
     keyBindings = [],
     readonly = false,
+    vimMode = false,
     onChange,
     onFocus,
     onBlur,
@@ -86,6 +88,7 @@ export const PythonEditor = ({
                 onBlur={onBlur}
                 extensions={extensions}
                 readonly={readonly}
+                vimMode={vimMode}
             />
         </div>
     );

--- a/querybook/webapp/components/QueryEditor/BoundQueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/BoundQueryEditor.tsx
@@ -39,6 +39,7 @@ export const BoundQueryEditor = React.forwardRef<
         fontSize,
         autoCompleteType,
         sqlCompleteEnabled,
+        vimModeEnabled,
     } = useUserCodeEditorConfig();
     const combinedOptions = useMemo(
         () => ({
@@ -79,6 +80,7 @@ export const BoundQueryEditor = React.forwardRef<
             cellId={cellId}
             engineId={engine?.id}
             sqlCompleteEnabled={sqlCompleteEnabled}
+            vimMode={vimModeEnabled}
         />
     );
 });

--- a/querybook/webapp/components/QueryEditor/QueryEditor.tsx
+++ b/querybook/webapp/components/QueryEditor/QueryEditor.tsx
@@ -48,6 +48,7 @@ export interface IQueryEditorProps {
     className?: string;
     autoCompleteType?: AutoCompleteType;
     sqlCompleteEnabled?: boolean;
+    vimMode?: boolean;
 
     engineId: number;
     templatedVariables?: TDataDocMetaVariables;
@@ -101,6 +102,7 @@ export const QueryEditor: React.FC<
             className,
             autoCompleteType = 'all',
             sqlCompleteEnabled = false,
+            vimMode = false,
             engineId,
             cellId,
             templatedVariables = [],
@@ -386,6 +388,7 @@ export const QueryEditor: React.FC<
                     keyBindings={keyBindings}
                     extensions={extensions}
                     readonly={readOnly}
+                    vimMode={vimMode}
                     onChange={onChange}
                     onSelection={onSelection}
                 />

--- a/querybook/webapp/hooks/redux/useUserCodeEditorConfig.ts
+++ b/querybook/webapp/hooks/redux/useUserCodeEditorConfig.ts
@@ -25,8 +25,7 @@ export function useUserCodeEditorConfig(): {
         tab: state.user.computedSettings['tab'],
         sqlCompleteEnabled:
             state.user.computedSettings['sql_complete'] === 'enabled',
-        vimModeEnabled:
-            state.user.computedSettings['vim_mode'] === 'enabled',
+        vimModeEnabled: state.user.computedSettings['vim_mode'] === 'enabled',
     }));
     const indentWithTabs = editorSettings.tab === 'tab';
     const tabSize =

--- a/querybook/webapp/hooks/redux/useUserCodeEditorConfig.ts
+++ b/querybook/webapp/hooks/redux/useUserCodeEditorConfig.ts
@@ -13,6 +13,7 @@ export function useUserCodeEditorConfig(): {
     options: CodeMirror.EditorConfiguration;
     autoCompleteType: AutoCompleteType;
     sqlCompleteEnabled: boolean;
+    vimModeEnabled: boolean;
 } {
     const editorSettings = useShallowSelector((state: IStoreState) => ({
         theme: state.user.computedSettings['theme'],
@@ -24,6 +25,8 @@ export function useUserCodeEditorConfig(): {
         tab: state.user.computedSettings['tab'],
         sqlCompleteEnabled:
             state.user.computedSettings['sql_complete'] === 'enabled',
+        vimModeEnabled:
+            state.user.computedSettings['vim_mode'] === 'enabled',
     }));
     const indentWithTabs = editorSettings.tab === 'tab';
     const tabSize =
@@ -43,6 +46,7 @@ export function useUserCodeEditorConfig(): {
         fontSize: editorSettings.fontSize,
         autoCompleteType: editorSettings.autoComplete as AutoCompleteType,
         sqlCompleteEnabled: editorSettings.sqlCompleteEnabled,
+        vimModeEnabled: editorSettings.vimModeEnabled,
         options,
     };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5070,6 +5070,11 @@
     classcat "^5.0.3"
     zustand "^4.1.1"
 
+"@replit/codemirror-vim@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@replit/codemirror-vim/-/codemirror-vim-6.3.0.tgz#1bcde09f25bcb1c4f96d2cd50ea07f9f71fc9ec4"
+  integrity sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ==
+
 "@rooks/use-mutation-observer@4.11.2":
   version "4.11.2"
   resolved "https://registry.npmjs.org/@rooks/use-mutation-observer/-/use-mutation-observer-4.11.2.tgz"


### PR DESCRIPTION
Related to this issue: https://github.com/pinterest/querybook/issues/1673

Adding vim keybindings in query and python cells.

## Testing

Started querybook locally, verified:
* vim keybindings work for basic vim navigation as expected.
* keybindings available in python cells
* keybindings available in query cells
* keybindings available in adhoc page
* functionality can be enabled/disabled in settings
