### PR TITLE
ci: declare workflow-level `contents: read` on 4 workflows

### DIFF
--- a/.github/workflows/docstests.yml
+++ b/.github/workflows/docstests.yml
@@ -10,6 +10,9 @@ on:
         paths:
             - 'docs_website/**/*'
 
+permissions:
+  contents: read
+
 jobs:
     test-docs-build:
         name: Test Docs Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,10 @@ on:
         branches:
             - master
     pull_request:
+
+permissions:
+  contents: read
+
 jobs:
     lint:
         runs-on: ubuntu-latest

--- a/.github/workflows/nodetests.yml
+++ b/.github/workflows/nodetests.yml
@@ -16,6 +16,10 @@ on:
             - 'querybook/**/*.s?css'
             - 'querybook/**/*.html'
             - 'package.json'
+
+permissions:
+  contents: read
+
 jobs:
     nodetests:
         runs-on: ubuntu-latest

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -10,6 +10,10 @@ on:
         paths:
             - '**.py'
             - 'requirements/**/*.txt'
+
+permissions:
+  contents: read
+
 jobs:
     pythontests:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 4 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `pr_title_check.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.