### PR TITLE
feat(permissions): Generalize restricted query access checks via plugin

### DIFF
--- a/containers/bundled_querybook_config.yaml
+++ b/containers/bundled_querybook_config.yaml
@@ -43,16 +43,12 @@ ELASTICSEARCH_HOST: http://elasticsearch:9200
 #     opensearch_url: http://elasticsearch:9200
 #     index_name: 'vector_index_v1'
 
-# API Access Token restrictions
-# List of allowed environment ids for API access token requests.
-# Format: [<id>, ...] (e.g., [1, 2, 3])
-# If empty or not set, all environments are allowed for API token requests.
+# Safe environments/engines for API access token and deployment-specific restrictions.
+# List of allowed environment ids. If empty or not set, all environments are allowed.
 # Example:
-# API_ACCESS_TOKEN_ALLOWED_ENVIRONMENTS:
+# SAFE_ENVIRONMENTS:
 #   - 1
-# List of allowed query engine ids for API access token requests.
-# Format: [<id>, ...] (e.g., [1, 2, 3])
-# If empty or not set, all query engines are allowed for API token requests.
+# List of allowed query engine ids. If empty or not set, all query engines are allowed.
 # Example:
-# API_ACCESS_TOKEN_ALLOWED_QUERY_ENGINES:
+# SAFE_QUERY_ENGINES:
 #   - 1

--- a/plugins/access_control_plugin/__init__.py
+++ b/plugins/access_control_plugin/__init__.py
@@ -1,0 +1,16 @@
+# Override `check_restricted_query_access` to control access to environments
+# and query engines that are outside the SAFE_ENVIRONMENTS / SAFE_QUERY_ENGINES
+# allowlists. The function is called with no arguments but runs inside a Flask
+# request context, so `flask.request` and `flask_login.current_user` are
+# available for inspecting the request.
+#
+# Return True to allow the request, False to deny it.
+#
+# Example: only allow access when an API access token is NOT used
+# (i.e. restrict API token requests to the safe allowlists while letting
+# normal browser sessions through unrestricted):
+#
+# from flask import request
+#
+# def check_restricted_query_access() -> bool:
+#     return request.headers.get("api-access-token") is None

--- a/querybook/server/app/auth/permission.py
+++ b/querybook/server/app/auth/permission.py
@@ -1,4 +1,3 @@
-from flask import request
 from flask_login import current_user
 from typing import List, Optional
 

