### PR TITLE
ErrorPage: fix 'Unknown error occured' -> 'occurred' fallback text

### DIFF
--- a/querybook/webapp/ui/ErrorPage/ErrorPage.tsx
+++ b/querybook/webapp/ui/ErrorPage/ErrorPage.tsx
@@ -43,7 +43,7 @@ export const ErrorPage: React.FunctionComponent<IErrorPageProps> = ({
         errorMessage
     ) : (
         <>
-            {httpCodeToDescription[errorCode] || 'Unknown error occured at'}
+            {httpCodeToDescription[errorCode] || 'Unknown error occurred at'}
             <code className="ErrorPage-path ml4">{location.pathname}</code>.
             <span className="ml4">
                 Click <a onClick={history.goBack}>here</a> to go back.


### PR DESCRIPTION
`ErrorPage` component in `querybook/webapp/ui/ErrorPage/ErrorPage.tsx:46` rendered `Unknown error occured at` when `httpCodeToDescription` lookup missed. User-visible fallback. String-literal-only change.