### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License](http://img.shields.io/:license-Apache%202-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.txt)
 [![Slack](https://img.shields.io/badge/Slack-Join%20our%20community-brightgreen?style=flat&logo=slack)](https://join.slack.com/t/querybook/shared_invite/zt-se82lvld-yyzRIqvIASsyYozk7jMCYQ)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/pinterest/querybook)
+[![gitcgr](https://gitcgr.com/badge/pinterest/querybook.svg)](https://gitcgr.com/pinterest/querybook)
 
 Querybook is a Big Data IDE that allows you to discover, create, and share data analyses, queries, and tables.
 [Check out the full documentation & feature highlights here.](https://querybook.org)


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/pinterest/querybook.svg)](https://gitcgr.com/pinterest/querybook)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).