--- a/querybook/server/app/auth/permission.py
+++ b/querybook/server/app/auth/permission.py
@@ -35,7 +35,7 @@ def verify_every_environment_permission(environment_ids: List[int]):
     If the user does not have access to every one of the provided environment ids,
     the function will abort the request with a 403 error.
     """
-    verify_api_access_token_environment_permission(environment_ids)
+    verify_safe_environment_access(environment_ids)
     if len(environment_ids) == 0:
         abort_404("Requested resource is not available within accessible environment")
 

--- a/querybook/server/app/auth/permission.py
+++ b/querybook/server/app/auth/permission.py
@@ -11,6 +11,7 @@ from const.datasources import (
 )
 
 from env import QuerybookSettings
+from lib.access_control import check_restricted_query_access
 from models.admin import QueryEngine, QueryMetastore, QueryEngineEnvironment
 from models.query_execution import QueryExecution, StatementExecution
 from models.metastore import DataSchema, DataTable, DataTableColumn
@@ -55,7 +56,7 @@ def verify_environment_permission(environment_ids: List[int]):
     # If we are verifying environment ids and none is returned
     # it is most likely that the object we are verifying does
     # not associate with any environment
-    verify_api_access_token_environment_permission(environment_ids)
+    verify_safe_environment_access(environment_ids)
     if len(environment_ids) == 0:
         abort_404("Requested resource is not available within accessible environment")
 
@@ -80,42 +81,36 @@ def verify_query_engine_environment_permission(
     )
 
 
-def check_api_access_token_used():
-    return request.headers.get("api-access-token") is not None
-
-
-def verify_api_access_token_environment_permission(environment_ids: List[int]):
-    if not check_api_access_token_used():
+def verify_safe_environment_access(environment_ids: List[int]):
+    # If safe_environments is empty or the environment ids are safe, we can return early
+    safe_environments = QuerybookSettings.SAFE_ENVIRONMENTS
+    if not safe_environments or any(
+        environment_id in safe_environments for environment_id in environment_ids
+    ):
         return
-    api_access_token_allowed_environments = (
-        QuerybookSettings.API_ACCESS_TOKEN_ALLOWED_ENVIRONMENTS
+
+    # Check that the environment access is not restricted
+    api_assert(
+        check_restricted_query_access(),
+        message=f"Environment ids '{str(environment_ids)}' are not allowed for this request.",
+        status_code=ACCESS_RESTRICTED_STATUS_CODE,
     )
-    if api_access_token_allowed_environments:
-        api_assert(
-            any(
-                environment_id in api_access_token_allowed_environments
-                for environment_id in environment_ids
-            ),
-            message=f"Environment ids '{str(environment_ids)}' are not allowed for API access token requests. Allowed environments: {str(api_access_token_allowed_environments)}",
-            status_code=ACCESS_RESTRICTED_STATUS_CODE,
-        )
 
 
-def verify_api_access_token_query_engine_permission(query_engine_ids: List[int]):
-    if not check_api_access_token_used():
+def verify_safe_query_engine_access(query_engine_ids: List[int]):
+    # If safe_query_engines is empty or the query engine ids are safe, we can return early
+    safe_query_engines = QuerybookSettings.SAFE_QUERY_ENGINES
+    if not safe_query_engines or all(
+        query_engine_id in safe_query_engines for query_engine_id in query_engine_ids
+    ):
         return
-    api_access_token_allowed_query_engines = (
-        QuerybookSettings.API_ACCESS_TOKEN_ALLOWED_QUERY_ENGINES
+
+    # Check that the query engine access is not restricted
+    api_assert(
+        check_restricted_query_access(),
+        message=f"Query engine ids '{str(query_engine_ids)}' are not allowed for this request.",
+        status_code=ACCESS_RESTRICTED_STATUS_CODE,
     )
-    if api_access_token_allowed_query_engines:
-        api_assert(
-            all(
-                query_engine_id in api_access_token_allowed_query_engines
-                for query_engine_id in query_engine_ids
-            ),
-            message=f"Query engine ids '{str(query_engine_ids)}' are not allowed for API access token requests. Allowed query engines: {str(api_access_token_allowed_query_engines)}",
-            status_code=ACCESS_RESTRICTED_STATUS_CODE,
-        )
 
 
 @with_session
@@ -126,7 +121,7 @@ def verify_query_engine_permission(query_engine_id, session=None):
         .join(QueryEngine)
         .filter(QueryEngine.id == query_engine_id)
     ]
-    verify_api_access_token_query_engine_permission([query_engine_id])
+    verify_safe_query_engine_access([query_engine_id])
     verify_environment_permission(environment_ids)
 
 
@@ -144,7 +139,7 @@ def verify_query_execution_permission(query_execution_id, session=None):
         .join(QueryExecution)
         .filter(QueryExecution.id == query_execution_id)
     ]
-    verify_api_access_token_query_engine_permission(query_engine_ids)
+    verify_safe_query_engine_access(query_engine_ids)
 
 
 @with_session
@@ -165,7 +160,7 @@ def verify_statement_execution_permission(statement_execution_id, session=None):
         .join(StatementExecution)
         .filter(StatementExecution.id == statement_execution_id)
     ]
-    verify_api_access_token_query_engine_permission(query_engine_ids)
+    verify_safe_query_engine_access(query_engine_ids)
 
 
 @with_session
@@ -233,7 +228,7 @@ def verify_data_doc_permission(data_doc_id, session=None):
     environment_ids = get_data_doc_environment_ids(data_doc_id, session=session)
     verify_environment_permission(environment_ids)
     query_engine_ids = get_query_engine_ids_by_data_doc_id(data_doc_id, session=session)
-    verify_api_access_token_query_engine_permission(query_engine_ids)
+    verify_safe_query_engine_access(query_engine_ids)
 
 
 @with_session
@@ -258,7 +253,7 @@ def verify_data_cell_permission(cell_id, session=None):
     verify_environment_permission(environment_ids)
 
     engine_ids = get_query_engine_ids_by_data_cell_ids([cell_id], session=session)
-    verify_api_access_token_query_engine_permission(engine_ids)
+    verify_safe_query_engine_access(engine_ids)
 
 
 @with_session
@@ -272,7 +267,7 @@ def verify_data_cells_permission(cell_ids: List, session=None):
     ]
     verify_every_environment_permission(environment_ids)
     engine_ids = get_query_engine_ids_by_data_cell_ids(cell_ids, session=session)
-    verify_api_access_token_query_engine_permission(engine_ids)
+    verify_safe_query_engine_access(engine_ids)
 
 
 def get_engine_ids_by_data_cells(data_cells: List[DataCell]):

--- a/querybook/server/env.py
+++ b/querybook/server/env.py
@@ -84,13 +84,9 @@ class QuerybookSettings(object):
     AUTH_BACKEND = get_env_config("AUTH_BACKEND")
     LOGS_OUT_AFTER = int(get_env_config("LOGS_OUT_AFTER"))
 
-    # API Access Token restrictions
-    API_ACCESS_TOKEN_ALLOWED_ENVIRONMENTS = (
-        get_env_config("API_ACCESS_TOKEN_ALLOWED_ENVIRONMENTS", optional=True) or []
-    )
-    API_ACCESS_TOKEN_ALLOWED_QUERY_ENGINES = (
-        get_env_config("API_ACCESS_TOKEN_ALLOWED_QUERY_ENGINES", optional=True) or []
-    )
+    # Safe environments/engines for deployment-specific restrictions.
+    SAFE_ENVIRONMENTS = get_env_config("SAFE_ENVIRONMENTS", optional=True) or []
+    SAFE_QUERY_ENGINES = get_env_config("SAFE_QUERY_ENGINES", optional=True) or []
 
     OAUTH_CLIENT_ID = get_env_config("OAUTH_CLIENT_ID")
     OAUTH_CLIENT_SECRET = get_env_config("OAUTH_CLIENT_SECRET")

--- a/querybook/server/lib/access_control/__init__.py
+++ b/querybook/server/lib/access_control/__init__.py
@@ -1,0 +1,18 @@
+from lib.utils.import_helper import import_module_with_default
+
+
+def _default_check_restricted_query_access() -> bool:
+    """Default access control: allow all requests."""
+    return True
+
+
+# Deployments can override this by defining `check_restricted_query_access`
+# in an `access_control_plugin` module on the PYTHONPATH. The function
+# takes no arguments but can inspect Flask's `request` and `current_user`
+# context, and should return True to allow or False to deny the request.
+# See plugins/access_control_plugin/__init__.py for a template.
+check_restricted_query_access = import_module_with_default(
+    "access_control_plugin",
+    "check_restricted_query_access",
+    default=_default_check_restricted_query_access,
+)

--- a/querybook/tests/test_app/test_auth/test_permission.py
+++ b/querybook/tests/test_app/test_auth/test_permission.py
@@ -15,23 +15,23 @@ class TestVerifyEveryEnvironmentPermission:
         return user
 
     @pytest.fixture
-    def fake_verify_api_access_token_environment_permission(self):
-        verify_api_access_token_environment_permission = MagicMock()
-        verify_api_access_token_environment_permission.side_effect = None
-        return verify_api_access_token_environment_permission
+    def fake_verify_safe_environment_access(self):
+        verify_safe_environment_access = MagicMock()
+        verify_safe_environment_access.side_effect = None
+        return verify_safe_environment_access
 
     @pytest.fixture(autouse=True)
     def setup_mocks(
         self,
         monkeypatch,
         fake_user,
-        fake_verify_api_access_token_environment_permission,
+        fake_verify_safe_environment_access,
     ):
         monkeypatch.setattr(permission, "current_user", fake_user)
         monkeypatch.setattr(
             permission,
-            "verify_api_access_token_environment_permission",
-            fake_verify_api_access_token_environment_permission,
+            "verify_safe_environment_access",
+            fake_verify_safe_environment_access,
         )
 
     def test_rejects_when_user_does_not_have_access_to_every_environment(self):


### PR DESCRIPTION
### Summary
- `permission.py`: Replaced verify_api_access_token_environment/query_engine_permission with `verify_safe_environment_access` / `verify_safe_query_engine_access`. Logic now delegates the restriction check to a pluggable check_restricted_query_access function instead of being hardcoded to API token requests.
- `env.py`: Renamed config keys `API_ACCESS_TOKEN_ALLOWED_ENVIRONMENTS` → `SAFE_ENVIRONMENTS` and `API_ACCESS_TOKEN_ALLOWED_QUERY_ENGINES` → `SAFE_QUERY_ENGINES` to reflect their broader, token-agnostic purpose.
- `lib/access_control/__init__.py`: New module that loads check_restricted_query_access from an optional access_control_plugin, falling back to a default that allows all requests.
- `plugins/access_control_plugin/__init__.py`: Added plugin template with a commented example showing how to restrict access to non-safe environments/engines for API token requests.
- `bundled_querybook_config.yaml`: Updated comments and config key names to match the rename.