### PR TITLE
Add warning to querybook docs to prevent adding querybook db as query engine

### DIFF
--- a/docs_website/docs/setup_guide/connect_to_a_query_engine.mdx
+++ b/docs_website/docs/setup_guide/connect_to_a_query_engine.mdx
@@ -23,6 +23,15 @@ If you dont have an idea of above concepts of **query engine**, **environment** 
 
 Here we'll guide you through the process of adding a query engine for **PostgreSQL** as an example.
 
+:::warning Security Risk: Query Engine Connection String
+
+Be careful when choosing which database to connect as a query engine.
+If you use the same connection string as Querybook's internal metadata database (e.g. the MySQL instance defined in `DATABASE_CONN`),
+all users with access to the environment will be able to browse and query the admin database directly — including sensitive system tables.
+Only connect a query engine to a database that is safe to expose to your users.
+
+:::
+
 1. Create a `local.txt` file under the `requirements/` folder in the project's root directory.
 
 ```bash


### PR DESCRIPTION
### Context:
* There is no warning in the querybook documentation that if user's add the querybook metadata db as a query engine in a default environment, this exposes access to querybook admin tables. Add this warning to surface potential security concerns to users creating a querybook deployment.

### Summary:
* Update Querybook website docs to add this security warning