### PR TITLE
Create EXTRA_CLIENT_SETTINGS_HOOK to inject flask params into query engine client_settings

### DIFF
--- a/plugins/executor_plugin/__init__.py
+++ b/plugins/executor_plugin/__init__.py
@@ -4,3 +4,25 @@
 ALL_PLUGIN_EXECUTORS = [
 
 ]
+
+# Optional hook invoked inside a Flask request to compute extra kwargs that
+# should be merged into the executor ``client_setting`` dict (i.e. the dict
+# eventually splatted into the executor client constructor, e.g.
+# ``TrinoClient(**client_setting)``).
+#
+# Signature: () -> Dict[str, Any]
+#
+# The hook fires in two situations:
+#   - Async path: ``initiate_query_execution`` invokes it while still in the
+#     Flask request that created the QueryExecution, and the returned dict is
+#     passed to ``run_query_task.apply_async`` as the ``client_setting_override``
+#     kwarg. The Celery worker merges it into ``client_setting`` without ever
+#     invoking the hook itself.
+#   - Direct/sync path: callers of ``get_client_setting_from_engine`` that
+#     don't pass an explicit ``client_setting_override`` trigger an inline
+#     invocation. Hook implementations should return ``{}`` when there is no
+#     live Flask request or when no request-scoped settings apply.
+#
+# Convention: return ``{}`` for the common in-app case so downstream consumers
+# can treat the absence of an injected key as "use defaults".
+EXTRA_CLIENT_SETTINGS_HOOK = None

--- a/querybook/server/datasources/query_execution.py
+++ b/querybook/server/datasources/query_execution.py
@@ -45,6 +45,7 @@ from logic.query_execution_permission import (
     get_default_user_environment_by_execution_id,
 )
 from lib.config import get_config_value
