### PR TITLE
[Fix] Update schema cache to prevent unauthz access

### DIFF
--- a/querybook/server/datasources/metastore.py
+++ b/querybook/server/datasources/metastore.py
@@ -10,7 +10,7 @@ from app.auth.permission import (
 )
 from app.datasource import admin_only, api_assert, register, with_impression
 from app.db import DBSession
-from app.flask_app import cache, limiter
+from app.flask_app import limiter
 from const.datasources import RESOURCE_NOT_FOUND_STATUS_CODE
 from const.impression import ImpressionItemType
 from const.metastore import DataTableWarningSeverity, MetadataType
@@ -18,7 +18,7 @@ from const.time import seconds_in_a_day
 from flask_login import current_user
 from lib.lineage.utils import lineage
 from lib.metastore import get_metastore_loader
-from lib.metastore.utils import DataTableFinder
+from lib.metastore.utils import DataTableFinder, get_schema_cached
 from lib.query_analysis.samples import make_samples_query
 from lib.utils import mysql_cache
 from logic import admin as admin_logic
@@ -46,15 +46,12 @@ def update_schema(schema_id, description):
 
 
 @register("/schema/<int:schema_id>/", methods=["GET"])
-@cache.memoize(14400)
 def get_schema(schema_id, include_metastore=False, include_table=False):
-    with DBSession() as session:
-        schema = logic.get_schema_by_id(schema_id, session=session)
-        api_assert(schema, "Invalid schema")
-        verify_metastore_permission(schema.metastore_id, session=session)
+    schema = get_schema_cached(schema_id)
+    api_assert(schema, "Invalid schema")
 
-        schema_dict = schema.to_dict(include_metastore, include_table)
-        return schema_dict
+    verify_metastore_permission(schema.metastore_id)
+    return schema.to_dict(include_metastore, include_table)
 
 
 @register("/schema/<int:schema_id>/table/", methods=["GET"])

--- a/querybook/server/lib/metastore/utils.py
+++ b/querybook/server/lib/metastore/utils.py
@@ -1,6 +1,8 @@
 from typing import Dict, List
-from logic import metastore as logic
+
 from app.db import with_session
+from app.flask_app import cache
+from logic import metastore as logic
 
 
 class MetastoreTableACLChecker(object):
@@ -98,3 +100,11 @@ class DataTableFinder:
             return logic.get_column_by_name(
                 name=column_name, table_id=table.id, session=session
             )
+
+
+@cache.memoize(14400)
+@with_session
+def get_schema_cached(schema_id, session=None):
+    """Internal cached function - fetches data only, no authz."""
+    schema = logic.get_schema_by_id(schema_id, session=session)
+    return schema


### PR DESCRIPTION
## Summary
Currently there is an app wide memoization on calls to retrieve schema information. There is an authorization check in the registered handler, but, after the cache is primed, this check is bypassed by the cache.

Update to cache the retrieval of the schema, and authorize every request to retrieve the schema

## Test Plans
### Before
#### Unprimed cache -- access is correctly forbidden
<img width="1192" height="1162" alt="Screenshot 2026-05-01 at 11 26 47 AM" src="https://github.com/user-attachments/assets/aae1b1de-71d0-4654-8542-111000a3f086" />

#### Primed cache -- access is incorrectly granted
<img width="1192" height="1162" alt="Screenshot 2026-05-01 at 11 27 38 AM" src="https://github.com/user-attachments/assets/9d650ae3-d54f-440b-84e7-f4002fa4d4ba" />

### After
#### Primed cache -- access is correctly forbidden to the restricted schema
<img width="1192" height="1162" alt="Screenshot 2026-05-01 at 11 18 14 AM" src="https://github.com/user-attachments/assets/a2971289-5e3d-4fd9-a57d-9f1fd2347092" />
