### PR TITLE
Make Docker cleanup project-scoped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,4 +65,7 @@ clean_pyc:
 	find . -name "*.pyc" -delete
 	find . -type d -name __pycache__ -delete
 clean_docker:
-	docker system prune --volumes
+	# Only remove Querybook Docker resources. Avoid global docker system prune
+	# because it can delete volumes and caches from unrelated projects.
+	docker-compose --file containers/docker-compose.dev.yml down --volumes --remove-orphans || true
+	docker-compose --file containers/docker-compose.test.yml down --volumes --remove-orphans || true


### PR DESCRIPTION
## Summary

Updates the `clean_docker` Makefile target to avoid using global Docker cleanup.

Previously, `make clean` ran `docker system prune --volumes`, which can remove unused Docker resources from unrelated projects on the developer's machine.

This change scopes Docker cleanup to Querybook's development and test Docker Compose resources instead.

## Why

This prevents accidental deletion of Docker volumes, networks, and caches belonging to other local development projects.

Fixes #1663.

## Testing

- Ran `make -n clean_docker` to confirm Docker cleanup is scoped to Querybook Compose files
- Ran `make clean_docker` and confirmed it no longer calls `docker system prune --volumes`