+from lib.query_executor.executor_factory import get_client_setting_override_from_hook
 from lib.query_analysis.validation.all_validators import get_validator_by_name
 from lib.query_analysis.transpilation.all_transpilers import (
     ALL_TRANSPILERS,
@@ -106,6 +107,7 @@ def initiate_query_execution(
             kwargs={
                 "query_execution_id": query_execution.id,
                 "session_props": session_props,
+                "client_setting_override": get_client_setting_override_from_hook(),
             },
         )
 

--- a/querybook/server/lib/query_executor/executor_factory.py
+++ b/querybook/server/lib/query_executor/executor_factory.py
@@ -5,6 +5,7 @@ from const.query_execution import QueryExecutionStatus
 from lib.logger import get_logger
 from lib.query_analysis.statements import get_statement_ranges
 from lib.query_analysis.lineage import process_query
+from lib.utils.import_helper import import_module_with_default
 from logic import (
     admin as admin_logic,
     query_execution as qe_logic,
@@ -15,16 +16,42 @@ from .all_executors import get_executor_class
 
 LOG = get_logger(__file__)
 
+EXTRA_CLIENT_SETTINGS_HOOK = import_module_with_default(
+    "executor_plugin", "EXTRA_CLIENT_SETTINGS_HOOK", default=None
+)
+
+
+def get_client_setting_override_from_hook() -> Dict:
+    """Compute request-scoped client settings from the optional plugin hook.
+
+    Call this while a Flask request is active (for example, right before
+    queuing a Celery task). Hook implementations may still return ``{}``
+    when no request-scoped settings apply.
+    """
+    if EXTRA_CLIENT_SETTINGS_HOOK is None:
+        return {}
+    try:
+        return EXTRA_CLIENT_SETTINGS_HOOK() or {}
+    except Exception:
+        LOG.exception("EXTRA_CLIENT_SETTINGS_HOOK raised; skipping plugin settings")
+        return {}
+
 
 @with_session
 def create_executor_from_execution(
-    query_execution_id, celery_task, execution_type, session_props, session=None
+    query_execution_id,
+    celery_task,
+    execution_type,
+    session_props,
+    client_setting_override=None,
+    session=None,
 ):
     executor_params, engine = _get_executor_params_and_engine(
         query_execution_id,
         celery_task=celery_task,
         execution_type=execution_type,
         session_props=session_props,
+        client_setting_override=client_setting_override,
         session=session,
     )
     executor = get_executor_class(engine.language, engine.executor)(**executor_params)
@@ -33,7 +60,12 @@ def create_executor_from_execution(
 
 @with_session
 def _get_executor_params_and_engine(
-    query_execution_id, celery_task, execution_type, session_props, session=None
+    query_execution_id,
+    celery_task,
+    execution_type,
+    session_props,
+    client_setting_override=None,
+    session=None,
 ):
     query, statement_ranges, uid, engine_id = _get_query_execution_info(
         query_execution_id, session=session
@@ -43,7 +75,12 @@ def _get_executor_params_and_engine(
     if engine.deleted_at is not None:
         raise ArchivedQueryEngine("This query engine is disabled.")
 
-    client_setting = get_client_setting_from_engine(engine, uid, session=session)
+    client_setting = get_client_setting_from_engine(
+        engine,
+        uid,
+        client_setting_override=client_setting_override,
+        session=session,
+    )
 
     if session_props:
         client_setting["session_props"] = session_props
@@ -62,13 +99,21 @@ def _get_executor_params_and_engine(
 
 
 @with_session
-def get_client_setting_from_engine(engine, uid=None, session=None) -> Dict:
+def get_client_setting_from_engine(
+    engine, uid=None, client_setting_override=None, session=None
+) -> Dict:
     """Compute the settings passed to the query engine.
        Both engine and user must be attached to a sqlalchemy session.
 
     Args:
         engine (QueryEngine): Corresponds to the DB QueryEngine
         uid (int, optional): Optional User id executed the query. Defaults to None.
+        client_setting_override (Dict, optional): Extra kwargs merged into the
+            client_setting dict. Async callers should pass an explicit
+            override computed before queuing the Celery task. Direct/sync
+            callers leave this as ``None`` and the hook (if configured) fires
+            inline, using Flask request context when one is available. Plugin
+            keys override engine defaults.
 
     Returns:
         Dict: Dictionary of Kwargs send to the query engine client
@@ -80,6 +125,11 @@ def get_client_setting_from_engine(engine, uid=None, session=None) -> Dict:
         if executor_params.get("proxy_user_id", "") != "":
             proxy_user = user.to_dict()[executor_params["proxy_user_id"]]
         executor_params["proxy_user"] = proxy_user
+
+    if client_setting_override is None:
+        client_setting_override = get_client_setting_override_from_hook()
+    if client_setting_override:
+        executor_params.update(client_setting_override)
 
     return executor_params
 

--- a/querybook/server/lib/query_review/base_query_review_handler.py
+++ b/querybook/server/lib/query_review/base_query_review_handler.py
@@ -12,6 +12,7 @@ from lib.query_review.utils import (
     notify_query_author_of_rejection,
     notify_reviewers_of_new_request,
 )
+from lib.query_executor.executor_factory import get_client_setting_override_from_hook
 from logic import query_review as logic, query_execution as qe_logic
 from const.query_execution import PeerReviewParamsDict, QueryExecutionStatus
 from models.query_execution import QueryExecution
@@ -187,7 +188,12 @@ class BaseQueryReviewHandler(metaclass=ABCMeta):
 
             session.commit()
 
-            run_query_task.apply_async(args=[query_execution.id])
+            run_query_task.apply_async(
+                kwargs={
+                    "query_execution_id": query_execution.id,
+                    "client_setting_override": get_client_setting_override_from_hook(),
+                },
+            )
             notify_query_author_of_approval(
                 query_review=query_review,
                 query_execution=query_execution,

--- a/querybook/server/tasks/run_query.py
+++ b/querybook/server/tasks/run_query.py
@@ -33,8 +33,10 @@ def run_query_task(
     query_execution_id,
     execution_type=QueryExecutionType.ADHOC.value,
     session_props=None,
+    client_setting_override=None,
 ):
     stats_logger.incr(QUERY_EXECUTIONS, tags={"execution_type": execution_type})
+    client_setting_override = client_setting_override or {}
 
     executor = None
     error_message = None
@@ -46,6 +48,7 @@ def run_query_task(
             celery_task=self,
             session_props=session_props,
             execution_type=execution_type,
+            client_setting_override=client_setting_override,
         )
         run_executor_until_finish(self, executor)
     except SoftTimeLimitExceeded:


### PR DESCRIPTION
### Context
Today, plugin-provided executor clients receive their kwargs from a single `client_setting` dict that's computed from the `QueryEngine` row in the database. There's no clean way to inject values that are only known at request time (i.e. from the Flask request that triggered the query). This PR adds an optional `EXTRA_CLIENT_SETTINGS_HOOK` plugin hook that lets a plugin compute a dict of extra `client_setting` kwargs once in the originating Flask request and have them flow through every executor entry point — sync, async, and peer-review approval — without any DB plumbing.

### Summary of changes
- **[plugins/executor_plugin/__init__.py](plugins/executor_plugin/__init__.py)** — declares the new optional `EXTRA_CLIENT_SETTINGS_HOOK` symbol (defaults to `None`) with a docstring example showing how a plugin can read the Flask request and return a `Dict[str, Any]` to merge into `client_setting`.
- **[querybook/server/lib/query_executor/executor_factory.py](querybook/server/lib/query_executor/executor_factory.py)** — loads the hook at module import via `import_module_with_default`. Adds `get_client_setting_override_from_hook()` to centralize invocation + exception handling (returns `{}` on failure or when the hook is unset). Threads a new `client_setting_override` kwarg through `create_executor_from_execution` → `_get_executor_params_and_engine` → `get_client_setting_from_engine`. When the override is `None`, `get_client_setting_from_engine` invokes the hook inline; when it's a dict (including `{}`), the hook is skipped and the explicit override is merged. Plugin-supplied keys win over engine defaults.
- **[querybook/server/tasks/run_query.py](querybook/server/tasks/run_query.py)** — `run_query_task` accepts a new `client_setting_override` kwarg, normalizes a missing value to `{}` (so the worker never accidentally re-invokes the hook in a Celery context without Flask), and forwards it to `create_executor_from_execution`.
- **[querybook/server/datasources/query_execution.py](querybook/server/datasources/query_execution.py)** — `initiate_query_execution` calls `get_client_setting_override_from_hook()` while still in the Flask request that created the `QueryExecution`, and passes the result through `run_query_task.apply_async(kwargs=...)`.
- **[querybook/server/lib/query_review/base_query_review_handler.py](querybook/server/lib/query_review/base_query_review_handler.py)** — `approve_review` does the same, so peer-reviewed queries also carry the override from the approver's Flask request into the worker. Replaces the positional `args=[...]` apply_async call with a kwargs-based call for consistency.

Behavior is unchanged when no plugin implements `EXTRA_CLIENT_SETTINGS_HOOK`. Sync executor paths (`ExecuteQuery`, validators, sample queries, table upload) are unchanged at the call site — the inline branch in `get_client_setting_from_engine` handles them transparently.