### PR TITLE
Update cron to prevent invalid dates

### DIFF
--- a/querybook/server/lib/celery/cron.py
+++ b/querybook/server/lib/celery/cron.py
@@ -1,9 +1,29 @@
 # Helper functions to validate cron
 from celery.schedules import crontab_parser, ParseException
 
+# Max day a month can ever have; Feb=29 keeps leap-year "0 0 29 2 *" valid
+_MAX_DAY_IN_MONTH = {
+    1: 31,
+    2: 29,
+    3: 31,
+    4: 30,
+    5: 31,
+    6: 30,
+    7: 31,
+    8: 31,
+    9: 30,
+    10: 31,
+    11: 30,
+    12: 31,
+}
+
 
 def validate_cron(expression: str) -> bool:
     """Validate whether or not the cron tab expression is valid
+
+    In addition to validating each field independently, this also performs a
+    cross-field calendar check so that calendar-impossible schedules such as
+    "0 0 30 2 *" (Feb 30) or "0 0 31 4 *" (Apr 31) are rejected.
 
     Arguments:
         expression {str} -- A cron tab express
@@ -15,7 +35,7 @@ def validate_cron(expression: str) -> bool:
     if not isinstance(expression, str):
         return False
 
-    parts = expression.split(" ")
+    parts = expression.split()
     if len(parts) != 5:
         return False
 
@@ -25,9 +45,15 @@ def validate_cron(expression: str) -> bool:
         crontab_parser(60).parse(minute)
         crontab_parser(24).parse(hour)
         crontab_parser(7).parse(day_of_week)
-        crontab_parser(31, 1).parse(day_of_month)
-        crontab_parser(12, 1).parse(month_of_year)
+        days = crontab_parser(31, 1).parse(day_of_month)
+        months = crontab_parser(12, 1).parse(month_of_year)
     except (ValueError, ParseException):
+        return False
+
+    # Cross-field: at least one (month, day-of-month) combination must be a
+    # real calendar date. Under celery's crontab AND-semantics, an impossible
+    # (month, day) pair never fires regardless of day-of-week.
+    if not any(day <= _MAX_DAY_IN_MONTH[month] for month in months for day in days):
         return False
 
     return True

--- a/querybook/tests/test_lib/test_celery/test_cron.py
+++ b/querybook/tests/test_lib/test_celery/test_cron.py
@@ -1,0 +1,51 @@
+from unittest import TestCase
+
+from lib.celery.cron import validate_cron
+
+
+class ValidateCronTestCase(TestCase):
+    def test_valid_expressions(self):
+        for expression in [
+            "* * * * *",
+            "0 0 * * *",
+            "*/5 * * * *",
+            "0 22 * * 1-5",
+            "0 0 29 2 *",  # leap-year Feb 29 stays valid
+            "0 0 30 2,3 *",  # March saves the impossible Feb 30
+            "0 0 31 * *",  # some month has a 31st
+        ]:
+            self.assertTrue(validate_cron(expression), f"expected valid: {expression}")
+
+    def test_impossible_dates_are_invalid(self):
+        for expression in [
+            "0 0 30 2 *",  # Feb 30
+            "0 0 31 2 *",  # Feb 31
+            "0 0 31 4 *",  # Apr 31
+            "0 0 31 6 *",  # Jun 31
+            "0 0 31 9 *",  # Sep 31
+            "0 0 31 11 *",  # Nov 31
+            "0 0 30 2 1",  # never fires even with a weekday set
+        ]:
+            self.assertFalse(
+                validate_cron(expression), f"expected invalid: {expression}"
+            )
+
+    def test_malformed_expressions_are_invalid(self):
+        for expression in [
+            "not a cron",
+            "* * * *",  # only 4 fields
+            "* * * * * *",  # 6 fields
+            "0 0 * * 8",  # day-of-week out of range
+            "70 0 * * *",  # minute out of range
+            "0 25 * * *",  # hour out of range
+            "0 0 0 * *",  # day-of-month below range
+            "0 0 * 13 *",  # month out of range
+        ]:
+            self.assertFalse(
+                validate_cron(expression), f"expected invalid: {expression}"
+            )
+
+    def test_non_string_input_is_invalid(self):
+        self.assertFalse(validate_cron(None))
+        self.assertFalse(validate_cron(12345))
+        self.assertFalse(validate_cron(["0", "0", "*", "*", "*"]))


### PR DESCRIPTION
## Summary
The current cron validation did not ensure that the day+month combination was valid. This means a use can submit something like `2 30 2 30 *` and it will be allowed.

This PR adds an additional layer to validate that the day provided is valid